### PR TITLE
Improve errors for missed installation steps

### DIFF
--- a/internal/command/operator.go
+++ b/internal/command/operator.go
@@ -317,7 +317,7 @@ Note: If --auto-registry-credentials and --registry-credentials-path are unset, 
 				_, err = installationClient.Status(ctx)
 				switch {
 				case errors.Is(err, operator.ErrNoInstallationCRD):
-					return fmt.Errorf("no installation CRD found in cluster %q, have you run 'jsctl operator deploy'?", kubeCfg.Host)
+					return fmt.Errorf("no installations.operator.jetstack.io CRD found in cluster %q, have you run 'jsctl operator deploy'?", kubeCfg.Host)
 				case err != nil && !errors.Is(err, operator.ErrNoInstallation):
 					return fmt.Errorf("failed to check cluster status before deploying new installation: %w", err)
 				}

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -574,7 +574,7 @@ func (ic *InstallationClient) Status(ctx context.Context) ([]ComponentStatus, er
 	var installation operatorv1alpha1.Installation
 
 	const (
-		crdName  = "installations.operator.cert-manager.io"
+		crdName  = "installations.operator.jetstack.io"
 		resource = "installations"
 		name     = "installation"
 	)

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -550,6 +550,9 @@ var (
 	// ErrNoInstallation is the error given when querying an Installation resource that does not exist.
 	ErrNoInstallation = errors.New("no installation")
 
+	// ErrNoInstallationCRD is the error given when the Installation CRD does not exist in the cluster.
+	ErrNoInstallationCRD = errors.New("no installation CRD")
+
 	componentNames = map[operatorv1alpha1.InstallationConditionType]string{
 		operatorv1alpha1.InstallationConditionCertManagerReady:        "cert-manager",
 		operatorv1alpha1.InstallationConditionCertManagerIssuersReady: "issuers",
@@ -567,14 +570,26 @@ var (
 // is chosen based on the content of the componentNames map. Add friendly names to that map to include additional
 // component statuses to return.
 func (ic *InstallationClient) Status(ctx context.Context) ([]ComponentStatus, error) {
+	var err error
 	var installation operatorv1alpha1.Installation
 
 	const (
+		crdName  = "installations.operator.cert-manager.io"
 		resource = "installations"
 		name     = "installation"
 	)
 
-	err := ic.client.Get().Resource(resource).Name(name).Do(ctx).Into(&installation)
+	// first check if the installation CRD exists in the cluster
+	_, err = ic.client.Get().Resource("crd").Name(crdName).Do(ctx).Get()
+	switch {
+	case kerrors.IsNotFound(err):
+		return nil, ErrNoInstallationCRD
+	case err != nil:
+		return nil, err
+	}
+
+	// next, check if there's an installation resource instance in the cluster
+	err = ic.client.Get().Resource(resource).Name(name).Do(ctx).Into(&installation)
 	switch {
 	case kerrors.IsNotFound(err):
 		return nil, ErrNoInstallation


### PR DESCRIPTION
It's my hope that these messages will guide users who have jumped the gun on the operator installation steps and encourage them to go back to deploy the operator before continuing.

I also hope that the messages make it clearer where they are connecting to in case it's a kubeconfig context issue that's causing issues.

```
$ jsctl operator installations status
no installation CRD found in cluster "https://127.0.0.1:52378", have you run 'jsctl operator deploy'?
exit status 1
$ jsctl operator installations apply
no installation CRD found in cluster "https://127.0.0.1:52378", have you run 'jsctl operator deploy'?
exit status 1
$ jsctl operator installations status --stdout
cannot use --stdout flag with status command. When using --stdout, jsctl does not connect to kubernetes
exit status 1
```

Signed-off-by: Charlie Egan <charlieegan3@users.noreply.github.com>