### PR TITLE
Fix panic when missing kubeconfig or cluster

### DIFF
--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -53,6 +53,10 @@ func NewConfig(kubeConfig string) (*rest.Config, error) {
 		return nil, err
 	}
 
+	if config == nil {
+		return nil, fmt.Errorf("failed to create config, is your kubeconfig present and configured to connect to a cluster that's still running?")
+	}
+
 	return config, nil
 }
 

--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -36,6 +36,14 @@ func NewConfig(kubeConfig string) (*rest.Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to expand kubeconfig path: %w", err)
 		}
+
+		_, err = os.Stat(kubeConfigPath)
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("kubeconfig doesn't exist: %w", err)
+		} else if err != nil {
+			return nil, fmt.Errorf("failed to check kubeconfig path: %w", err)
+		}
+
 		config, err = clientcmd.BuildConfigFromFlags("", kubeConfigPath)
 	} else {
 		config, err = rest.InClusterConfig()


### PR DESCRIPTION
Closes https://github.com/jetstack/jsctl/issues/23

When ~/.kube/config did not exist or the cluster had been deleted, jsctl would panic like this:

```
$ go run main.go operator deploy

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x105c214f0]

goroutine 1 [running]:
k8s.io/client-go/kubernetes.NewForConfig(0x105cf3d2b?)
        /Users/charlieegan/go/pkg/mod/k8s.io/client-go@v0.25.2/kubernetes/clientset.go:422 +0x20
github.com/jetstack/jsctl/internal/kubernetes.NewKubeConfigApplier({0x105cf3d2b?, 0x30?})
        /Users/charlieegan/Code/jsctl/internal/kubernetes/kubernetes.go:87 +0x2c
github.com/jetstack/jsctl/internal/command.operatorDeploy.func2({0x10621da80, 0x140004a28d0}, {0x1060665e0?, 0x106c57000?, 0x105fc05a0?})
        /Users/charlieegan/Code/jsctl/internal/command/operator.go:82 +0xc8
github.com/jetstack/jsctl/internal/command.run.func1(0x140003ae000?, {0x106c57000, 0x0, 0x0})
        /Users/charlieegan/Code/jsctl/internal/command/command.go:74 +0x1d8
github.com/spf13/cobra.(*Command).execute(0x140003ae000, {0x106c57000, 0x0, 0x0})
        /Users/charlieegan/go/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:876 +0x4b8
github.com/spf13/cobra.(*Command).ExecuteC(0x1400056d900)
        /Users/charlieegan/go/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:990 +0x354
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/charlieegan/go/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:918
github.com/spf13/cobra.(*Command).ExecuteContext(...)
        /Users/charlieegan/go/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:911
main.main()
        /Users/charlieegan/Code/jsctl/main.go:26 +0x1dc
exit status 2
```

Now we see:

```
$ go run main.go operator deploy
failed initialize deployment configuration using kubeconfig: kubeconfig doesn't exist: stat /Users/charlieegan/.kube/config: no such file or directory
exit status 1
```

or, when the cluster has been deleted:

```
$ go run main.go operator deploy --kubeconfig=dist/config.yaml
failed initialize deployment configuration using kubeconfig: failed to create config, is your kubeconfig present and configured to connect to a cluster that's still running?
exit status 1
```

Signed-off-by: Charlie Egan <charlieegan3@users.noreply.github.com>