### PR TITLE
Implement tier selection for operator installations apply

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/cert-manager/cert-manager v1.9.1
 	github.com/gofrs/uuid v4.2.0+incompatible
-	github.com/jetstack/js-operator v0.0.1-alpha.13
+	github.com/jetstack/js-operator v0.0.1-alpha.16
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -322,6 +322,8 @@ github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLf
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jetstack/js-operator v0.0.1-alpha.13 h1:npSCqdvbwgBpYE9AVxRv4gT1dI8PZAsdYE8ZojQKElM=
 github.com/jetstack/js-operator v0.0.1-alpha.13/go.mod h1:AIMzZ2+jPvLvTGcm8X3GnGBWNc8OSjWF2lfXL/2uP2M=
+github.com/jetstack/js-operator v0.0.1-alpha.16 h1:dtmtDh1lwgDPqAHW26/cDyOe+Ulfua6bONUGeUdkV6s=
+github.com/jetstack/js-operator v0.0.1-alpha.16/go.mod h1:WAHhkbXyXaRMcAorHJDp5/wbt7YydM01I2+ejdHrdv8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=

--- a/internal/operator/operator_test.go
+++ b/internal/operator/operator_test.go
@@ -335,6 +335,22 @@ func TestApplyInstallationYAML(t *testing.T) {
 			assert.EqualValues(t, &options.IstioCSRReplicas, actual.Spec.IstioCSR.ReplicaCount)
 		}
 	})
+
+	t.Run("It should generate an installation manifest with approver policy enterprise", func(t *testing.T) {
+		options := operator.ApplyInstallationYAMLOptions{
+			InstallApproverPolicyEnterprise: true,
+		}
+		applier := &TestApplier{}
+
+		err := operator.ApplyInstallationYAML(ctx, applier, options)
+		assert.NoError(t, err)
+
+		var actual operatorv1alpha1.Installation
+		assert.NoError(t, yaml.Unmarshal(applier.data.Bytes(), &actual))
+
+		assert.Nil(t, actual.Spec.ApproverPolicy)
+		assert.NotNil(t, actual.Spec.ApproverPolicyEnterprise)
+	})
 }
 
 func findIssuer(t *testing.T, name, namespace string, issuers []*operatorv1alpha1.Issuer) *operatorv1alpha1.Issuer {


### PR DESCRIPTION
This commit implements a command that allows the configured approverPolicy to be set using a flag based on the tier.

```
$ go run main.go operator installations apply --stdout --tier=enterprise-plus | grep approver
  approverPolicyEnterprise: {}
$ go run main.go operator installations apply --stdout --tier=enterprise | grep approver
  approverPolicy: {}
$ go run main.go operator installations apply --stdout --tier="" | grep approver
  approverPolicy: {}
$ go run main.go operator installations apply --stdout | grep approver
  approverPolicy: {}
```

Only setting 'enterprise-plus' will enable the `approverPolicyEnterprise` setting. 
