### PR TITLE
Bump goreleaser/goreleaser-action from 2 to 3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v2
+      uses: goreleaser/goreleaser-action@v3
       with:
         version: latest
         args: release --rm-dist


### PR DESCRIPTION
Replaces https://github.com/jetstack/jsctl/pull/3