### PR TITLE
Fix secrets order

### DIFF
--- a/internal/command/operator.go
+++ b/internal/command/operator.go
@@ -290,7 +290,7 @@ Note: If --auto-registry-credentials and --registry-credentials-path are unset, 
 
 			cdv, err := venafi.ParseCertDiscoveryVenafiConfig(certDiscoveryVenafiConnection, vcs, certDiscoveryVenafi)
 			if err != nil {
-				return fmt.Errorf("error parsing cert-discovery-venafi config")
+				return fmt.Errorf("error parsing cert-discovery-venafi config: %w", err)
 			}
 			options.CertDiscoveryVenafi = cdv
 

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -321,11 +321,13 @@ func ApplyInstallationYAML(ctx context.Context, applier Applier, options ApplyIn
 		registryCredentials = string(registryCredentialsBytes)
 	}
 
-	secret, err := ImagePullSecret(registryCredentials)
-	if err != nil {
-		return fmt.Errorf("failed to parse image pull secret: %w", err)
+	if registryCredentials != "" {
+		secret, err := ImagePullSecret(registryCredentials)
+		if err != nil {
+			return fmt.Errorf("failed to parse image pull secret: %w", err)
+		}
+		manifestTemplates.secrets = append(manifestTemplates.secrets, secret)
 	}
-	manifestTemplates.secrets = append(manifestTemplates.secrets, secret)
 
 	if err := generateVenafiIssuerManifests(manifestTemplates, options); err != nil {
 		return fmt.Errorf("error building manifests for Venafi issuers: %w", err)


### PR DESCRIPTION
This PR ensures that any Secrets get created before resources that might be using them, for example, image pull secret for the operator gets created before the operator's deployment.

To test:
1. Create a cluster, authenticate with JSS, create agent
2. Run `jsctl operator deploy --registry-credentials-path <path-to-creds>`
3. Wait for the operator's deployment to become ready
4. Run `kubectl describe deploy js-operator -n jetstack-secure`
5. Observe errors related to image pulling
6. Repeat steps 1 - 4 using code from this PR
7. Observe no errors related to image pulling

Fixes https://github.com/jetstack/js-operator/issues/301