### PR TITLE
Prompt user to check supported versions if unknown

### DIFF
--- a/internal/command/operator.go
+++ b/internal/command/operator.go
@@ -124,7 +124,7 @@ Note: If --auto-registry-credentials and --registry-credentials-path are unset, 
 
 			switch {
 			case errors.Is(err, operator.ErrNoManifest):
-				return fmt.Errorf("operator version %s does not exist", version)
+				return fmt.Errorf("operator version %s is unknown or not supported by this version of jsctl. Run 'jsctl operator versions' to see the supported operator versions.", version)
 			case errors.Is(err, operator.ErrNoKeyFile):
 				return fmt.Errorf("no key file exists at %s", registryCredentialsPath)
 			case err != nil:


### PR DESCRIPTION
Before:

```
$ go run main.go operator deploy --version=foo
operator version foo does not exist
exit status 1
```

After:

```
$ jsctl operator versions
v0.0.1-alpha.17
$ go run main.go operator deploy --version=foo
operator version foo is unknown or not supported by this version of jsctl. Run 'jsctl operator versions' to see the supported operator versions.
exit status 1
```

Signed-off-by: Charlie Egan <charlieegan3@users.noreply.github.com>