### PR TITLE
Fix number of args for operator installations apply

### DIFF
--- a/internal/command/operator.go
+++ b/internal/command/operator.go
@@ -229,7 +229,7 @@ func operatorInstallationsApply() *cobra.Command {
 		Long: `Applies an Installation manifest to the current cluster, configured via flags
 
 Note: If --auto-registry-credentials and --registry-credentials-path are unset, then the installation components will be deployed without an image pull secret. The images must be availble for the component pods to start.`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.ExactArgs(0),
 		Run: run(func(ctx context.Context, args []string) error {
 			var err error
 


### PR DESCRIPTION
`jsctl operator installations apply` command is currently broken as it expects an argument that it doesn't need

```
irbe@jsctl$ jsctl operator installations apply
Error: accepts 1 arg(s), received 0
```


Signed-off-by: irbekrm <irbekrm@gmail.com>