### PR TITLE
Implement automatic registry credential fetching & auth status command

### DIFF
--- a/internal/command/auth.go
+++ b/internal/command/auth.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/jetstack/jsctl/internal/auth"
-	"github.com/jetstack/jsctl/internal/config"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/spf13/cobra"
 	"github.com/toqueteos/webbrowser"
 	"golang.org/x/oauth2"
+
+	"github.com/jetstack/jsctl/internal/auth"
+	"github.com/jetstack/jsctl/internal/config"
 )
 
 // Auth returns a cobra.Command instance that is the root for all "jsctl auth" subcommands.
@@ -23,6 +25,70 @@ func Auth() *cobra.Command {
 	cmd.AddCommand(
 		authLogin(),
 		authLogout(),
+		authStatus(),
+	)
+
+	return cmd
+}
+
+func authStatus() *cobra.Command {
+	var credentials string
+
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Print the logged in account and token location",
+		Run: run(func(ctx context.Context, args []string) error {
+			var token *oauth2.Token
+			var err error
+			var tokenPath string
+			if credentials != "" {
+				tokenPath = credentials
+				token, err = loginWithCredentials(ctx, auth.GetOAuthConfig(), credentials)
+				if err != nil {
+					return fmt.Errorf("failed to login with credentials file %q: %w", credentials, err)
+				}
+			} else {
+				tokenPath, err = auth.DetermineTokenFilePath()
+				if err != nil {
+					fmt.Println("Can't find token", err)
+				}
+				fmt.Println("Token path:", tokenPath)
+
+				token, err = auth.LoadOAuthToken()
+				if err != nil {
+					fmt.Println("Not logged in")
+					return nil
+				}
+			}
+
+			claims := jwt.MapClaims{}
+			_, err = jwt.ParseWithClaims(token.AccessToken, claims, func(token *jwt.Token) (interface{}, error) {
+				return []byte(""), nil
+			})
+
+			email, ok := claims["https://jetstack.io/claims/name"].(string)
+			if ok {
+				fmt.Println("Logged in as:", email)
+			}
+
+			cnf, ok := config.FromContext(ctx)
+			if !ok || cnf.Organization == "" {
+				fmt.Println("You do not have an organization selected, select one using: \n\n\tjsctl config set organization [name]\n\n" +
+					"To view organizations you have access to, list them using: \n\n\tjsctl organizations list")
+				return nil
+			}
+			fmt.Println("Current Organization:", cnf.Organization)
+
+			return nil
+		}),
+	}
+
+	flags := cmd.PersistentFlags()
+	flags.StringVar(
+		&credentials,
+		"credentials",
+		os.Getenv("JSCTL_CREDENTIALS"),
+		"The location of a credentials file to use instead of the normal oauth login flow",
 	)
 
 	return cmd

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -40,6 +40,7 @@ func Command() *cobra.Command {
 		Operator(),
 		Organizations(),
 		Users(),
+		Registry(),
 	)
 
 	return cmd

--- a/internal/command/operator.go
+++ b/internal/command/operator.go
@@ -58,6 +58,9 @@ func operatorDeploy() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deploy",
 		Short: "Deploys the operator and its components in the current Kubernetes context",
+		Long: `Deploys the operator and its components in the current Kubernetes context
+
+Note: If --auto-registry-credentials and --registry-credentials-path are unset, then the operator will be deployed without an image pull secret. The images must be availble for the operator pods to start.`,
 		Run: run(func(ctx context.Context, args []string) error {
 			var applier operator.Applier
 			var err error
@@ -200,6 +203,9 @@ func operatorInstallationsApply() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "apply",
 		Short: "Applies an Installation manifest to the current cluster, configured via flags",
+		Long: `Applies an Installation manifest to the current cluster, configured via flags
+
+Note: If --auto-registry-credentials and --registry-credentials-path are unset, then the installation components will be deployed without an image pull secret. The images must be availble for the component pods to start.`,
 		Run: run(func(ctx context.Context, args []string) error {
 			var err error
 

--- a/internal/command/registry.go
+++ b/internal/command/registry.go
@@ -1,0 +1,92 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jetstack/jsctl/internal/client"
+	"github.com/jetstack/jsctl/internal/registry"
+)
+
+func Registry() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "registry",
+		Short: "Subcommands for Jetstack Secure registry management",
+	}
+
+	cmd.AddCommand(registryAuth())
+
+	return cmd
+}
+
+func registryAuth() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "auth",
+		Short: "Subcommands for registry authentication",
+	}
+
+	cmd.AddCommand(registryAuthStatus())
+	cmd.AddCommand(registryAuthInit())
+
+	return cmd
+}
+
+func registryAuthInit() *cobra.Command {
+	return &cobra.Command{
+		Use:   "init",
+		Short: "Fetch or check the local registry credentials for the Jetstack Secure Enterprise registry",
+		Run: run(func(ctx context.Context, args []string) error {
+			configDir, err := os.UserConfigDir()
+			if err != nil {
+				return err
+			}
+
+			fmt.Println("Checking for existing credentials in", configDir)
+
+			jscpClient := client.New(ctx, apiURL)
+
+			_, err = registry.FetchOrLoadJetstackSecureEnterpriseRegistryCredentials(ctx, jscpClient, configDir)
+			if err != nil {
+				return err
+			}
+
+			status, err := registry.StatusJetstackSecureEnterpriseRegistry(configDir)
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(status)
+
+			return nil
+		}),
+	}
+}
+
+func registryAuthStatus() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Print the status of the local registry credentials",
+		Run: run(func(ctx context.Context, args []string) error {
+			// TODO: it'd be nice to get this from the ctx config so that
+			//  operations can be performed relative to the loaded config
+			configDir, err := os.UserConfigDir()
+			if err != nil {
+				return err
+			}
+
+			fmt.Println("Checking for existing credentials in", configDir)
+
+			status, err := registry.StatusJetstackSecureEnterpriseRegistry(configDir)
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(status)
+
+			return nil
+		}),
+	}
+}

--- a/internal/operator/operator_test.go
+++ b/internal/operator/operator_test.go
@@ -78,12 +78,6 @@ func TestImagePullSecret(t *testing.T) {
 		assert.NotEmpty(t, actualGCR.Auth)
 		assert.NotEmpty(t, actualGCR.Username)
 	})
-
-	t.Run("It should return an error if the key file does not exist", func(t *testing.T) {
-		data, err := operator.ImagePullSecret("./testdata/nope.json")
-		assert.Equal(t, operator.ErrNoKeyFile, err)
-		assert.Nil(t, data)
-	})
 }
 
 func TestApplyInstallationYAML(t *testing.T) {
@@ -145,7 +139,7 @@ func TestApplyInstallationYAML(t *testing.T) {
 		applier := &TestApplier{}
 		options := operator.ApplyInstallationYAMLOptions{
 			InstallVenafiOauthHelper: true,
-			Credentials:              "./testdata/key.json",
+			RegistryCredentialsPath:  "./testdata/key.json",
 		}
 
 		err := operator.ApplyInstallationYAML(ctx, applier, options)

--- a/internal/operator/operator_test.go
+++ b/internal/operator/operator_test.go
@@ -197,8 +197,8 @@ func TestApplyInstallationYAML(t *testing.T) {
 			AccessToken: "footoken",
 		}
 		options := operator.ApplyInstallationYAMLOptions{
-			CertDiscoveryVenafi: cdv,
-			Credentials:         "./testdata/key.json",
+			CertDiscoveryVenafi:     cdv,
+			RegistryCredentialsPath: "./testdata/key.json",
 		}
 
 		err := operator.ApplyInstallationYAML(ctx, applier, options)

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -5,9 +5,11 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 
+	"github.com/jetstack/jsctl/internal/client"
 	"github.com/jetstack/jsctl/internal/config"
 	"github.com/jetstack/jsctl/internal/subscription"
 )
@@ -71,6 +73,11 @@ func FetchOrLoadJetstackSecureEnterpriseRegistryCredentials(ctx context.Context,
 		cnf.Organization,
 		fmt.Sprintf("%s-jsctl-auto", cnf.Organization),
 	)
+	if apiErr, ok := err.(client.APIError); ok {
+		if apiErr.Status == http.StatusUnauthorized {
+			return nil, fmt.Errorf("failed to create registry credentials, current organization %q does not have permissions to access the Jetstack Secure Enterprise registry. Please contact support if this is unexpected.", cnf.Organization)
+		}
+	}
 	if err != nil || len(serviceAccounts) < 1 {
 		return nil, fmt.Errorf("failed to create registry credentials: %w", err)
 	}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -19,7 +19,7 @@ const jetstackSecureRegistryFileKey = "eu.gcr.io--jetstack-secure-enterprise"
 // StatusJetstackSecureEnterpriseRegistry will return the status of the registry
 // credentials for the Jetstack Secure Enterprise registry stashed to disk
 func StatusJetstackSecureEnterpriseRegistry(configDir string) (string, error) {
-	registryCredentialsPath := filepath.Join(configDir, fmt.Sprintf("%s.json", jetstackSecureRegistryFileKey))
+	registryCredentialsPath := filepath.Join(configDir, "jsctl", fmt.Sprintf("%s.json", jetstackSecureRegistryFileKey))
 
 	_, err := os.Stat(registryCredentialsPath)
 	if errors.Is(err, os.ErrNotExist) {
@@ -36,9 +36,14 @@ func StatusJetstackSecureEnterpriseRegistry(configDir string) (string, error) {
 // a local copy of registry credentials. If there is, then these are returned,
 // if not, then a new set is fetched and stashed in the jsctl config dir specified
 func FetchOrLoadJetstackSecureEnterpriseRegistryCredentials(ctx context.Context, httpClient subscription.HTTPClient, configDir string) ([]byte, error) {
-	registryCredentialsPath := filepath.Join(configDir, fmt.Sprintf("%s.json", jetstackSecureRegistryFileKey))
+	err := os.MkdirAll(filepath.Join(configDir, "jsctl"), os.ModePerm)
+	if err != nil {
+		return nil, fmt.Errorf("error creating jsctl config dir: %s", err)
+	}
 
-	_, err := os.Stat(registryCredentialsPath)
+	registryCredentialsPath := filepath.Join(configDir, "jsctl", fmt.Sprintf("%s.json", jetstackSecureRegistryFileKey))
+
+	_, err = os.Stat(registryCredentialsPath)
 	if !errors.Is(err, os.ErrNotExist) {
 		// then we can just load and return the file
 		bytes, err := os.ReadFile(registryCredentialsPath)

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,0 +1,85 @@
+package registry
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/jetstack/jsctl/internal/config"
+	"github.com/jetstack/jsctl/internal/subscription"
+)
+
+// jetstackSecureRegistryFileKey is the filename used to store the registry
+// credentials in jsctl config
+const jetstackSecureRegistryFileKey = "eu.gcr.io--jetstack-secure-enterprise"
+
+// StatusJetstackSecureEnterpriseRegistry will return the status of the registry
+// credentials for the Jetstack Secure Enterprise registry stashed to disk
+func StatusJetstackSecureEnterpriseRegistry(configDir string) (string, error) {
+	registryCredentialsPath := filepath.Join(configDir, fmt.Sprintf("%s.json", jetstackSecureRegistryFileKey))
+
+	_, err := os.Stat(registryCredentialsPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return "not authenticated", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("error checking if registry credentials exist: %s", err)
+	}
+
+	return "authenticated", nil
+}
+
+// FetchOrLoadJetstackSecureEnterpriseRegistryCredentials will check of there are
+// a local copy of registry credentials. If there is, then these are returned,
+// if not, then a new set is fetched and stashed in the jsctl config dir specified
+func FetchOrLoadJetstackSecureEnterpriseRegistryCredentials(ctx context.Context, httpClient subscription.HTTPClient, configDir string) ([]byte, error) {
+	registryCredentialsPath := filepath.Join(configDir, fmt.Sprintf("%s.json", jetstackSecureRegistryFileKey))
+
+	_, err := os.Stat(registryCredentialsPath)
+	if !errors.Is(err, os.ErrNotExist) {
+		// then we can just load and return the file
+		bytes, err := os.ReadFile(registryCredentialsPath)
+		if err != nil {
+			return nil, fmt.Errorf("error reading registry credentials file: %s", err)
+		}
+
+		return bytes, nil
+	}
+
+	cnf, ok := config.FromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("error getting config from context")
+	}
+
+	// organization must be set here so that we know which org to create
+	// the credentials in
+	if cnf.Organization == "" {
+		return nil, fmt.Errorf("no organization must be set")
+	}
+
+	serviceAccounts, err := subscription.CreateGoogleServiceAccount(
+		ctx,
+		httpClient,
+		cnf.Organization,
+		fmt.Sprintf("%s-jsctl-auto", cnf.Organization),
+	)
+	if err != nil || len(serviceAccounts) < 1 {
+		return nil, fmt.Errorf("failed to create registry credentials: %w", err)
+	}
+
+	registryCredentialsBytes, err := base64.StdEncoding.DecodeString(serviceAccounts[0].Key.PrivateData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode registry credentials: %w", err)
+	}
+
+	// stash the bytes in the config dir for use in future invocations
+	err = os.WriteFile(registryCredentialsPath, registryCredentialsBytes, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("failed to write registry credentials to path %q: %w", registryCredentialsPath, err)
+	}
+
+	return registryCredentialsBytes, nil
+}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,0 +1,88 @@
+package registry_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jetstack/jsctl/internal/client"
+	"github.com/jetstack/jsctl/internal/config"
+	"github.com/jetstack/jsctl/internal/registry"
+	"github.com/jetstack/jsctl/internal/subscription"
+)
+
+func TestRegistryAuthInit(t *testing.T) {
+	httpClient := &MockHTTPClient{
+		Response: []subscription.GoogleServiceAccountWithKey{
+			{
+				GoogleServiceAccount: subscription.GoogleServiceAccount{DisplayName: "things"},
+				Key:                  subscription.GoogleServiceAccountKey{PrivateData: "MQo="},
+			},
+		},
+	}
+
+	// tempConfigDir is created in order to test that credentials are put in the correct place
+	tempConfigDir, err := os.MkdirTemp("", "registry-test-*")
+	require.NoError(t, err)
+	defer os.Remove(tempConfigDir)
+
+	ctx := config.ToContext(context.Background(), &config.Config{Organization: "example"})
+
+	bytes, err := registry.FetchOrLoadJetstackSecureEnterpriseRegistryCredentials(ctx, httpClient, tempConfigDir)
+	require.NoError(t, err)
+	assert.Equal(t, "1\n", string(bytes))
+
+	// call it again to make sure that the file is reused
+	bytes, err = registry.FetchOrLoadJetstackSecureEnterpriseRegistryCredentials(ctx, httpClient, tempConfigDir)
+	require.NoError(t, err)
+	assert.Equal(t, "1\n", string(bytes))
+
+	// check that the contents on disk is also correct
+	bytes, err = os.ReadFile(tempConfigDir + "/eu.gcr.io--jetstack-secure-enterprise.json")
+	require.NoError(t, err)
+	assert.Equal(t, "1\n", string(bytes))
+
+	// the http handler for the call should have only been invoked once
+	assert.Equal(t, 1, httpClient.InvocationCount)
+}
+
+// MockHTTPClient is a mock HTTP client used to return prepared responses for
+// API calls
+type MockHTTPClient struct {
+	Method          string
+	URI             string
+	Body            interface{}
+	Response        interface{}
+	InvocationCount int
+}
+
+func (m *MockHTTPClient) Do(_ context.Context, method, uri string, body, out interface{}) error {
+	m.InvocationCount++
+
+	m.URI = uri
+	m.Method = method
+	m.Body = body
+
+	if m.Response == nil {
+		return nil
+	}
+
+	if err, ok := m.Response.(client.APIError); ok {
+		return err
+	}
+
+	if out == nil {
+		return nil
+	}
+
+	data, err := json.Marshal(m.Response)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(data, out)
+}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -42,7 +42,7 @@ func TestRegistryAuthInit(t *testing.T) {
 	assert.Equal(t, "1\n", string(bytes))
 
 	// check that the contents on disk is also correct
-	bytes, err = os.ReadFile(tempConfigDir + "/eu.gcr.io--jetstack-secure-enterprise.json")
+	bytes, err = os.ReadFile(tempConfigDir + "/jsctl/eu.gcr.io--jetstack-secure-enterprise.json")
 	require.NoError(t, err)
 	assert.Equal(t, "1\n", string(bytes))
 

--- a/internal/subscription/mocks_test.go
+++ b/internal/subscription/mocks_test.go
@@ -1,0 +1,42 @@
+package subscription_test
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/jetstack/jsctl/internal/client"
+)
+
+// MockHTTPClient is a mock HTTP client used to return prepared responses for
+// subscription API calls
+type MockHTTPClient struct {
+	Method   string
+	URI      string
+	Body     interface{}
+	Response interface{}
+}
+
+func (m *MockHTTPClient) Do(_ context.Context, method, uri string, body, out interface{}) error {
+	m.URI = uri
+	m.Method = method
+	m.Body = body
+
+	if m.Response == nil {
+		return nil
+	}
+
+	if err, ok := m.Response.(client.APIError); ok {
+		return err
+	}
+
+	if out == nil {
+		return nil
+	}
+
+	data, err := json.Marshal(m.Response)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(data, out)
+}

--- a/internal/subscription/subscription.go
+++ b/internal/subscription/subscription.go
@@ -40,7 +40,7 @@ type (
 
 // CreateGoogleServiceAccount calls the subscription API to create a new Google
 // Service Account for GCR access
-func CreateGoogleServiceAccount(ctx context.Context, httpClient HTTPClient, organization, name string) (*[]GoogleServiceAccountWithKey, error) {
+func CreateGoogleServiceAccount(ctx context.Context, httpClient HTTPClient, organization, name string) ([]GoogleServiceAccountWithKey, error) {
 	request := []GoogleServiceAccount{
 		{DisplayName: name},
 	}
@@ -52,5 +52,5 @@ func CreateGoogleServiceAccount(ctx context.Context, httpClient HTTPClient, orga
 		return nil, err
 	}
 
-	return &serviceAccounts, nil
+	return serviceAccounts, nil
 }

--- a/internal/subscription/subscription.go
+++ b/internal/subscription/subscription.go
@@ -1,0 +1,56 @@
+// Package subscription contains functions to call endpoints in the JSCP
+// subscription API
+package subscription
+
+import (
+	"context"
+	_ "embed"
+	"net/http"
+	"path"
+)
+
+type (
+	// The HTTPClient interface describes types that perform HTTP requests.
+	HTTPClient interface {
+		Do(ctx context.Context, method, uri string, body, out interface{}) error
+	}
+
+	// GoogleServiceAccount is the base type for Google Service Account data
+	// returned by the subscription API
+	GoogleServiceAccount struct {
+		ID          string `json:"id"`
+		DisplayName string `json:"displayName"`
+	}
+
+	// GoogleServiceAccountWithKey adds the key to GoogleServiceAccount
+	GoogleServiceAccountWithKey struct {
+		GoogleServiceAccount
+		Key GoogleServiceAccountKey `json:"key"`
+	}
+
+	// GoogleServiceAccountKey represents the type of for the GCP SA key and
+	// docker config as returned by the subscription API
+	GoogleServiceAccountKey struct {
+		// PrivateData is the service account credentials encoded in base64
+		PrivateData string `json:"privateData"`
+		// DockerConfig is a base64 encoded dockerconfig file using the service account credentials to access Jetstack's enterprise registries.
+		DockerConfig string `json:"dockerConfig"`
+	}
+)
+
+// CreateGoogleServiceAccount calls the subscription API to create a new Google
+// Service Account for GCR access
+func CreateGoogleServiceAccount(ctx context.Context, httpClient HTTPClient, organization, name string) (*[]GoogleServiceAccountWithKey, error) {
+	request := []GoogleServiceAccount{
+		{DisplayName: name},
+	}
+
+	uri := path.Join("/subscription/api/v1/org/", organization, "svc_accounts")
+
+	var serviceAccounts []GoogleServiceAccountWithKey
+	if err := httpClient.Do(ctx, http.MethodPost, uri, request, &serviceAccounts); err != nil {
+		return nil, err
+	}
+
+	return &serviceAccounts, nil
+}

--- a/internal/subscription/subscription_test.go
+++ b/internal/subscription/subscription_test.go
@@ -1,0 +1,41 @@
+package subscription_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jetstack/jsctl/internal/subscription"
+)
+
+func TestCreateServiceAccount(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("create gcp service account", func(t *testing.T) {
+		expected := &[]subscription.GoogleServiceAccountWithKey{
+			{
+				GoogleServiceAccount: subscription.GoogleServiceAccount{
+					DisplayName: "things",
+				},
+				Key: subscription.GoogleServiceAccountKey{
+					PrivateData:  "data",
+					DockerConfig: "data",
+				},
+			},
+		}
+
+		httpClient := &MockHTTPClient{
+			Response: expected,
+		}
+
+		actual, err := subscription.CreateGoogleServiceAccount(ctx, httpClient, "test", "test")
+		assert.NoError(t, err)
+		assert.EqualValues(t, expected, actual)
+		assert.EqualValues(t, http.MethodPost, httpClient.Method)
+		assert.EqualValues(t, "/subscription/api/v1/org/test/svc_accounts", httpClient.URI)
+	})
+}

--- a/internal/subscription/subscription_test.go
+++ b/internal/subscription/subscription_test.go
@@ -16,7 +16,7 @@ func TestCreateServiceAccount(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("create gcp service account", func(t *testing.T) {
-		expected := &[]subscription.GoogleServiceAccountWithKey{
+		expected := []subscription.GoogleServiceAccountWithKey{
 			{
 				GoogleServiceAccount: subscription.GoogleServiceAccount{
 					DisplayName: "things",


### PR DESCRIPTION
Fixes https://github.com/jetstack/jsctl/issues/9

We are building an improved installation flow where users are guided through installing the operator using in the Jetstack Secure UI. These changes are to make that easier by:

* Not requiring users to have registry credentials downloaded to install the operator
* Making flag names for registry credentials distinct from JSCP credential files
* Allowing users to see who is logged in and what their current organisation is with `jsctl auth status`