### PR TITLE
Release artifact: wrap directory

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,6 +26,7 @@ builds:
 archives:
   - format: zip
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    wrap_in_directory: true
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
   algorithm: sha256


### PR DESCRIPTION
Adds a wrap directory in the zip artifact for cleaner scripting and general cleaniness.

I'd also be keen to change the naming convention of the archive names to is '-' separator instead of '_', as that is more convention, or at least matches what we do on [cert-manager](https://github.com/cert-manager/cert-manager/releases). Not a huge deal though.

question: Any particular reason for using `zip` over `tar.gz`?