### PR TITLE
Replace amd64 with x86_64 for uname -m URL generation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,6 +26,9 @@ builds:
 archives:
   - format: tar.gz
     name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    replacements:
+      # we are trying to generate asset URLs from uname -m, this returns x86_64 on intel machines
+      amd64: x86_64
     wrap_in_directory: true
 checksum:
   name_template: "{{ .ProjectName }}-{{ .Version }}-SHA256SUMS"


### PR DESCRIPTION
This command should generate a valid archive name.


```
echo "jsctl-$VERSION-$(uname -s)-$(uname -m)" | tr '[:upper:]' '[:lower:]'
```