### PR TITLE
Make releases drafts

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -81,7 +81,8 @@ archives:
 checksum:
   name_template: "{{ .ProjectName }}-{{ .Version }}-SHA256SUMS"
   algorithm: sha256
-release: {}
+release:
+  draft: true
 changelog:
   use: github-native
   skip: false


### PR DESCRIPTION
This avoids publishing an incomplete release if the build fails.