### PR TITLE
Ensure correct number of args are used

### DIFF
--- a/internal/command/auth.go
+++ b/internal/command/auth.go
@@ -37,6 +37,7 @@ func authStatus() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Print the logged in account and token location",
+		Args:  cobra.ExactArgs(0),
 		Run: run(func(ctx context.Context, args []string) error {
 			var token *oauth2.Token
 			var err error
@@ -100,6 +101,7 @@ func authLogin() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Performs the authentication flow to allow access to other commands",
+		Args:  cobra.ExactArgs(0),
 		Run: run(func(ctx context.Context, args []string) error {
 			oAuthConfig := auth.GetOAuthConfig()
 
@@ -152,7 +154,8 @@ func authLogin() *cobra.Command {
 
 func authLogout() *cobra.Command {
 	return &cobra.Command{
-		Use: "logout",
+		Use:  "logout",
+		Args: cobra.ExactArgs(0),
 		Run: run(func(ctx context.Context, args []string) error {
 			err := auth.DeleteOAuthToken()
 			switch {

--- a/internal/command/clusters.go
+++ b/internal/command/clusters.go
@@ -7,14 +7,15 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
+	"github.com/toqueteos/webbrowser"
+
 	"github.com/jetstack/jsctl/internal/client"
 	"github.com/jetstack/jsctl/internal/cluster"
 	"github.com/jetstack/jsctl/internal/config"
 	"github.com/jetstack/jsctl/internal/kubernetes"
 	"github.com/jetstack/jsctl/internal/prompt"
 	"github.com/jetstack/jsctl/internal/table"
-	"github.com/spf13/cobra"
-	"github.com/toqueteos/webbrowser"
 )
 
 // Clusters returns a cobra.Command instance that is the root for all "jsctl clusters" subcommands.
@@ -101,6 +102,7 @@ func clustersList() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Lists all clusters connected to the control plane for the organization",
+		Args:  cobra.ExactValidArgs(0),
 		Run: run(func(ctx context.Context, args []string) error {
 			cnf, ok := config.FromContext(ctx)
 			if !ok || cnf.Organization == "" {

--- a/internal/command/operator.go
+++ b/internal/command/operator.go
@@ -68,6 +68,7 @@ func operatorDeploy() *cobra.Command {
 		Long: `Deploys the operator and its components in the current Kubernetes context
 
 Note: If --auto-registry-credentials and --registry-credentials-path are unset, then the operator will be deployed without an image pull secret. The images must be availble for the operator pods to start.`,
+		Args: cobra.ExactArgs(0),
 		Run: run(func(ctx context.Context, args []string) error {
 			var applier operator.Applier
 			var err error
@@ -147,6 +148,7 @@ func operatorVersions() *cobra.Command {
 	return &cobra.Command{
 		Use:   "versions",
 		Short: "Outputs all available versions of the jetstack operator",
+		Args:  cobra.ExactArgs(0),
 		Run: run(func(ctx context.Context, args []string) error {
 			versions, err := operator.Versions()
 			if err != nil {
@@ -223,6 +225,7 @@ func operatorInstallationsApply() *cobra.Command {
 		Long: `Applies an Installation manifest to the current cluster, configured via flags
 
 Note: If --auto-registry-credentials and --registry-credentials-path are unset, then the installation components will be deployed without an image pull secret. The images must be availble for the component pods to start.`,
+		Args: cobra.ExactArgs(1),
 		Run: run(func(ctx context.Context, args []string) error {
 			var err error
 
@@ -385,6 +388,7 @@ func operatorInstallationStatus() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Output the status of all operator components",
+		Args:  cobra.ExactArgs(0),
 		Run: run(func(ctx context.Context, args []string) error {
 			if stdout {
 				return fmt.Errorf("cannot use --stdout flag with status command. When using --stdout, jsctl does not connect to kubernetes")

--- a/internal/command/organizations.go
+++ b/internal/command/organizations.go
@@ -7,10 +7,11 @@ import (
 	"os"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/jetstack/jsctl/internal/client"
 	"github.com/jetstack/jsctl/internal/organization"
 	"github.com/jetstack/jsctl/internal/table"
-	"github.com/spf13/cobra"
 )
 
 // Organizations returns a cobra.Command instance that is the root for all "jsctl organizations" subcommands.
@@ -34,6 +35,7 @@ func organizationsList() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Lists all organizations the user has access to",
+		Args:  cobra.ExactArgs(0),
 		Run: run(func(ctx context.Context, args []string) error {
 			http := client.New(ctx, apiURL)
 

--- a/internal/command/registry.go
+++ b/internal/command/registry.go
@@ -38,6 +38,7 @@ func registryAuthInit() *cobra.Command {
 	return &cobra.Command{
 		Use:   "init",
 		Short: "Fetch or check the local registry credentials for the Jetstack Secure Enterprise registry",
+		Args:  cobra.ExactArgs(0),
 		Run: run(func(ctx context.Context, args []string) error {
 			configDir, err := os.UserConfigDir()
 			if err != nil {
@@ -69,6 +70,7 @@ func registryAuthStatus() *cobra.Command {
 	return &cobra.Command{
 		Use:   "status",
 		Short: "Print the status of the local registry credentials",
+		Args:  cobra.ExactArgs(0),
 		Run: run(func(ctx context.Context, args []string) error {
 			// TODO: it'd be nice to get this from the ctx config so that
 			//  operations can be performed relative to the loaded config

--- a/internal/command/users.go
+++ b/internal/command/users.go
@@ -8,12 +8,13 @@ import (
 	"os"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/jetstack/jsctl/internal/client"
 	"github.com/jetstack/jsctl/internal/config"
 	"github.com/jetstack/jsctl/internal/prompt"
 	"github.com/jetstack/jsctl/internal/table"
 	"github.com/jetstack/jsctl/internal/user"
-	"github.com/spf13/cobra"
 )
 
 // Users returns a cobra.Command instance that is the root for all "jsctl users" subcommands.
@@ -39,6 +40,7 @@ func usersList() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Lists all users the within the current organization",
+		Args:  cobra.ExactArgs(0),
 		Run: run(func(ctx context.Context, args []string) error {
 			http := client.New(ctx, apiURL)
 			cnf, ok := config.FromContext(ctx)

--- a/internal/command/version.go
+++ b/internal/command/version.go
@@ -12,6 +12,7 @@ func Version(version *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "view the version, commit and build date of jsctl",
+		Args:  cobra.ExactArgs(0),
 		Run: run(func(ctx context.Context, args []string) error {
 			fmt.Println(*version)
 			if strings.Contains(*version, "dev") {


### PR DESCRIPTION
```bash
 $ go run main.go operator deploy versions
Error: accepts 0 arg(s), received 1
Usage:
  jsctl operator deploy [flags]
...

```

Signed-off-by: Charlie Egan <charlieegan3@users.noreply.github.com>