### PR TITLE
Automatically generate release notes again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v2
+      uses: goreleaser/goreleaser-action@v3
       with:
         version: latest
         args: release --rm-dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,4 +32,5 @@ checksum:
   algorithm: sha256
 release:
 changelog:
-  skip: true
+  use: github
+  skip: false


### PR DESCRIPTION
This was missed before, release notes were skipped right at the end of the file. This was unlrelated to the goreleaser action as previously expected.

Signed-off-by: Charlie Egan <charlieegan3@users.noreply.github.com>