### PR TITLE
Print login URL to terminal

### DIFF
--- a/internal/command/auth.go
+++ b/internal/command/auth.go
@@ -171,6 +171,8 @@ func authLogout() *cobra.Command {
 func loginWithOAuth(ctx context.Context, oAuthConfig *oauth2.Config) (*oauth2.Token, error) {
 	url, state := auth.GetOAuthURLAndState(oAuthConfig)
 
+	fmt.Println("Opening browser to:", url)
+
 	if err := webbrowser.Open(url); err != nil {
 		fmt.Printf("Navigate to the URL below to login:\n%s\n", url)
 	} else {


### PR DESCRIPTION
This allows users to copy the URL if they are using a browser other than the default

```
$ go run main.go auth login
Opening browser to: https://auth.jetstack.io/authorize...
You will be taken to your browser for authentication
```

Signed-off-by: Charlie Egan <charlieegan3@users.noreply.github.com>