### PR TITLE
Implement a version command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - "-s -w -X main.version={{.Version}}"
+      - -s -w -X "main.version={{.Version}}" -X "main.commit={{.Commit}}" -X "main.date={{.Date}}"
     goos:
       - freebsd
       - windows
@@ -30,7 +30,7 @@ archives:
 checksum:
   name_template: "{{ .ProjectName }}-{{ .Version }}-SHA256SUMS"
   algorithm: sha256
-release:
+release: {}
 changelog:
   use: github-native
   skip: false

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/cert-manager/cert-manager v1.9.1
 	github.com/gofrs/uuid v4.2.0+incompatible
+	github.com/golang-jwt/jwt/v4 v4.4.2
 	github.com/jetstack/js-operator v0.0.1-alpha.16
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.5.0
@@ -38,7 +39,6 @@ require (
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -320,8 +320,6 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
-github.com/jetstack/js-operator v0.0.1-alpha.13 h1:npSCqdvbwgBpYE9AVxRv4gT1dI8PZAsdYE8ZojQKElM=
-github.com/jetstack/js-operator v0.0.1-alpha.13/go.mod h1:AIMzZ2+jPvLvTGcm8X3GnGBWNc8OSjWF2lfXL/2uP2M=
 github.com/jetstack/js-operator v0.0.1-alpha.16 h1:dtmtDh1lwgDPqAHW26/cDyOe+Ulfua6bONUGeUdkV6s=
 github.com/jetstack/js-operator v0.0.1-alpha.16/go.mod h1:WAHhkbXyXaRMcAorHJDp5/wbt7YydM01I2+ejdHrdv8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -39,8 +39,9 @@ func Command() *cobra.Command {
 		Config(),
 		Operator(),
 		Organizations(),
-		Users(),
 		Registry(),
+		Users(),
+		Version(&cmd.Version),
 	)
 
 	return cmd

--- a/internal/command/version.go
+++ b/internal/command/version.go
@@ -1,0 +1,25 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func Version(version *string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "view the version, commit and build date of jsctl",
+		Run: run(func(ctx context.Context, args []string) error {
+			fmt.Println(*version)
+			if strings.Contains(*version, "dev") {
+				fmt.Println("note: this is either a development build or the version was not injected at build-time")
+			}
+			return nil
+		}),
+	}
+
+	return cmd
+}

--- a/main.go
+++ b/main.go
@@ -11,12 +11,14 @@ import (
 
 // Values injected at build-time
 var (
-	version string
+	version string = "dev"
+	commit  string = "unknown"
+	date    string = "unknown"
 )
 
 func main() {
 	cmd := command.Command()
-	cmd.Version = version
+	cmd.Version = fmt.Sprintf("%s, commit %s, built at %s", version, commit, date)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()


### PR DESCRIPTION
This adds a version command to the CLI.

The output from a dev build on this branch looks like this:

```
$ ./dist/jsctl_darwin_arm64/jsctl version
0.1.7-SNAPSHOT-6691014, commit 6691014cee9f7aeedf0c9ec4984cb84e02ea4bde, built at 2022-10-06T13:18:54Z
```