### PR TITLE
Add a test make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 REPO_ROOT ?= $(shell pwd)
 GO ?= $(shell which go)
 
+.PHONY: test
+test:
+	$(GO) test ./...
+
+.PHONY: local
 local:
 	goreleaser release --snapshot --skip-publish --rm-dist
 


### PR DESCRIPTION
This adds a testing make target

```
$ make test
/Users/charlieegan/.goenv/versions/1.19.0/bin/go test ./...
?       github.com/jetstack/jsctl       [no test files]
ok      github.com/jetstack/jsctl/internal/auth (cached)
?       github.com/jetstack/jsctl/internal/client       [no test files]
ok      github.com/jetstack/jsctl/internal/cluster      (cached)
?       github.com/jetstack/jsctl/internal/command      [no test files]
ok      github.com/jetstack/jsctl/internal/config       (cached)
?       github.com/jetstack/jsctl/internal/docker       [no test files]
ok      github.com/jetstack/jsctl/internal/kubernetes   (cached)
ok      github.com/jetstack/jsctl/internal/operator     (cached)
ok      github.com/jetstack/jsctl/internal/organization (cached)
ok      github.com/jetstack/jsctl/internal/prompt       (cached)
ok      github.com/jetstack/jsctl/internal/registry     (cached)
ok      github.com/jetstack/jsctl/internal/subscription (cached)
ok      github.com/jetstack/jsctl/internal/table        (cached)
ok      github.com/jetstack/jsctl/internal/user (cached)
ok      github.com/jetstack/jsctl/internal/venafi       (cached)
ok      github.com/jetstack/jsctl/tools/cobra   (cached)

```