### PR TITLE
Implement `jsctl  cluster backup` command

### DIFF
--- a/docs/reference/jsctl_experimental_clusters.md
+++ b/docs/reference/jsctl_experimental_clusters.md
@@ -20,5 +20,6 @@ Experimental clusters commands
 ### SEE ALSO
 
 * [jsctl experimental](jsctl_experimental.md)	 - Experimental jsctl commands
+* [jsctl experimental clusters backup](jsctl_experimental_clusters_backup.md)	 - This command outputs the YAML data of Jetstack Secure relevant resources in the cluster
 * [jsctl experimental clusters cleanup](jsctl_experimental_clusters_cleanup.md)	 - Contains commands to prepare a cluster for the uninstallation of Jetstack Secure software
 

--- a/docs/reference/jsctl_experimental_clusters_backup.md
+++ b/docs/reference/jsctl_experimental_clusters_backup.md
@@ -1,0 +1,32 @@
+## jsctl experimental clusters backup
+
+This command outputs the YAML data of Jetstack Secure relevant resources in the cluster
+
+```
+jsctl experimental clusters backup [flags]
+```
+
+### Options
+
+```
+      --format string                          output format, one of: yaml, json (default "yaml")
+      --format-resources                       if set, will remove some fields from resources such as status and metadata to allow them to be cleanly applied later (default true)
+  -h, --help                                   help for backup
+      --include-certificate-request-policies   if set, certificate request policy resources will be included in the backup (default true)
+      --include-certificates                   if set, certificate resources will be included in the backup. Note: ingress-shim managed certificates are not included since they are automatically generated. (default true)
+      --include-issuers                        if set, issuer resources will be included in the backup (supports: issuers.cert-manager.io[v1], clusterissuers.cert-manager.io[v1], venafiissuers.jetstack.io[v1alpha1], venaficlusterissuers.jetstack.io[v1alpha1], awspcaissuers.awspca.cert-manager.io[v1beta1], awspcaclusterissuers.awspca.cert-manager.io[v1beta1], kmsissuers.cert-manager.skyscanner.net[v1alpha1], googlecasissuers.cas-issuer.jetstack.io[v1beta1], googlecasclusterissuers.cas-issuer.jetstack.io[v1beta1], originissuers.cert-manager.k8s.cloudflare.com[v1], stepissuers.certmanager.step.sm[v1beta1], stepclusterissuers.certmanager.step.sm[v1beta1]) (default true)
+```
+
+### Options inherited from parent commands
+
+```
+      --api-url string      Base URL of the control-plane API (default "https://platform.jetstack.io")
+      --config string       Location of the user's jsctl config directory (default "HOME or USERPROFILE/.jsctl")
+      --kubeconfig string   Location of the user's kubeconfig file for applying directly to the cluster (default "~/.kube/config")
+      --stdout              If provided, manifests are written to stdout rather than applied to the current cluster
+```
+
+### SEE ALSO
+
+* [jsctl experimental clusters](jsctl_experimental_clusters.md)	 - Experimental clusters commands
+

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/jetstack/jsctl
 go 1.19
 
 require (
+	github.com/Jeffail/gabs/v2 v2.6.1
 	github.com/Masterminds/semver v1.5.0
 	github.com/Skyscanner/kms-issuer v1.0.1-0.20221007144244-feb19f32171b
 	github.com/cert-manager/aws-privateca-issuer v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/Jeffail/gabs/v2 v2.6.1 h1:wwbE6nTQTwIMsMxzi6XFQQYRZ6wDc1mSdxoAN+9U4Gk=
+github.com/Jeffail/gabs/v2 v2.6.1/go.mod h1:xCn81vdHKxFUuWWAaD5jCTQDNPBMh5pPs9IJ+NcziBI=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=

--- a/internal/command/clusters.go
+++ b/internal/command/clusters.go
@@ -20,6 +20,7 @@ func Clusters() *cobra.Command {
 		clusters.Delete(run, &apiURL),
 		clusters.View(run, &apiURL),
 		clusters.Status(run, &kubeConfig),
+		clusters.Backup(run, &kubeConfig),
 		// TODO cleanup is currently experimental
 		// clusters.CleanUp(run, kubeConfig),
 	)

--- a/internal/command/clusters.go
+++ b/internal/command/clusters.go
@@ -20,9 +20,9 @@ func Clusters() *cobra.Command {
 		clusters.Delete(run, &apiURL),
 		clusters.View(run, &apiURL),
 		clusters.Status(run, &kubeConfig),
-		clusters.Backup(run, &kubeConfig),
-		// TODO cleanup is currently experimental
+		// TODO these commands are currently experimental
 		// clusters.CleanUp(run, kubeConfig),
+		// clusters.Backup(run, kubeConfig),
 	)
 
 	return cmd

--- a/internal/command/clusters/backup.go
+++ b/internal/command/clusters/backup.go
@@ -20,8 +20,6 @@ func Backup(run types.RunFunc, kubeConfigPath string) *cobra.Command {
 	var includeIssuers bool
 	var includeCertificateRequestPolicies bool
 
-	var skipIngressCerts bool
-
 	cmd := &cobra.Command{
 		Use:   "backup",
 		Short: "This command outputs the YAML data of Jetstack Secure relevant resources in the cluster",
@@ -38,7 +36,6 @@ func Backup(run types.RunFunc, kubeConfigPath string) *cobra.Command {
 				FormatResources: formatResources,
 
 				IncludeCertificates:               includeCertificates,
-				IncludeIngressCertificates:        !skipIngressCerts,
 				IncludeIssuers:                    includeIssuers,
 				IncludeCertificateRequestPolicies: includeCertificateRequestPolicies,
 			}
@@ -66,7 +63,6 @@ func Backup(run types.RunFunc, kubeConfigPath string) *cobra.Command {
 	flags.BoolVar(&includeCertificates, "include-certificates", true, "if set, certificate resources will be included in the backup")
 	flags.BoolVar(&includeIssuers, "include-issuers", true, "if set, issuer resources will be included in the backup")
 	flags.BoolVar(&includeCertificateRequestPolicies, "include-certificate-request-policies", true, "if set, certificate request policy resources will be included in the backup")
-	flags.BoolVar(&skipIngressCerts, "skip-ingress-certs", true, "if set, certificates created by ingress-shim will be skipped")
 
 	return cmd
 }

--- a/internal/command/clusters/backup.go
+++ b/internal/command/clusters/backup.go
@@ -13,7 +13,7 @@ import (
 	"github.com/jetstack/jsctl/internal/kubernetes/clients"
 )
 
-func Backup(run types.RunFunc, kubeConfigPath string) *cobra.Command {
+func Backup(run types.RunFunc, kubeConfigPath *string) *cobra.Command {
 	var formatResources bool
 	var outputFormat string
 
@@ -26,7 +26,7 @@ func Backup(run types.RunFunc, kubeConfigPath string) *cobra.Command {
 		Short: "This command outputs the YAML data of Jetstack Secure relevant resources in the cluster",
 		Args:  cobra.MatchAll(cobra.ExactArgs(0)),
 		Run: run(func(ctx context.Context, args []string) error {
-			kubeCfg, err := kubernetes.NewConfig(kubeConfigPath)
+			kubeCfg, err := kubernetes.NewConfig(*kubeConfigPath)
 			if err != nil {
 				return err
 			}

--- a/internal/command/clusters/backup.go
+++ b/internal/command/clusters/backup.go
@@ -1,0 +1,72 @@
+package clusters
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jetstack/jsctl/internal/command/types"
+	"github.com/jetstack/jsctl/internal/kubernetes"
+	"github.com/jetstack/jsctl/internal/kubernetes/backup"
+)
+
+func Backup(run types.RunFunc, kubeConfigPath string) *cobra.Command {
+	var formatResources bool
+	var outputFormat string
+
+	var includeCertificates bool
+	var includeIssuers bool
+	var includeCertificateRequestPolicies bool
+
+	var skipIngressCerts bool
+
+	cmd := &cobra.Command{
+		Use:   "backup",
+		Short: "This command outputs the YAML data of Jetstack Secure relevant resources in the cluster",
+		Args:  cobra.MatchAll(cobra.ExactArgs(0)),
+		Run: run(func(ctx context.Context, args []string) error {
+			kubeCfg, err := kubernetes.NewConfig(kubeConfigPath)
+			if err != nil {
+				return err
+			}
+
+			opts := backup.ClusterBackupOptions{
+				RestConfig: kubeCfg,
+
+				FormatResources: formatResources,
+
+				IncludeCertificates:               includeCertificates,
+				IncludeIngressCertificates:        !skipIngressCerts,
+				IncludeIssuers:                    includeIssuers,
+				IncludeCertificateRequestPolicies: includeCertificateRequestPolicies,
+			}
+
+			clusterBackup, err := backup.FetchClusterBackup(context.Background(), opts)
+			if err != nil {
+				return fmt.Errorf("error backing up cluster: %s", err)
+			}
+
+			backupYAML, err := clusterBackup.ToYAML()
+			if err != nil {
+				return fmt.Errorf("error converting backup to YAML: %s", err)
+			}
+
+			fmt.Fprintf(os.Stdout, "%s", backupYAML)
+
+			return nil
+		}),
+	}
+
+	flags := cmd.PersistentFlags()
+	flags.BoolVar(&formatResources, "format-resources", true, "if set, will remove some fields from resources such as status and metadata to allow them to be cleanly applied later")
+	flags.StringVar(&outputFormat, "format", "yaml", "output format, one of: yaml, json")
+
+	flags.BoolVar(&includeCertificates, "include-certificates", true, "if set, certificate resources will be included in the backup")
+	flags.BoolVar(&includeIssuers, "include-issuers", true, "if set, issuer resources will be included in the backup")
+	flags.BoolVar(&includeCertificateRequestPolicies, "include-certificate-request-policies", true, "if set, certificate request policy resources will be included in the backup")
+	flags.BoolVar(&skipIngressCerts, "skip-ingress-certs", true, "if set, certificates created by ingress-shim will be skipped")
+
+	return cmd
+}

--- a/internal/command/clusters/backup.go
+++ b/internal/command/clusters/backup.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jetstack/jsctl/internal/command/types"
 	"github.com/jetstack/jsctl/internal/kubernetes"
 	"github.com/jetstack/jsctl/internal/kubernetes/backup"
+	"github.com/jetstack/jsctl/internal/kubernetes/clients"
 )
 
 func Backup(run types.RunFunc, kubeConfigPath string) *cobra.Command {
@@ -56,12 +57,21 @@ func Backup(run types.RunFunc, kubeConfigPath string) *cobra.Command {
 		}),
 	}
 
+	allIssuers, err := clients.ListSupportedIssuers()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error determining supported issuers, this is a bug: %s", err)
+		os.Exit(1)
+	}
+	allIssuersString := allIssuers.String()
+
+	fmt.Println(allIssuersString)
+
 	flags := cmd.PersistentFlags()
 	flags.BoolVar(&formatResources, "format-resources", true, "if set, will remove some fields from resources such as status and metadata to allow them to be cleanly applied later")
 	flags.StringVar(&outputFormat, "format", "yaml", "output format, one of: yaml, json")
 
 	flags.BoolVar(&includeCertificates, "include-certificates", true, "if set, certificate resources will be included in the backup. Note: ingress-shim managed certificates are not included since they are automatically generated.")
-	flags.BoolVar(&includeIssuers, "include-issuers", true, "if set, issuer resources will be included in the backup")
+	flags.BoolVar(&includeIssuers, "include-issuers", true, fmt.Sprintf("if set, issuer resources will be included in the backup (supports: %s)", allIssuersString))
 	flags.BoolVar(&includeCertificateRequestPolicies, "include-certificate-request-policies", true, "if set, certificate request policy resources will be included in the backup")
 
 	return cmd

--- a/internal/command/clusters/backup.go
+++ b/internal/command/clusters/backup.go
@@ -46,12 +46,23 @@ func Backup(run types.RunFunc, kubeConfigPath *string) *cobra.Command {
 				return fmt.Errorf("error backing up cluster: %s", err)
 			}
 
-			backupYAML, err := clusterBackup.ToYAML()
-			if err != nil {
-				return fmt.Errorf("error converting backup to YAML: %s", err)
+			var backupData []byte
+			switch outputFormat {
+			case "yaml":
+				backupData, err = clusterBackup.ToYAML()
+				if err != nil {
+					return fmt.Errorf("error converting backup to YAML: %s", err)
+				}
+			case "json":
+				backupData, err = clusterBackup.ToJSON()
+				if err != nil {
+					return fmt.Errorf("error converting backup to JSON: %s", err)
+				}
+			default:
+				return fmt.Errorf("unknown output format: %s", outputFormat)
 			}
 
-			fmt.Fprintf(os.Stdout, "%s", backupYAML)
+			fmt.Fprintf(os.Stdout, "%s", string(backupData))
 
 			return nil
 		}),

--- a/internal/command/clusters/backup.go
+++ b/internal/command/clusters/backup.go
@@ -60,7 +60,7 @@ func Backup(run types.RunFunc, kubeConfigPath string) *cobra.Command {
 	flags.BoolVar(&formatResources, "format-resources", true, "if set, will remove some fields from resources such as status and metadata to allow them to be cleanly applied later")
 	flags.StringVar(&outputFormat, "format", "yaml", "output format, one of: yaml, json")
 
-	flags.BoolVar(&includeCertificates, "include-certificates", true, "if set, certificate resources will be included in the backup")
+	flags.BoolVar(&includeCertificates, "include-certificates", true, "if set, certificate resources will be included in the backup. Note: ingress-shim managed certificates are not included since they are automatically generated.")
 	flags.BoolVar(&includeIssuers, "include-issuers", true, "if set, issuer resources will be included in the backup")
 	flags.BoolVar(&includeCertificateRequestPolicies, "include-certificate-request-policies", true, "if set, certificate request policy resources will be included in the backup")
 

--- a/internal/command/clusters/backup.go
+++ b/internal/command/clusters/backup.go
@@ -64,8 +64,6 @@ func Backup(run types.RunFunc, kubeConfigPath *string) *cobra.Command {
 	}
 	allIssuersString := allIssuers.String()
 
-	fmt.Println(allIssuersString)
-
 	flags := cmd.PersistentFlags()
 	flags.BoolVar(&formatResources, "format-resources", true, "if set, will remove some fields from resources such as status and metadata to allow them to be cleanly applied later")
 	flags.StringVar(&outputFormat, "format", "yaml", "output format, one of: yaml, json")

--- a/internal/command/clusters/cleanup.go
+++ b/internal/command/clusters/cleanup.go
@@ -21,13 +21,13 @@ import (
 )
 
 // CleanUp returns a new command that wraps cluster clean up commands
-func CleanUp(run types.RunFunc, kubeConfigPath string) *cobra.Command {
+func CleanUp(run types.RunFunc, kubeConfigPath *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cleanup",
 		Short: "Contains commands to prepare a cluster for the uninstallation of Jetstack Secure software",
 	}
 
-	cmd.AddCommand(secrets(run, kubeConfigPath))
+	cmd.AddCommand(secrets(run, *kubeConfigPath))
 
 	return cmd
 }

--- a/internal/command/experimental.go
+++ b/internal/command/experimental.go
@@ -20,7 +20,8 @@ func Experimental() *cobra.Command {
 	}
 
 	experimentalClustersCommands.AddCommand(
-		clusters.CleanUp(run, kubeConfig),
+		clusters.CleanUp(run, &kubeConfig),
+		clusters.Backup(run, &kubeConfig),
 	)
 
 	cmd.AddCommand(experimentalClustersCommands)

--- a/internal/kubernetes/backup/backup.go
+++ b/internal/kubernetes/backup/backup.go
@@ -87,9 +87,15 @@ func FetchClusterBackup(ctx context.Context, opts ClusterBackupOptions) (*Cluste
 		if len(crd.Spec.Versions) == 0 {
 			return nil, fmt.Errorf("unexpectedly found no versions on cert-manager.io CRD %s", crd.Name)
 		}
-		// the first version in the list must be v1 as we expect v1 resources
-		if crd.Spec.Versions[0].Name != "v1" {
-			return nil, fmt.Errorf("backup only supports cert-manager.io API version v1, found %s", crd.Spec.Versions[0].Name)
+		v1FoundAndServed := false
+		for _, v := range crd.Spec.Versions {
+			if v.Name == "v1" && v.Served {
+				v1FoundAndServed = true
+				break
+			}
+		}
+		if !v1FoundAndServed {
+			return nil, fmt.Errorf("backup only supports cert-manager.io API version v1. v1 must be present and served")
 		}
 	}
 

--- a/internal/kubernetes/backup/backup.go
+++ b/internal/kubernetes/backup/backup.go
@@ -1,0 +1,311 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	v1alpha1kmsissuer "github.com/Skyscanner/kms-issuer/apis/certmanager/v1alpha1"
+	v1alpha1approverpolicy "github.com/cert-manager/approver-policy/pkg/apis/policy/v1alpha1"
+	v1beta1awspcaissuer "github.com/cert-manager/aws-privateca-issuer/pkg/api/v1beta1"
+	v1certmanager "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	v1origincaissuer "github.com/cloudflare/origin-ca-issuer/pkgs/apis/v1"
+	v1beta1googlecasissuer "github.com/jetstack/google-cas-issuer/api/v1beta1"
+	v1alpha1vei "github.com/jetstack/venafi-enhanced-issuer/api/v1alpha1"
+	v1beta1stepissuer "github.com/smallstep/step-issuer/api/v1beta1"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/yaml"
+
+	"github.com/jetstack/jsctl/internal/kubernetes/clients"
+)
+
+// ClusterBackupOptions wraps the options for fetching a cluster backup, sometimes
+// not all resources are required, so these options allow for filtering and
+// formatting.
+type ClusterBackupOptions struct {
+	RestConfig *rest.Config
+
+	// FormatResources, if set, will remove certain fields from the resources
+	FormatResources bool
+
+	IncludeCertificates               bool
+	IncludeIngressCertificates        bool
+	IncludeIssuers                    bool
+	IncludeCertificateRequestPolicies bool
+}
+
+type ClusterBackup []interface{}
+
+func (c *ClusterBackup) ToYAML() ([]byte, error) {
+	buf := new(bytes.Buffer)
+
+	for _, r := range *c {
+		buf.Write([]byte("---\n"))
+		yamlBytes, err := yaml.Marshal(r)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(yamlBytes)
+	}
+
+	return []byte(strings.TrimSpace(buf.String()) + "\n"), nil
+}
+
+func FetchClusterBackup(ctx context.Context, opts ClusterBackupOptions) (*ClusterBackup, error) {
+	var clusterBackup ClusterBackup
+
+	// these fields should be excluded from the backup
+	var dropFields []string
+	if opts.FormatResources {
+		dropFields = []string{
+			"/metadata/creationTimestamp", // this is set as null in marshalling, but we clear the value anyway
+			"/metadata/generation",
+			"/metadata/resourceVersion",
+			"/metadata/uid",
+			"/metadata/managedFields",
+			"/status",
+			"/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration",
+		}
+	}
+
+	// fetch all configured issuers and external issuers
+	issuers, err := fetchAllIssuers(ctx, opts.RestConfig, dropFields)
+	if err != nil {
+		return &ClusterBackup{}, fmt.Errorf("failed to backup issuers: %w", err)
+	}
+	clusterBackup = append(clusterBackup, issuers...)
+
+	// fetch certifcates
+	certificateClient, err := clients.NewCertificateClient(opts.RestConfig)
+	if err != nil {
+		return &ClusterBackup{}, fmt.Errorf("failed to create client for certificates: %w", err)
+	}
+
+	var certificates v1certmanager.CertificateList
+	err = certificateClient.List(
+		ctx,
+		&clients.GenericRequestOptions{DropFields: dropFields},
+		&certificates,
+	)
+	if err != nil {
+		return &ClusterBackup{}, fmt.Errorf("failed to list certificates: %w", err)
+	}
+	for _, c := range certificates.Items {
+		// if we're not including ingress certificates, skip them
+		skip := false
+		if !opts.IncludeIngressCertificates && len(c.OwnerReferences) > 0 {
+			for _, owner := range c.OwnerReferences {
+				if owner.Kind == "Ingress" {
+					skip = true
+					break
+				}
+			}
+		}
+		if !skip {
+			clusterBackup = append(clusterBackup, c)
+		}
+	}
+
+	// fetch certificate request policies
+	certificateRequestPolicyClient, err := clients.NewCertificateRequestPolicyClient(opts.RestConfig)
+	if err != nil {
+		return &ClusterBackup{}, fmt.Errorf("failed to create client for certificate request policies: %w", err)
+	}
+
+	var certificateRequestPolicies v1alpha1approverpolicy.CertificateRequestPolicyList
+	err = certificateRequestPolicyClient.List(
+		ctx,
+		&clients.GenericRequestOptions{DropFields: dropFields},
+		&certificateRequestPolicies,
+	)
+	if err != nil {
+		return &ClusterBackup{}, fmt.Errorf("failed to list certificate request policies: %w", err)
+	}
+	for _, p := range certificateRequestPolicies.Items {
+		clusterBackup = append(clusterBackup, p)
+	}
+
+	return &clusterBackup, nil
+}
+
+// TODO: this is similar to the logic in status.go, however with the types it's
+// a pain to share functionality.
+func fetchAllIssuers(ctx context.Context, cfg *rest.Config, dropFields []string) ([]interface{}, error) {
+	requestOptions := &clients.GenericRequestOptions{
+		DropFields: dropFields,
+	}
+
+	issuerClient, err := clients.NewAllIssuers(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create issuer client: %s", err)
+	}
+	issuerKinds, err := issuerClient.ListKinds(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list issuer kinds: %s", err)
+	}
+
+	var allIssuers []interface{}
+	for _, kind := range issuerKinds {
+		switch kind {
+		case clients.CertManagerIssuer:
+			client, err := clients.NewCertManagerIssuerClient(cfg)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create clusterissuer client: %s", err)
+			}
+			var issuers v1certmanager.IssuerList
+			err = client.List(ctx, requestOptions, &issuers)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list clusterissuers: %s", err)
+			}
+			for _, issuer := range issuers.Items {
+				allIssuers = append(allIssuers, issuer)
+			}
+		case clients.CertManagerClusterIssuer:
+			client, err := clients.NewCertManagerClusterIssuerClient(cfg)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create clusterissuer client: %s", err)
+			}
+			var clusterIssuers v1certmanager.ClusterIssuerList
+			err = client.List(ctx, requestOptions, &clusterIssuers)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list clusterissuers: %s", err)
+			}
+			for _, issuer := range clusterIssuers.Items {
+				allIssuers = append(allIssuers, issuer)
+			}
+		case clients.GoogleCASIssuer:
+			client, err := clients.NewGoogleCASIssuerClient(cfg)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create cas client: %s", err)
+			}
+			var issuers v1beta1googlecasissuer.GoogleCASIssuerList
+			err = client.List(ctx, requestOptions, &issuers)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list cas issuers: %s", err)
+			}
+			for _, issuer := range issuers.Items {
+				allIssuers = append(allIssuers, issuer)
+			}
+		case clients.GoogleCASClusterIssuer:
+			client, err := clients.NewGoogleCASClusterIssuerClient(cfg)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create cas cluster issuer client: %s", err)
+			}
+			var issuers v1beta1googlecasissuer.GoogleCASClusterIssuerList
+			err = client.List(ctx, requestOptions, &issuers)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list cas cluster issuers: %s", err)
+			}
+			for _, issuer := range issuers.Items {
+				allIssuers = append(allIssuers, issuer)
+			}
+		case clients.AWSPCAIssuer:
+			client, err := clients.NewAWSPCAIssuerClient(cfg)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create aws pca issuer client: %s", err)
+			}
+			var issuers v1beta1awspcaissuer.AWSPCAIssuerList
+			err = client.List(ctx, requestOptions, &issuers)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list pca issuers: %s", err)
+			}
+			for _, issuer := range issuers.Items {
+				allIssuers = append(allIssuers, issuer)
+			}
+		case clients.AWSPCAClusterIssuer:
+			client, err := clients.NewAWSPCAClusterIssuerClient(cfg)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create aws pca cluster issuer client: %s", err)
+			}
+			var issuers v1beta1awspcaissuer.AWSPCAClusterIssuerList
+			err = client.List(ctx, requestOptions, &issuers)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list pca cluster issuers: %s", err)
+			}
+			for _, issuer := range issuers.Items {
+				allIssuers = append(allIssuers, issuer)
+			}
+		case clients.KMSIssuer:
+			client, err := clients.NewKMSIssuerClient(cfg)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create kms issuer client: %s", err)
+			}
+			var issuers v1alpha1kmsissuer.KMSIssuerList
+			err = client.List(ctx, requestOptions, &issuers)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list kms issuers: %s", err)
+			}
+			for _, issuer := range issuers.Items {
+				allIssuers = append(allIssuers, issuer)
+			}
+		case clients.VenafiEnhancedIssuer:
+			client, err := clients.NewVenafiEnhancedIssuerClient(cfg)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create venafi enhanced issuer client: %s", err)
+			}
+			var issuers v1alpha1vei.VenafiIssuerList
+			err = client.List(ctx, requestOptions, &issuers)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list venafi issuers: %s", err)
+			}
+			for _, issuer := range issuers.Items {
+				allIssuers = append(allIssuers, issuer)
+			}
+		case clients.VenafiEnhancedClusterIssuer:
+			client, err := clients.NewVenafiEnhancedClusterIssuerClient(cfg)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create venafi enhanced cluster issuer client: %s", err)
+			}
+			var issuers v1alpha1vei.VenafiClusterIssuerList
+			err = client.List(ctx, requestOptions, &issuers)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list venafi cluster issuers: %s", err)
+			}
+			for _, issuer := range issuers.Items {
+				allIssuers = append(allIssuers, issuer)
+			}
+		case clients.OriginCAIssuer:
+			client, err := clients.NewOriginCAIssuerClient(cfg)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create origin ca issuer client: %s", err)
+			}
+			var issuers v1origincaissuer.OriginIssuerList
+			err = client.List(ctx, requestOptions, &issuers)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list origin ca issuers: %s", err)
+			}
+			for _, issuer := range issuers.Items {
+				allIssuers = append(allIssuers, issuer)
+			}
+		case clients.SmallStepIssuer:
+			client, err := clients.NewSmallStepIssuerClient(cfg)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create smallstep issuer client: %s", err)
+			}
+			var issuers v1beta1stepissuer.StepIssuerList
+			err = client.List(ctx, requestOptions, &issuers)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list smallstep issuers: %s", err)
+			}
+			for _, issuer := range issuers.Items {
+				allIssuers = append(allIssuers, issuer)
+			}
+		case clients.SmallStepClusterIssuer:
+			client, err := clients.NewSmallStepClusterIssuerClient(cfg)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create smallstep cluster issuer client: %s", err)
+			}
+			var issuers v1beta1stepissuer.StepClusterIssuerList
+			err = client.List(ctx, requestOptions, &issuers)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list smallstep cluster issuers: %s", err)
+			}
+			for _, issuer := range issuers.Items {
+				allIssuers = append(allIssuers, issuer)
+			}
+		}
+	}
+
+	return allIssuers, nil
+}

--- a/internal/kubernetes/backup/backup.go
+++ b/internal/kubernetes/backup/backup.go
@@ -3,6 +3,7 @@ package backup
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -51,6 +52,21 @@ func (c *ClusterBackup) ToYAML() ([]byte, error) {
 	}
 
 	return []byte(strings.TrimSpace(buf.String()) + "\n"), nil
+}
+
+func (c *ClusterBackup) ToJSON() ([]byte, error) {
+	listWrapper := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "List",
+		"items":      *c,
+	}
+
+	bytes, err := json.MarshalIndent(listWrapper, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling cluster backup to JSON: %s", err)
+	}
+
+	return bytes, nil
 }
 
 func FetchClusterBackup(ctx context.Context, opts ClusterBackupOptions) (*ClusterBackup, error) {

--- a/internal/kubernetes/backup/backup.go
+++ b/internal/kubernetes/backup/backup.go
@@ -108,6 +108,8 @@ func FetchClusterBackup(ctx context.Context, opts ClusterBackupOptions) (*Cluste
 	}
 
 	// fetch certificate request policies
+	// Note: this back up data is not used in the migration to an operator managed installation.
+	// These resourcse are only included for disaster recovery purposes.
 	certificateRequestPolicyClient, err := clients.NewCertificateRequestPolicyClient(opts.RestConfig)
 	if err != nil {
 		return &ClusterBackup{}, fmt.Errorf("failed to create client for certificate request policies: %w", err)

--- a/internal/kubernetes/backup/backup_test.go
+++ b/internal/kubernetes/backup/backup_test.go
@@ -101,5 +101,5 @@ func TestBackup_LegacyAPIVersions(t *testing.T) {
 	}
 
 	_, err := FetchClusterBackup(context.Background(), opts)
-	require.ErrorContains(t, err, "backup only supports cert-manager.io API version v1, found v2")
+	require.ErrorContains(t, err, "backup only supports cert-manager.io API version v1. v1 must be present and served")
 }

--- a/internal/kubernetes/backup/backup_test.go
+++ b/internal/kubernetes/backup/backup_test.go
@@ -1,0 +1,75 @@
+package backup
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func TestBackup(t *testing.T) {
+	expectedBackupYAML, err := os.ReadFile("fixtures/backup.yaml")
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		w.Header().Set("Content-Type", "application/json")
+
+		var data []byte
+		switch r.URL.Path {
+		// CRDs are needed to determine the issuer types to backup
+		case "/apis/apiextensions.k8s.io/v1/customresourcedefinitions":
+			data, err = os.ReadFile("fixtures/crd-list.json")
+			require.NoError(t, err)
+		case "/apis/cert-manager.io/v1/certificates":
+			data, err = os.ReadFile("fixtures/certificate-list.json")
+			require.NoError(t, err)
+		case "/apis/cert-manager.io/v1/clusterissuers":
+			data, err = os.ReadFile("fixtures/cluster-issuer-list.json")
+			require.NoError(t, err)
+		case "/apis/cert-manager.io/v1/issuers":
+			data, err = os.ReadFile("fixtures/issuer-list.json")
+			require.NoError(t, err)
+		case "/apis/cas-issuer.jetstack.io/v1beta1/googlecasissuers":
+			data, err = os.ReadFile("fixtures/googlecasissuer-list.json")
+			require.NoError(t, err)
+		case "/apis/cas-issuer.jetstack.io/v1beta1/googlecasclusterissuers":
+			data = []byte(`{"items": []}`)
+			require.NoError(t, err)
+		case "/apis/awspca.cert-manager.io/v1beta1/awspcaissuers":
+			data, err = os.ReadFile("fixtures/awspcaissuer-list.json")
+			require.NoError(t, err)
+		case "/apis/policy.cert-manager.io/v1alpha1/certificaterequestpolicies":
+			data, err = os.ReadFile("fixtures/certificate-request-policy-list.json")
+			require.NoError(t, err)
+		default:
+			t.Fatalf("unexpected request: %s", r.URL.Path)
+		}
+
+		w.Write(data)
+	}))
+
+	opts := ClusterBackupOptions{
+		RestConfig: &rest.Config{Host: server.URL},
+
+		FormatResources: true,
+
+		IncludeCertificates:               true,
+		IncludeIngressCertificates:        true,
+		IncludeCertificateRequestPolicies: true,
+		IncludeIssuers:                    true,
+	}
+
+	backup, err := FetchClusterBackup(context.Background(), opts)
+	require.NoError(t, err)
+
+	backupYAML, err := backup.ToYAML()
+	require.NoError(t, err)
+
+	assert.Equal(t, string(expectedBackupYAML), string(backupYAML))
+}

--- a/internal/kubernetes/backup/backup_test.go
+++ b/internal/kubernetes/backup/backup_test.go
@@ -60,7 +60,6 @@ func TestBackup(t *testing.T) {
 		FormatResources: true,
 
 		IncludeCertificates:               true,
-		IncludeIngressCertificates:        true,
 		IncludeCertificateRequestPolicies: true,
 		IncludeIssuers:                    true,
 	}

--- a/internal/kubernetes/backup/backup_test.go
+++ b/internal/kubernetes/backup/backup_test.go
@@ -13,9 +13,6 @@ import (
 )
 
 func TestBackup(t *testing.T) {
-	expectedBackupYAML, err := os.ReadFile("fixtures/backup.yaml")
-	require.NoError(t, err)
-
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var err error
 		w.Header().Set("Content-Type", "application/json")
@@ -67,10 +64,23 @@ func TestBackup(t *testing.T) {
 	backup, err := FetchClusterBackup(context.Background(), opts)
 	require.NoError(t, err)
 
+	// test output formats
+	expectedBackupYAML, err := os.ReadFile("fixtures/backup.yaml")
+	require.NoError(t, err)
+
 	backupYAML, err := backup.ToYAML()
 	require.NoError(t, err)
 
 	assert.Equal(t, string(expectedBackupYAML), string(backupYAML))
+
+	// json
+	expectedBackupJSON, err := os.ReadFile("fixtures/backup.json")
+	require.NoError(t, err)
+
+	backupJSON, err := backup.ToJSON()
+	require.NoError(t, err)
+
+	assert.Equal(t, string(expectedBackupJSON), string(backupJSON))
 }
 
 func TestBackup_LegacyAPIVersions(t *testing.T) {

--- a/internal/kubernetes/backup/fixtures/awspcaissuer-list.json
+++ b/internal/kubernetes/backup/fixtures/awspcaissuer-list.json
@@ -1,0 +1,28 @@
+{
+  "apiVersion": "v1",
+  "items": [
+    {
+      "apiVersion": "awspca.cert-manager.io/v1beta1",
+      "kind": "AWSPCAIssuer",
+      "metadata": {
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"awspca.cert-manager.io/v1beta1\",\"kind\":\"AWSPCAIssuer\",\"metadata\":{\"annotations\":{},\"name\":\"pca-sample\",\"namespace\":\"jetstack-secure\"},\"spec\":{\"arn\":\"acb\"}}\n"
+        },
+        "creationTimestamp": "2022-11-08T14:22:24Z",
+        "generation": 1,
+        "name": "pca-sample",
+        "namespace": "jetstack-secure",
+        "resourceVersion": "289080",
+        "uid": "27e5601b-c4cd-4f78-ac74-413bba8c0c96"
+      },
+      "spec": {
+        "arn": "acb"
+      }
+    }
+  ],
+  "kind": "List",
+  "metadata": {
+    "resourceVersion": "",
+    "selfLink": ""
+  }
+}

--- a/internal/kubernetes/backup/fixtures/backup.json
+++ b/internal/kubernetes/backup/fixtures/backup.json
@@ -1,0 +1,121 @@
+{
+  "apiVersion": "v1",
+  "items": [
+    {
+      "kind": "AWSPCAIssuer",
+      "apiVersion": "awspca.cert-manager.io/v1beta1",
+      "metadata": {
+        "name": "pca-sample",
+        "namespace": "jetstack-secure",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "arn": "acb",
+        "secretRef": {
+          "accessKeyIDSelector": {
+            "key": ""
+          },
+          "secretAccessKeySelector": {
+            "key": ""
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "ClusterIssuer",
+      "apiVersion": "cert-manager.io/v1",
+      "metadata": {
+        "name": "cm-cluster-issuer-sample",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "acme": {
+          "email": "dummy-email@example.com",
+          "server": "https://",
+          "preferredChain": "",
+          "privateKeySecretRef": {
+            "name": "example"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "GoogleCASIssuer",
+      "apiVersion": "cas-issuer.jetstack.io/v1beta1",
+      "metadata": {
+        "name": "googlecasissuer-sample",
+        "namespace": "jetstack-secure",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "project": "example",
+        "location": "us-east1",
+        "caPoolId": "my-pool",
+        "credentials": {
+          "name": "googlesa",
+          "key": "example"
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "Issuer",
+      "apiVersion": "cert-manager.io/v1",
+      "metadata": {
+        "name": "cm-issuer-sample",
+        "namespace": "jetstack-secure",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "ca": {
+          "secretName": "ca-key-pair"
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "Certificate",
+      "apiVersion": "cert-manager.io/v1",
+      "metadata": {
+        "name": "example-com",
+        "namespace": "jetstack-secure",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "dnsNames": [
+          "example.com"
+        ],
+        "secretName": "example-com-tls",
+        "issuerRef": {
+          "name": "ca-issuer",
+          "kind": "Issuer",
+          "group": "cert-manager.io"
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "CertificateRequestPolicy",
+      "apiVersion": "policy.cert-manager.io/v1alpha1",
+      "metadata": {
+        "name": "test-policy",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "allowed": {
+          "commonName": {
+            "value": "hello.world",
+            "required": true
+          }
+        },
+        "selector": {
+          "issuerRef": {}
+        }
+      },
+      "status": {}
+    }
+  ],
+  "kind": "List"
+}

--- a/internal/kubernetes/backup/fixtures/backup.yaml
+++ b/internal/kubernetes/backup/fixtures/backup.yaml
@@ -1,0 +1,108 @@
+---
+apiVersion: awspca.cert-manager.io/v1beta1
+kind: AWSPCAIssuer
+metadata:
+  creationTimestamp: null
+  name: pca-sample
+  namespace: jetstack-secure
+spec:
+  arn: acb
+  secretRef:
+    accessKeyIDSelector:
+      key: ""
+    secretAccessKeySelector:
+      key: ""
+status: {}
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  creationTimestamp: null
+  name: cm-cluster-issuer-sample
+spec:
+  acme:
+    email: dummy-email@example.com
+    preferredChain: ""
+    privateKeySecretRef:
+      name: example
+    server: https://
+status: {}
+---
+apiVersion: cas-issuer.jetstack.io/v1beta1
+kind: GoogleCASIssuer
+metadata:
+  creationTimestamp: null
+  name: googlecasissuer-sample
+  namespace: jetstack-secure
+spec:
+  caPoolId: my-pool
+  credentials:
+    key: example
+    name: googlesa
+  location: us-east1
+  project: example
+status: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  creationTimestamp: null
+  name: cm-issuer-sample
+  namespace: jetstack-secure
+spec:
+  ca:
+    secretName: ca-key-pair
+status: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  name: example-com-ingress
+  namespace: jetstack-secure
+  ownerReferences:
+  - apiVersion: networking.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Ingress
+    name: example-com
+    uid: f9013344-8318-4fd6-b8d3-12345
+spec:
+  dnsNames:
+  - example.com
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: ca-issuer
+  secretName: example-com-tls
+status: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  name: example-com
+  namespace: jetstack-secure
+spec:
+  dnsNames:
+  - example.com
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: ca-issuer
+  secretName: example-com-tls
+status: {}
+---
+apiVersion: policy.cert-manager.io/v1alpha1
+kind: CertificateRequestPolicy
+metadata:
+  creationTimestamp: null
+  name: test-policy
+spec:
+  allowed:
+    commonName:
+      required: true
+      value: hello.world
+  selector:
+    issuerRef: {}
+status: {}

--- a/internal/kubernetes/backup/fixtures/backup.yaml
+++ b/internal/kubernetes/backup/fixtures/backup.yaml
@@ -58,29 +58,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   creationTimestamp: null
-  name: example-com-ingress
-  namespace: jetstack-secure
-  ownerReferences:
-  - apiVersion: networking.k8s.io/v1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Ingress
-    name: example-com
-    uid: f9013344-8318-4fd6-b8d3-12345
-spec:
-  dnsNames:
-  - example.com
-  issuerRef:
-    group: cert-manager.io
-    kind: Issuer
-    name: ca-issuer
-  secretName: example-com-tls
-status: {}
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  creationTimestamp: null
   name: example-com
   namespace: jetstack-secure
 spec:

--- a/internal/kubernetes/backup/fixtures/certificate-list.json
+++ b/internal/kubernetes/backup/fixtures/certificate-list.json
@@ -1,0 +1,102 @@
+{
+  "apiVersion": "v1",
+  "items": [
+    {
+      "apiVersion": "cert-manager.io/v1",
+      "kind": "Certificate",
+      "metadata": {
+        "annotations": { },
+        "ownerReferences": [
+          {
+            "apiVersion": "networking.k8s.io/v1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Ingress",
+            "name": "example-com",
+            "uid": "f9013344-8318-4fd6-b8d3-12345"
+          }
+        ],
+        "creationTimestamp": "2022-11-11T16:00:29Z",
+        "generation": 1,
+        "name": "example-com-ingress",
+        "namespace": "jetstack-secure",
+        "resourceVersion": "2535",
+        "uid": "f9013344-8318-4fd6-b8d3-b8b95a50b7f5"
+      },
+      "spec": {
+        "dnsNames": [
+          "example.com"
+        ],
+        "issuerRef": {
+          "group": "cert-manager.io",
+          "kind": "Issuer",
+          "name": "ca-issuer"
+        },
+        "secretName": "example-com-tls"
+      },
+      "status": {
+        "conditions": [
+          {
+            "lastTransitionTime": "2022-11-11T16:01:23Z",
+            "message": "Certificate is up to date and has not expired",
+            "observedGeneration": 1,
+            "reason": "Ready",
+            "status": "True",
+            "type": "Ready"
+          }
+        ],
+        "notAfter": "2023-02-09T16:01:23Z",
+        "notBefore": "2022-11-11T16:01:23Z",
+        "renewalTime": "2023-01-10T16:01:23Z",
+        "revision": 1
+      }
+    },
+    {
+      "apiVersion": "cert-manager.io/v1",
+      "kind": "Certificate",
+      "metadata": {
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"cert-manager.io/v1\",\"kind\":\"Certificate\",\"metadata\":{\"annotations\":{},\"name\":\"example-com\",\"namespace\":\"jetstack-secure\"},\"spec\":{\"dnsNames\":[\"example.com\"],\"issuerRef\":{\"group\":\"cert-manager.io\",\"kind\":\"Issuer\",\"name\":\"ca-issuer\"},\"secretName\":\"example-com-tls\"}}\n"
+        },
+        "creationTimestamp": "2022-11-11T16:00:29Z",
+        "generation": 1,
+        "name": "example-com",
+        "namespace": "jetstack-secure",
+        "resourceVersion": "2535",
+        "uid": "f9013344-8318-4fd6-b8d3-b8b95a50b7f5"
+      },
+      "spec": {
+        "dnsNames": [
+          "example.com"
+        ],
+        "issuerRef": {
+          "group": "cert-manager.io",
+          "kind": "Issuer",
+          "name": "ca-issuer"
+        },
+        "secretName": "example-com-tls"
+      },
+      "status": {
+        "conditions": [
+          {
+            "lastTransitionTime": "2022-11-11T16:01:23Z",
+            "message": "Certificate is up to date and has not expired",
+            "observedGeneration": 1,
+            "reason": "Ready",
+            "status": "True",
+            "type": "Ready"
+          }
+        ],
+        "notAfter": "2023-02-09T16:01:23Z",
+        "notBefore": "2022-11-11T16:01:23Z",
+        "renewalTime": "2023-01-10T16:01:23Z",
+        "revision": 1
+      }
+    }
+  ],
+  "kind": "List",
+  "metadata": {
+    "resourceVersion": "",
+    "selfLink": ""
+  }
+}

--- a/internal/kubernetes/backup/fixtures/certificate-request-policy-list.json
+++ b/internal/kubernetes/backup/fixtures/certificate-request-policy-list.json
@@ -1,0 +1,29 @@
+{
+  "apiVersion": "v1",
+  "items": [
+    {
+      "apiVersion": "policy.cert-manager.io/v1alpha1",
+      "kind": "CertificateRequestPolicy",
+      "metadata": {
+        "name": "test-policy"
+      },
+      "spec": {
+        "allowed": {
+          "commonName": {
+            "value": "hello.world",
+            "required": true
+          }
+        },
+        "selector": {
+          "issuerRef": {
+          }
+        }
+      }
+    }
+  ],
+  "kind": "List",
+  "metadata": {
+    "resourceVersion": "",
+    "selfLink": ""
+  }
+}

--- a/internal/kubernetes/backup/fixtures/cluster-issuer-list.json
+++ b/internal/kubernetes/backup/fixtures/cluster-issuer-list.json
@@ -1,0 +1,47 @@
+{
+  "apiVersion": "v1",
+  "items": [
+    {
+      "apiVersion": "cert-manager.io/v1",
+      "kind": "ClusterIssuer",
+      "metadata": {
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"cert-manager.io/v1\",\"kind\":\"ClusterIssuer\",\"metadata\":{\"annotations\":{},\"name\":\"cm-cluster-issuer-sample\"},\"spec\":{\"acme\":{\"email\":\"dummy-email@example.com\",\"privateKeySecretRef\":{\"name\":\"example\"},\"server\":\"https://\"}}}\n"
+        },
+        "creationTimestamp": "2022-11-08T14:22:44Z",
+        "generation": 1,
+        "name": "cm-cluster-issuer-sample",
+        "resourceVersion": "289132",
+        "uid": "e8bc6f6a-4003-45e5-bc41-0a3d6b447427"
+      },
+      "spec": {
+        "acme": {
+          "email": "dummy-email@example.com",
+          "preferredChain": "",
+          "privateKeySecretRef": {
+            "name": "example"
+          },
+          "server": "https://"
+        }
+      },
+      "status": {
+        "acme": {},
+        "conditions": [
+          {
+            "lastTransitionTime": "2022-11-08T14:22:44Z",
+            "message": "Failed to register ACME account: Get \"https:\": http: no Host in request URL",
+            "observedGeneration": 1,
+            "reason": "ErrRegisterACMEAccount",
+            "status": "False",
+            "type": "Ready"
+          }
+        ]
+      }
+    }
+  ],
+  "kind": "List",
+  "metadata": {
+    "resourceVersion": "",
+    "selfLink": ""
+  }
+}

--- a/internal/kubernetes/backup/fixtures/crd-list-unsupported.json
+++ b/internal/kubernetes/backup/fixtures/crd-list-unsupported.json
@@ -1,0 +1,7315 @@
+{
+  "apiVersion": "v1",
+  "items": [
+    {
+      "apiVersion": "apiextensions.k8s.io/v1",
+      "kind": "CustomResourceDefinition",
+      "metadata": {
+        "annotations": {
+          "controller-gen.kubebuilder.io/version": "v0.9.2",
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apiextensions.k8s.io/v1\",\"kind\":\"CustomResourceDefinition\",\"metadata\":{\"annotations\":{\"controller-gen.kubebuilder.io/version\":\"v0.9.2\",\"operator.jetstack.io/component\":\"approver-policy\",\"operator.jetstack.io/component-version\":\"v0.4.0\"},\"creationTimestamp\":\"2022-11-11T15:53:14Z\",\"finalizers\":[\"operator.jetstack.io/crd-controller\"],\"generation\":1,\"name\":\"certificaterequestpolicies.policy.cert-manager.io\",\"ownerReferences\":[{\"apiVersion\":\"operator.jetstack.io/v1alpha1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"Installation\",\"name\":\"installation\",\"uid\":\"36ea7a42-2dfa-48de-b3bc-acb8d9c29f6d\"}],\"resourceVersion\":\"1311\",\"uid\":\"040d09e1-a541-4798-a736-11367c8953be\"},\"spec\":{\"conversion\":{\"strategy\":\"None\"},\"group\":\"policy.cert-manager.io\",\"names\":{\"categories\":[\"cert-manager\"],\"kind\":\"CertificateRequestPolicy\",\"listKind\":\"CertificateRequestPolicyList\",\"plural\":\"certificaterequestpolicies\",\"shortNames\":[\"crp\"],\"singular\":\"certificaterequestpolicy\"},\"scope\":\"Cluster\",\"versions\":[{\"additionalPrinterColumns\":[{\"description\":\"CertificateRequestPolicy is ready for evaluation\",\"jsonPath\":\".status.conditions[?(@.type == \\\"Ready\\\")].status\",\"name\":\"Ready\",\"type\":\"string\"},{\"description\":\"Timestamp CertificateRequestPolicy was created\",\"jsonPath\":\".metadata.creationTimestamp\",\"name\":\"Age\",\"type\":\"date\"}],\"name\":\"v1alpha1\",\"schema\":{\"openAPIV3Schema\":{\"description\":\"CertificateRequestPolicy is an object for describing a \\\"policy profile\\\" that makes decisions on whether applicable CertificateRequests should be approved or denied.\",\"properties\":{\"apiVersion\":{\"description\":\"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources\",\"type\":\"string\"},\"kind\":{\"description\":\"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds\",\"type\":\"string\"},\"metadata\":{\"type\":\"object\"},\"spec\":{\"description\":\"CertificateRequestPolicySpec defines the desired state of CertificateRequestPolicy.\",\"properties\":{\"allowed\":{\"description\":\"Allowed is the set of attributes that are \\\"allowed\\\" by this policy. A CertificateRequest will only be considered permissible for this policy if the CertificateRequest has the same or less as what is allowed.  Empty or `nil` allowed fields mean CertificateRequests are not allowed to have that field present to be permissible.\",\"properties\":{\"commonName\":{\"description\":\"CommonName defines the X.509 Common Name that is permissible.\",\"properties\":{\"required\":{\"description\":\"Required marks this field as being a required value on the request. May only be set to true if Value is also defined.\",\"type\":\"boolean\"},\"value\":{\"description\":\"Value defines the value that is permissible to be present on the request. Accepts wildcards \\\"*\\\". An omitted field or value of `nil` forbids the value from being requested. An empty string is equivalent to `nil`, however an empty string pared with Required as `true` is an impossible condition that always denies. Value may not be `nil` if Required is `true`.\",\"type\":\"string\"}},\"type\":\"object\"},\"dnsNames\":{\"description\":\"DNSNames defines the X.509 DNS SANs that may be requested for. Accepts wildcards \\\"*\\\".\",\"properties\":{\"required\":{\"description\":\"Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.\",\"type\":\"boolean\"},\"values\":{\"description\":\"Defines the values that are permissible to be present on request. Accepts wildcards \\\"*\\\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"type\":\"object\"},\"emailAddresses\":{\"description\":\"EmailAddresses defines the X.509 Email SANs that may be requested for.\",\"properties\":{\"required\":{\"description\":\"Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.\",\"type\":\"boolean\"},\"values\":{\"description\":\"Defines the values that are permissible to be present on request. Accepts wildcards \\\"*\\\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"type\":\"object\"},\"ipAddresses\":{\"description\":\"IPAddresses defines the X.509 IP SANs that may be requested for.\",\"properties\":{\"required\":{\"description\":\"Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.\",\"type\":\"boolean\"},\"values\":{\"description\":\"Defines the values that are permissible to be present on request. Accepts wildcards \\\"*\\\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"type\":\"object\"},\"isCA\":{\"description\":\"IsCA defines whether it is permissible for a CertificateRequest to have the `spec.IsCA` field set to `true`. An omitted field, value of `nil` or `false`, forbids the `spec.IsCA` field from bring `true`. A value of `true` permits CertificateRequests setting the `spec.IsCA` field to `true`.\",\"type\":\"boolean\"},\"subject\":{\"description\":\"Subject defines the X.509 subject that is permissible. An omitted field or value of `nil` forbids any Subject being requested.\",\"properties\":{\"countries\":{\"description\":\"Countries define the X.509 Subject Countries that may be requested for.\",\"properties\":{\"required\":{\"description\":\"Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.\",\"type\":\"boolean\"},\"values\":{\"description\":\"Defines the values that are permissible to be present on request. Accepts wildcards \\\"*\\\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"type\":\"object\"},\"localities\":{\"description\":\"Localities defines the X.509 Subject Localities that may be requested for.\",\"properties\":{\"required\":{\"description\":\"Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.\",\"type\":\"boolean\"},\"values\":{\"description\":\"Defines the values that are permissible to be present on request. Accepts wildcards \\\"*\\\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"type\":\"object\"},\"organizationalUnits\":{\"description\":\"OrganizationalUnits defines the X.509 Subject Organizational Units that may be requested for.\",\"properties\":{\"required\":{\"description\":\"Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.\",\"type\":\"boolean\"},\"values\":{\"description\":\"Defines the values that are permissible to be present on request. Accepts wildcards \\\"*\\\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"type\":\"object\"},\"organizations\":{\"description\":\"Organizations define the X.509 Subject Organizations that may be requested for.\",\"properties\":{\"required\":{\"description\":\"Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.\",\"type\":\"boolean\"},\"values\":{\"description\":\"Defines the values that are permissible to be present on request. Accepts wildcards \\\"*\\\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"type\":\"object\"},\"postalCodes\":{\"description\":\"PostalCodes defines the X.509 Subject Postal Codes that may be requested for.\",\"properties\":{\"required\":{\"description\":\"Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.\",\"type\":\"boolean\"},\"values\":{\"description\":\"Defines the values that are permissible to be present on request. Accepts wildcards \\\"*\\\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"type\":\"object\"},\"provinces\":{\"description\":\"Provinces defines the X.509 Subject Provinces that may be requested for.\",\"properties\":{\"required\":{\"description\":\"Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.\",\"type\":\"boolean\"},\"values\":{\"description\":\"Defines the values that are permissible to be present on request. Accepts wildcards \\\"*\\\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"type\":\"object\"},\"serialNumber\":{\"description\":\"SerialNumber defines the X.509 Subject Serial Number that may be requested for.\",\"properties\":{\"required\":{\"description\":\"Required marks this field as being a required value on the request. May only be set to true if Value is also defined.\",\"type\":\"boolean\"},\"value\":{\"description\":\"Value defines the value that is permissible to be present on the request. Accepts wildcards \\\"*\\\". An omitted field or value of `nil` forbids the value from being requested. An empty string is equivalent to `nil`, however an empty string pared with Required as `true` is an impossible condition that always denies. Value may not be `nil` if Required is `true`.\",\"type\":\"string\"}},\"type\":\"object\"},\"streetAddresses\":{\"description\":\"StreetAddresses defines the X.509 Subject Street Addresses that may be requested for.\",\"properties\":{\"required\":{\"description\":\"Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.\",\"type\":\"boolean\"},\"values\":{\"description\":\"Defines the values that are permissible to be present on request. Accepts wildcards \\\"*\\\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"type\":\"object\"}},\"type\":\"object\"},\"uris\":{\"description\":\"URIs defines the X.509 URI SANs that may be requested for.\",\"properties\":{\"required\":{\"description\":\"Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.\",\"type\":\"boolean\"},\"values\":{\"description\":\"Defines the values that are permissible to be present on request. Accepts wildcards \\\"*\\\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"type\":\"object\"},\"usages\":{\"description\":\"Usages defines the list of permissible key usages that may appear on the CertificateRequest `spec.keyUsages` field. An omitted field or value of `nil` forbids any Usages being requested. An empty slice `[]` is equivalent to `nil`.\",\"items\":{\"description\":\"KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12 Valid KeyUsage values are as follows: \\\"signing\\\", \\\"digital signature\\\", \\\"content commitment\\\", \\\"key encipherment\\\", \\\"key agreement\\\", \\\"data encipherment\\\", \\\"cert sign\\\", \\\"crl sign\\\", \\\"encipher only\\\", \\\"decipher only\\\", \\\"any\\\", \\\"server auth\\\", \\\"client auth\\\", \\\"code signing\\\", \\\"email protection\\\", \\\"s/mime\\\", \\\"ipsec end system\\\", \\\"ipsec tunnel\\\", \\\"ipsec user\\\", \\\"timestamping\\\", \\\"ocsp signing\\\", \\\"microsoft sgc\\\", \\\"netscape sgc\\\"\",\"enum\":[\"signing\",\"digital signature\",\"content commitment\",\"key encipherment\",\"key agreement\",\"data encipherment\",\"cert sign\",\"crl sign\",\"encipher only\",\"decipher only\",\"any\",\"server auth\",\"client auth\",\"code signing\",\"email protection\",\"s/mime\",\"ipsec end system\",\"ipsec tunnel\",\"ipsec user\",\"timestamping\",\"ocsp signing\",\"microsoft sgc\",\"netscape sgc\"],\"type\":\"string\"},\"type\":\"array\"}},\"type\":\"object\"},\"constraints\":{\"description\":\"Constraints is the set of attributes that _must_ be satisfied by the CertificateRequest for the request to be permissible by the policy. Empty or `nil` constraint fields mean CertificateRequests satisfy that field with any value of their corresponding attribute.\",\"properties\":{\"maxDuration\":{\"description\":\"MaxDuration defines the maximum duration a certificate may be requested for. Values are inclusive (i.e. a max value of `1h` will accept a duration of `1h`). MaxDuration and MinDuration may be the same value. An omitted field or value of `nil` permits any maximum duration. If MaxDuration is defined, a duration _must_ be requested on the CertificateRequest.\",\"type\":\"string\"},\"minDuration\":{\"description\":\"MinDuration defines the minimum duration a certificate may be requested for. Values are inclusive (i.e. a min value of `1h` will accept a duration of `1h`). MinDuration and MaxDuration may be the same value. An omitted field or value of `nil` permits any minimum duration. If MinDuration is defined, a duration _must_ be requested on the CertificateRequest.\",\"type\":\"string\"},\"privateKey\":{\"description\":\"PrivateKey defines the shape of permissible private keys that may be used for the request with this policy. An omitted field or value of `nil` permits the use of any private key by the requestor.\",\"properties\":{\"algorithm\":{\"description\":\"Algorithm defines the allowed crypto algorithm that is used by the requestor for their private key in their request. An omitted field or value of `nil` permits any Algorithm.\",\"enum\":[\"RSA\",\"ECDSA\",\"Ed25519\"],\"type\":\"string\"},\"maxSize\":{\"description\":\"MaxSize defines the maximum key size a requestor may use for their private key. Values are inclusive (i.e. a min value of `2048` will accept a size of `2048`). MaxSize and MinSize may be the same value. An omitted field or value of `nil` permits any maximum size.\",\"type\":\"integer\"},\"minSize\":{\"description\":\"MinSize defines the minimum key size a requestor may use for their private key. Values are inclusive (i.e. a min value of `2048` will accept a size of `2048`). MinSize and MaxSize may be the same value. An omitted field or value of `nil` permits any minimum size.\",\"type\":\"integer\"}},\"type\":\"object\"}},\"type\":\"object\"},\"plugins\":{\"additionalProperties\":{\"description\":\"CertificateRequestPolicyPluginData is configuration needed by the plugin approver to evaluate a CertificateRequest on this policy.\",\"properties\":{\"values\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"Values define a set of well-known, to the plugin, key value pairs that are required for the plugin to successfully evaluate a request based on this policy.\",\"type\":\"object\"}},\"type\":\"object\"},\"description\":\"Plugins define a set of plugins and their configuration that should be executed when this policy is evaluated against a CertificateRequest. A plugin must already be built within approver-policy for it to be available.\",\"type\":\"object\"},\"selector\":{\"description\":\"Selector is used for selecting over which CertificateRequests this CertificateRequestPolicy is appropriate for and so will used for its evaluation.\",\"properties\":{\"issuerRef\":{\"description\":\"IssuerRef is used to match this CertificateRequestPolicy against processed CertificateRequests. This policy will only be evaluated against a CertificateRequest whose `spec.issuerRef` field matches `spec.selector.issuerRef`. CertificateRequests will not be processed on unmatched `issuerRef`, regardless of whether the requestor is bound by RBAC. Accepts wildcards \\\"*\\\". Nil values are equivalent to \\\"*\\\", \\n The following value will match _all_ `issuerRefs`: ``` issuerRef: {} ``` \\n Required field.\",\"properties\":{\"group\":{\"description\":\"Group is the wildcard selector to match the `spec.issuerRef.group` field on requests. Accepts wildcards \\\"*\\\". An omitted field or value of `nil` matches all.\",\"type\":\"string\"},\"kind\":{\"description\":\"Kind is the wildcard selector to match the `spec.issuerRef.kind` field on requests. Accepts wildcards \\\"*\\\". An omitted field or value of `nil` matches all.\",\"type\":\"string\"},\"name\":{\"description\":\"Name is the wildcard selector to match the `spec.issuerRef.name` field on requests. Accepts wildcards \\\"*\\\". An omitted field or value of `nil` matches all.\",\"type\":\"string\"}},\"type\":\"object\"}},\"required\":[\"issuerRef\"],\"type\":\"object\"}},\"required\":[\"selector\"],\"type\":\"object\"},\"status\":{\"description\":\"CertificateRequestPolicyStatus defines the observed state of the CertificateRequestPolicy.\",\"properties\":{\"conditions\":{\"description\":\"List of status conditions to indicate the status of the CertificateRequestPolicy. Known condition types are `Ready`.\",\"items\":{\"description\":\"CertificateRequestPolicyCondition contains condition information for a CertificateRequestPolicyStatus.\",\"properties\":{\"lastTransitionTime\":{\"description\":\"LastTransitionTime is the timestamp corresponding to the last status change of this condition.\",\"format\":\"date-time\",\"type\":\"string\"},\"message\":{\"description\":\"Message is a human readable description of the details of the last transition, complementing reason.\",\"type\":\"string\"},\"observedGeneration\":{\"description\":\"If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the CertificateRequestPolicy.\",\"format\":\"int64\",\"type\":\"integer\"},\"reason\":{\"description\":\"Reason is a brief machine readable explanation for the condition's last transition.\",\"type\":\"string\"},\"status\":{\"description\":\"Status of the condition, one of ('True', 'False', 'Unknown').\",\"type\":\"string\"},\"type\":{\"description\":\"Type of the condition, known values are (`Ready`).\",\"type\":\"string\"}},\"required\":[\"status\",\"type\"],\"type\":\"object\"},\"type\":\"array\"}},\"type\":\"object\"}},\"type\":\"object\"}},\"served\":true,\"storage\":true,\"subresources\":{\"status\":{}}}]},\"status\":{\"acceptedNames\":{\"categories\":[\"cert-manager\"],\"kind\":\"CertificateRequestPolicy\",\"listKind\":\"CertificateRequestPolicyList\",\"plural\":\"certificaterequestpolicies\",\"shortNames\":[\"crp\"],\"singular\":\"certificaterequestpolicy\"},\"conditions\":[{\"lastTransitionTime\":\"2022-11-11T15:53:14Z\",\"message\":\"no conflicts found\",\"reason\":\"NoConflicts\",\"status\":\"True\",\"type\":\"NamesAccepted\"},{\"lastTransitionTime\":\"2022-11-11T15:53:14Z\",\"message\":\"the initial names have been accepted\",\"reason\":\"InitialNamesAccepted\",\"status\":\"True\",\"type\":\"Established\"}],\"storedVersions\":[\"v1alpha1\"]}}\n",
+          "operator.jetstack.io/component": "approver-policy",
+          "operator.jetstack.io/component-version": "v0.4.0"
+        },
+        "creationTimestamp": "2022-11-11T15:53:14Z",
+        "deletionTimestamp": "2022-11-17T16:07:18Z",
+        "finalizers": [
+          "operator.jetstack.io/crd-controller"
+        ],
+        "generation": 1,
+        "name": "certificaterequestpolicies.policy.cert-manager.io",
+        "ownerReferences": [
+          {
+            "apiVersion": "operator.jetstack.io/v1alpha1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Installation",
+            "name": "installation",
+            "uid": "36ea7a42-2dfa-48de-b3bc-acb8d9c29f6d"
+          }
+        ],
+        "resourceVersion": "147970",
+        "uid": "040d09e1-a541-4798-a736-11367c8953be"
+      },
+      "spec": {
+        "conversion": {
+          "strategy": "None"
+        },
+        "group": "policy.cert-manager.io",
+        "names": {
+          "categories": [
+            "cert-manager"
+          ],
+          "kind": "CertificateRequestPolicy",
+          "listKind": "CertificateRequestPolicyList",
+          "plural": "certificaterequestpolicies",
+          "shortNames": [
+            "crp"
+          ],
+          "singular": "certificaterequestpolicy"
+        },
+        "scope": "Cluster",
+        "versions": [
+          {
+            "additionalPrinterColumns": [
+              {
+                "description": "CertificateRequestPolicy is ready for evaluation",
+                "jsonPath": ".status.conditions[?(@.type == \"Ready\")].status",
+                "name": "Ready",
+                "type": "string"
+              },
+              {
+                "description": "Timestamp CertificateRequestPolicy was created",
+                "jsonPath": ".metadata.creationTimestamp",
+                "name": "Age",
+                "type": "date"
+              }
+            ],
+            "name": "v1alpha1",
+            "schema": {
+              "openAPIV3Schema": {
+                "description": "CertificateRequestPolicy is an object for describing a \"policy profile\" that makes decisions on whether applicable CertificateRequests should be approved or denied.",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "type": "object"
+                  },
+                  "spec": {
+                    "description": "CertificateRequestPolicySpec defines the desired state of CertificateRequestPolicy.",
+                    "properties": {
+                      "allowed": {
+                        "description": "Allowed is the set of attributes that are \"allowed\" by this policy. A CertificateRequest will only be considered permissible for this policy if the CertificateRequest has the same or less as what is allowed.  Empty or `nil` allowed fields mean CertificateRequests are not allowed to have that field present to be permissible.",
+                        "properties": {
+                          "commonName": {
+                            "description": "CommonName defines the X.509 Common Name that is permissible.",
+                            "properties": {
+                              "required": {
+                                "description": "Required marks this field as being a required value on the request. May only be set to true if Value is also defined.",
+                                "type": "boolean"
+                              },
+                              "value": {
+                                "description": "Value defines the value that is permissible to be present on the request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids the value from being requested. An empty string is equivalent to `nil`, however an empty string pared with Required as `true` is an impossible condition that always denies. Value may not be `nil` if Required is `true`.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "dnsNames": {
+                            "description": "DNSNames defines the X.509 DNS SANs that may be requested for. Accepts wildcards \"*\".",
+                            "properties": {
+                              "required": {
+                                "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                "type": "boolean"
+                              },
+                              "values": {
+                                "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "emailAddresses": {
+                            "description": "EmailAddresses defines the X.509 Email SANs that may be requested for.",
+                            "properties": {
+                              "required": {
+                                "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                "type": "boolean"
+                              },
+                              "values": {
+                                "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "ipAddresses": {
+                            "description": "IPAddresses defines the X.509 IP SANs that may be requested for.",
+                            "properties": {
+                              "required": {
+                                "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                "type": "boolean"
+                              },
+                              "values": {
+                                "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "isCA": {
+                            "description": "IsCA defines whether it is permissible for a CertificateRequest to have the `spec.IsCA` field set to `true`. An omitted field, value of `nil` or `false`, forbids the `spec.IsCA` field from bring `true`. A value of `true` permits CertificateRequests setting the `spec.IsCA` field to `true`.",
+                            "type": "boolean"
+                          },
+                          "subject": {
+                            "description": "Subject defines the X.509 subject that is permissible. An omitted field or value of `nil` forbids any Subject being requested.",
+                            "properties": {
+                              "countries": {
+                                "description": "Countries define the X.509 Subject Countries that may be requested for.",
+                                "properties": {
+                                  "required": {
+                                    "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                    "type": "boolean"
+                                  },
+                                  "values": {
+                                    "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "localities": {
+                                "description": "Localities defines the X.509 Subject Localities that may be requested for.",
+                                "properties": {
+                                  "required": {
+                                    "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                    "type": "boolean"
+                                  },
+                                  "values": {
+                                    "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "organizationalUnits": {
+                                "description": "OrganizationalUnits defines the X.509 Subject Organizational Units that may be requested for.",
+                                "properties": {
+                                  "required": {
+                                    "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                    "type": "boolean"
+                                  },
+                                  "values": {
+                                    "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "organizations": {
+                                "description": "Organizations define the X.509 Subject Organizations that may be requested for.",
+                                "properties": {
+                                  "required": {
+                                    "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                    "type": "boolean"
+                                  },
+                                  "values": {
+                                    "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "postalCodes": {
+                                "description": "PostalCodes defines the X.509 Subject Postal Codes that may be requested for.",
+                                "properties": {
+                                  "required": {
+                                    "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                    "type": "boolean"
+                                  },
+                                  "values": {
+                                    "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "provinces": {
+                                "description": "Provinces defines the X.509 Subject Provinces that may be requested for.",
+                                "properties": {
+                                  "required": {
+                                    "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                    "type": "boolean"
+                                  },
+                                  "values": {
+                                    "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "serialNumber": {
+                                "description": "SerialNumber defines the X.509 Subject Serial Number that may be requested for.",
+                                "properties": {
+                                  "required": {
+                                    "description": "Required marks this field as being a required value on the request. May only be set to true if Value is also defined.",
+                                    "type": "boolean"
+                                  },
+                                  "value": {
+                                    "description": "Value defines the value that is permissible to be present on the request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids the value from being requested. An empty string is equivalent to `nil`, however an empty string pared with Required as `true` is an impossible condition that always denies. Value may not be `nil` if Required is `true`.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "streetAddresses": {
+                                "description": "StreetAddresses defines the X.509 Subject Street Addresses that may be requested for.",
+                                "properties": {
+                                  "required": {
+                                    "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                    "type": "boolean"
+                                  },
+                                  "values": {
+                                    "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "uris": {
+                            "description": "URIs defines the X.509 URI SANs that may be requested for.",
+                            "properties": {
+                              "required": {
+                                "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                "type": "boolean"
+                              },
+                              "values": {
+                                "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "usages": {
+                            "description": "Usages defines the list of permissible key usages that may appear on the CertificateRequest `spec.keyUsages` field. An omitted field or value of `nil` forbids any Usages being requested. An empty slice `[]` is equivalent to `nil`.",
+                            "items": {
+                              "description": "KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12 Valid KeyUsage values are as follows: \"signing\", \"digital signature\", \"content commitment\", \"key encipherment\", \"key agreement\", \"data encipherment\", \"cert sign\", \"crl sign\", \"encipher only\", \"decipher only\", \"any\", \"server auth\", \"client auth\", \"code signing\", \"email protection\", \"s/mime\", \"ipsec end system\", \"ipsec tunnel\", \"ipsec user\", \"timestamping\", \"ocsp signing\", \"microsoft sgc\", \"netscape sgc\"",
+                              "enum": [
+                                "signing",
+                                "digital signature",
+                                "content commitment",
+                                "key encipherment",
+                                "key agreement",
+                                "data encipherment",
+                                "cert sign",
+                                "crl sign",
+                                "encipher only",
+                                "decipher only",
+                                "any",
+                                "server auth",
+                                "client auth",
+                                "code signing",
+                                "email protection",
+                                "s/mime",
+                                "ipsec end system",
+                                "ipsec tunnel",
+                                "ipsec user",
+                                "timestamping",
+                                "ocsp signing",
+                                "microsoft sgc",
+                                "netscape sgc"
+                              ],
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "constraints": {
+                        "description": "Constraints is the set of attributes that _must_ be satisfied by the CertificateRequest for the request to be permissible by the policy. Empty or `nil` constraint fields mean CertificateRequests satisfy that field with any value of their corresponding attribute.",
+                        "properties": {
+                          "maxDuration": {
+                            "description": "MaxDuration defines the maximum duration a certificate may be requested for. Values are inclusive (i.e. a max value of `1h` will accept a duration of `1h`). MaxDuration and MinDuration may be the same value. An omitted field or value of `nil` permits any maximum duration. If MaxDuration is defined, a duration _must_ be requested on the CertificateRequest.",
+                            "type": "string"
+                          },
+                          "minDuration": {
+                            "description": "MinDuration defines the minimum duration a certificate may be requested for. Values are inclusive (i.e. a min value of `1h` will accept a duration of `1h`). MinDuration and MaxDuration may be the same value. An omitted field or value of `nil` permits any minimum duration. If MinDuration is defined, a duration _must_ be requested on the CertificateRequest.",
+                            "type": "string"
+                          },
+                          "privateKey": {
+                            "description": "PrivateKey defines the shape of permissible private keys that may be used for the request with this policy. An omitted field or value of `nil` permits the use of any private key by the requestor.",
+                            "properties": {
+                              "algorithm": {
+                                "description": "Algorithm defines the allowed crypto algorithm that is used by the requestor for their private key in their request. An omitted field or value of `nil` permits any Algorithm.",
+                                "enum": [
+                                  "RSA",
+                                  "ECDSA",
+                                  "Ed25519"
+                                ],
+                                "type": "string"
+                              },
+                              "maxSize": {
+                                "description": "MaxSize defines the maximum key size a requestor may use for their private key. Values are inclusive (i.e. a min value of `2048` will accept a size of `2048`). MaxSize and MinSize may be the same value. An omitted field or value of `nil` permits any maximum size.",
+                                "type": "integer"
+                              },
+                              "minSize": {
+                                "description": "MinSize defines the minimum key size a requestor may use for their private key. Values are inclusive (i.e. a min value of `2048` will accept a size of `2048`). MinSize and MaxSize may be the same value. An omitted field or value of `nil` permits any minimum size.",
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "plugins": {
+                        "additionalProperties": {
+                          "description": "CertificateRequestPolicyPluginData is configuration needed by the plugin approver to evaluate a CertificateRequest on this policy.",
+                          "properties": {
+                            "values": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Values define a set of well-known, to the plugin, key value pairs that are required for the plugin to successfully evaluate a request based on this policy.",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "description": "Plugins define a set of plugins and their configuration that should be executed when this policy is evaluated against a CertificateRequest. A plugin must already be built within approver-policy for it to be available.",
+                        "type": "object"
+                      },
+                      "selector": {
+                        "description": "Selector is used for selecting over which CertificateRequests this CertificateRequestPolicy is appropriate for and so will used for its evaluation.",
+                        "properties": {
+                          "issuerRef": {
+                            "description": "IssuerRef is used to match this CertificateRequestPolicy against processed CertificateRequests. This policy will only be evaluated against a CertificateRequest whose `spec.issuerRef` field matches `spec.selector.issuerRef`. CertificateRequests will not be processed on unmatched `issuerRef`, regardless of whether the requestor is bound by RBAC. Accepts wildcards \"*\". Nil values are equivalent to \"*\", \n The following value will match _all_ `issuerRefs`: ``` issuerRef: {} ``` \n Required field.",
+                            "properties": {
+                              "group": {
+                                "description": "Group is the wildcard selector to match the `spec.issuerRef.group` field on requests. Accepts wildcards \"*\". An omitted field or value of `nil` matches all.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind is the wildcard selector to match the `spec.issuerRef.kind` field on requests. Accepts wildcards \"*\". An omitted field or value of `nil` matches all.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the wildcard selector to match the `spec.issuerRef.name` field on requests. Accepts wildcards \"*\". An omitted field or value of `nil` matches all.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "required": [
+                          "issuerRef"
+                        ],
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "selector"
+                    ],
+                    "type": "object"
+                  },
+                  "status": {
+                    "description": "CertificateRequestPolicyStatus defines the observed state of the CertificateRequestPolicy.",
+                    "properties": {
+                      "conditions": {
+                        "description": "List of status conditions to indicate the status of the CertificateRequestPolicy. Known condition types are `Ready`.",
+                        "items": {
+                          "description": "CertificateRequestPolicyCondition contains condition information for a CertificateRequestPolicyStatus.",
+                          "properties": {
+                            "lastTransitionTime": {
+                              "description": "LastTransitionTime is the timestamp corresponding to the last status change of this condition.",
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "message": {
+                              "description": "Message is a human readable description of the details of the last transition, complementing reason.",
+                              "type": "string"
+                            },
+                            "observedGeneration": {
+                              "description": "If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the CertificateRequestPolicy.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "reason": {
+                              "description": "Reason is a brief machine readable explanation for the condition's last transition.",
+                              "type": "string"
+                            },
+                            "status": {
+                              "description": "Status of the condition, one of ('True', 'False', 'Unknown').",
+                              "type": "string"
+                            },
+                            "type": {
+                              "description": "Type of the condition, known values are (`Ready`).",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "status",
+                            "type"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "served": true,
+            "storage": true,
+            "subresources": {
+              "status": {}
+            }
+          }
+        ]
+      },
+      "status": {
+        "acceptedNames": {
+          "categories": [
+            "cert-manager"
+          ],
+          "kind": "CertificateRequestPolicy",
+          "listKind": "CertificateRequestPolicyList",
+          "plural": "certificaterequestpolicies",
+          "shortNames": [
+            "crp"
+          ],
+          "singular": "certificaterequestpolicy"
+        },
+        "conditions": [
+          {
+            "lastTransitionTime": "2022-11-11T15:53:14Z",
+            "message": "no conflicts found",
+            "reason": "NoConflicts",
+            "status": "True",
+            "type": "NamesAccepted"
+          },
+          {
+            "lastTransitionTime": "2022-11-11T15:53:14Z",
+            "message": "the initial names have been accepted",
+            "reason": "InitialNamesAccepted",
+            "status": "True",
+            "type": "Established"
+          },
+          {
+            "lastTransitionTime": "2022-11-17T16:07:18Z",
+            "message": "removed all instances",
+            "reason": "InstanceDeletionCompleted",
+            "status": "False",
+            "type": "Terminating"
+          }
+        ],
+        "storedVersions": [
+          "v1alpha1"
+        ]
+      }
+    },
+    {
+      "apiVersion": "apiextensions.k8s.io/v1",
+      "kind": "CustomResourceDefinition",
+      "metadata": {
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apiextensions.k8s.io/v1\",\"kind\":\"CustomResourceDefinition\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"cert-manager\",\"app.kubernetes.io/instance\":\"cert-manager\",\"app.kubernetes.io/name\":\"cert-manager\",\"app.kubernetes.io/version\":\"v1.9.2-beta.0\"},\"name\":\"certificaterequests.cert-manager.io\"},\"spec\":{\"group\":\"cert-manager.io\",\"names\":{\"categories\":[\"cert-manager\"],\"kind\":\"CertificateRequest\",\"listKind\":\"CertificateRequestList\",\"plural\":\"certificaterequests\",\"shortNames\":[\"cr\",\"crs\"],\"singular\":\"certificaterequest\"},\"scope\":\"Namespaced\",\"versions\":[{\"additionalPrinterColumns\":[{\"jsonPath\":\".status.conditions[?(@.type==\\\"Approved\\\")].status\",\"name\":\"Approved\",\"type\":\"string\"},{\"jsonPath\":\".status.conditions[?(@.type==\\\"Denied\\\")].status\",\"name\":\"Denied\",\"type\":\"string\"},{\"jsonPath\":\".status.conditions[?(@.type==\\\"Ready\\\")].status\",\"name\":\"Ready\",\"type\":\"string\"},{\"jsonPath\":\".spec.issuerRef.name\",\"name\":\"Issuer\",\"type\":\"string\"},{\"jsonPath\":\".spec.username\",\"name\":\"Requestor\",\"type\":\"string\"},{\"jsonPath\":\".status.conditions[?(@.type==\\\"Ready\\\")].message\",\"name\":\"Status\",\"priority\":1,\"type\":\"string\"},{\"description\":\"CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\",\"jsonPath\":\".metadata.creationTimestamp\",\"name\":\"Age\",\"type\":\"date\"}],\"name\":\"v1\",\"schema\":{\"openAPIV3Schema\":{\"description\":\"A CertificateRequest is used to request a signed certificate from one of the configured issuers. \\n All fields within the CertificateRequest's `spec` are immutable after creation. A CertificateRequest will either succeed or fail, as denoted by its `status.state` field. \\n A CertificateRequest is a one-shot resource, meaning it represents a single point in time request for a certificate and cannot be re-used.\",\"properties\":{\"apiVersion\":{\"description\":\"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources\",\"type\":\"string\"},\"kind\":{\"description\":\"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds\",\"type\":\"string\"},\"metadata\":{\"type\":\"object\"},\"spec\":{\"description\":\"Desired state of the CertificateRequest resource.\",\"properties\":{\"duration\":{\"description\":\"The requested 'duration' (i.e. lifetime) of the Certificate. This option may be ignored/overridden by some issuer types.\",\"type\":\"string\"},\"extra\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"description\":\"Extra contains extra attributes of the user that created the CertificateRequest. Populated by the cert-manager webhook on creation and immutable.\",\"type\":\"object\"},\"groups\":{\"description\":\"Groups contains group membership of the user that created the CertificateRequest. Populated by the cert-manager webhook on creation and immutable.\",\"items\":{\"type\":\"string\"},\"type\":\"array\",\"x-kubernetes-list-type\":\"atomic\"},\"isCA\":{\"description\":\"IsCA will request to mark the certificate as valid for certificate signing when submitting to the issuer. This will automatically add the `cert sign` usage to the list of `usages`.\",\"type\":\"boolean\"},\"issuerRef\":{\"description\":\"IssuerRef is a reference to the issuer for this CertificateRequest.  If the `kind` field is not set, or set to `Issuer`, an Issuer resource with the given name in the same namespace as the CertificateRequest will be used.  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the provided name will be used. The `name` field in this stanza is required at all times. The group field refers to the API group of the issuer which defaults to `cert-manager.io` if empty.\",\"properties\":{\"group\":{\"description\":\"Group of the resource being referred to.\",\"type\":\"string\"},\"kind\":{\"description\":\"Kind of the resource being referred to.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to.\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"request\":{\"description\":\"The PEM-encoded x509 certificate signing request to be submitted to the CA for signing.\",\"format\":\"byte\",\"type\":\"string\"},\"uid\":{\"description\":\"UID contains the uid of the user that created the CertificateRequest. Populated by the cert-manager webhook on creation and immutable.\",\"type\":\"string\"},\"usages\":{\"description\":\"Usages is the set of x509 usages that are requested for the certificate. If usages are set they SHOULD be encoded inside the CSR spec Defaults to `digital signature` and `key encipherment` if not specified.\",\"items\":{\"description\":\"KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12 Valid KeyUsage values are as follows: \\\"signing\\\", \\\"digital signature\\\", \\\"content commitment\\\", \\\"key encipherment\\\", \\\"key agreement\\\", \\\"data encipherment\\\", \\\"cert sign\\\", \\\"crl sign\\\", \\\"encipher only\\\", \\\"decipher only\\\", \\\"any\\\", \\\"server auth\\\", \\\"client auth\\\", \\\"code signing\\\", \\\"email protection\\\", \\\"s/mime\\\", \\\"ipsec end system\\\", \\\"ipsec tunnel\\\", \\\"ipsec user\\\", \\\"timestamping\\\", \\\"ocsp signing\\\", \\\"microsoft sgc\\\", \\\"netscape sgc\\\"\",\"enum\":[\"signing\",\"digital signature\",\"content commitment\",\"key encipherment\",\"key agreement\",\"data encipherment\",\"cert sign\",\"crl sign\",\"encipher only\",\"decipher only\",\"any\",\"server auth\",\"client auth\",\"code signing\",\"email protection\",\"s/mime\",\"ipsec end system\",\"ipsec tunnel\",\"ipsec user\",\"timestamping\",\"ocsp signing\",\"microsoft sgc\",\"netscape sgc\"],\"type\":\"string\"},\"type\":\"array\"},\"username\":{\"description\":\"Username contains the name of the user that created the CertificateRequest. Populated by the cert-manager webhook on creation and immutable.\",\"type\":\"string\"}},\"required\":[\"issuerRef\",\"request\"],\"type\":\"object\"},\"status\":{\"description\":\"Status of the CertificateRequest. This is set and managed automatically.\",\"properties\":{\"ca\":{\"description\":\"The PEM encoded x509 certificate of the signer, also known as the CA (Certificate Authority). This is set on a best-effort basis by different issuers. If not set, the CA is assumed to be unknown/not available.\",\"format\":\"byte\",\"type\":\"string\"},\"certificate\":{\"description\":\"The PEM encoded x509 certificate resulting from the certificate signing request. If not set, the CertificateRequest has either not been completed or has failed. More information on failure can be found by checking the `conditions` field.\",\"format\":\"byte\",\"type\":\"string\"},\"conditions\":{\"description\":\"List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready` and `InvalidRequest`.\",\"items\":{\"description\":\"CertificateRequestCondition contains condition information for a CertificateRequest.\",\"properties\":{\"lastTransitionTime\":{\"description\":\"LastTransitionTime is the timestamp corresponding to the last status change of this condition.\",\"format\":\"date-time\",\"type\":\"string\"},\"message\":{\"description\":\"Message is a human readable description of the details of the last transition, complementing reason.\",\"type\":\"string\"},\"reason\":{\"description\":\"Reason is a brief machine readable explanation for the condition's last transition.\",\"type\":\"string\"},\"status\":{\"description\":\"Status of the condition, one of (`True`, `False`, `Unknown`).\",\"enum\":[\"True\",\"False\",\"Unknown\"],\"type\":\"string\"},\"type\":{\"description\":\"Type of the condition, known values are (`Ready`, `InvalidRequest`, `Approved`, `Denied`).\",\"type\":\"string\"}},\"required\":[\"status\",\"type\"],\"type\":\"object\"},\"type\":\"array\",\"x-kubernetes-list-map-keys\":[\"type\"],\"x-kubernetes-list-type\":\"map\"},\"failureTime\":{\"description\":\"FailureTime stores the time that this CertificateRequest failed. This is used to influence garbage collection and back-off.\",\"format\":\"date-time\",\"type\":\"string\"}},\"type\":\"object\"}},\"required\":[\"spec\"],\"type\":\"object\"}},\"served\":true,\"storage\":true,\"subresources\":{\"status\":{}}}]}}\n"
+        },
+        "creationTimestamp": "2022-11-17T16:09:59Z",
+        "generation": 1,
+        "labels": {
+          "app": "cert-manager",
+          "app.kubernetes.io/instance": "cert-manager",
+          "app.kubernetes.io/name": "cert-manager",
+          "app.kubernetes.io/version": "v1.9.2-beta.0"
+        },
+        "name": "certificaterequests.cert-manager.io",
+        "resourceVersion": "148273",
+        "uid": "cd767263-0224-426a-960a-203e98c2ca5d"
+      },
+      "spec": {
+        "conversion": {
+          "strategy": "None"
+        },
+        "group": "cert-manager.io",
+        "names": {
+          "categories": [
+            "cert-manager"
+          ],
+          "kind": "CertificateRequest",
+          "listKind": "CertificateRequestList",
+          "plural": "certificaterequests",
+          "shortNames": [
+            "cr",
+            "crs"
+          ],
+          "singular": "certificaterequest"
+        },
+        "scope": "Namespaced",
+        "versions": [
+          {
+            "additionalPrinterColumns": [
+              {
+                "jsonPath": ".status.conditions[?(@.type==\"Approved\")].status",
+                "name": "Approved",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".status.conditions[?(@.type==\"Denied\")].status",
+                "name": "Denied",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".status.conditions[?(@.type==\"Ready\")].status",
+                "name": "Ready",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".spec.issuerRef.name",
+                "name": "Issuer",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".spec.username",
+                "name": "Requestor",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".status.conditions[?(@.type==\"Ready\")].message",
+                "name": "Status",
+                "priority": 1,
+                "type": "string"
+              },
+              {
+                "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.",
+                "jsonPath": ".metadata.creationTimestamp",
+                "name": "Age",
+                "type": "date"
+              }
+            ],
+            "name": "v1",
+            "schema": {
+              "openAPIV3Schema": {
+                "description": "A CertificateRequest is used to request a signed certificate from one of the configured issuers. \n All fields within the CertificateRequest's `spec` are immutable after creation. A CertificateRequest will either succeed or fail, as denoted by its `status.state` field. \n A CertificateRequest is a one-shot resource, meaning it represents a single point in time request for a certificate and cannot be re-used.",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "type": "object"
+                  },
+                  "spec": {
+                    "description": "Desired state of the CertificateRequest resource.",
+                    "properties": {
+                      "duration": {
+                        "description": "The requested 'duration' (i.e. lifetime) of the Certificate. This option may be ignored/overridden by some issuer types.",
+                        "type": "string"
+                      },
+                      "extra": {
+                        "additionalProperties": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "description": "Extra contains extra attributes of the user that created the CertificateRequest. Populated by the cert-manager webhook on creation and immutable.",
+                        "type": "object"
+                      },
+                      "groups": {
+                        "description": "Groups contains group membership of the user that created the CertificateRequest. Populated by the cert-manager webhook on creation and immutable.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "isCA": {
+                        "description": "IsCA will request to mark the certificate as valid for certificate signing when submitting to the issuer. This will automatically add the `cert sign` usage to the list of `usages`.",
+                        "type": "boolean"
+                      },
+                      "issuerRef": {
+                        "description": "IssuerRef is a reference to the issuer for this CertificateRequest.  If the `kind` field is not set, or set to `Issuer`, an Issuer resource with the given name in the same namespace as the CertificateRequest will be used.  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the provided name will be used. The `name` field in this stanza is required at all times. The group field refers to the API group of the issuer which defaults to `cert-manager.io` if empty.",
+                        "properties": {
+                          "group": {
+                            "description": "Group of the resource being referred to.",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "Kind of the resource being referred to.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the resource being referred to.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object"
+                      },
+                      "request": {
+                        "description": "The PEM-encoded x509 certificate signing request to be submitted to the CA for signing.",
+                        "format": "byte",
+                        "type": "string"
+                      },
+                      "uid": {
+                        "description": "UID contains the uid of the user that created the CertificateRequest. Populated by the cert-manager webhook on creation and immutable.",
+                        "type": "string"
+                      },
+                      "usages": {
+                        "description": "Usages is the set of x509 usages that are requested for the certificate. If usages are set they SHOULD be encoded inside the CSR spec Defaults to `digital signature` and `key encipherment` if not specified.",
+                        "items": {
+                          "description": "KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12 Valid KeyUsage values are as follows: \"signing\", \"digital signature\", \"content commitment\", \"key encipherment\", \"key agreement\", \"data encipherment\", \"cert sign\", \"crl sign\", \"encipher only\", \"decipher only\", \"any\", \"server auth\", \"client auth\", \"code signing\", \"email protection\", \"s/mime\", \"ipsec end system\", \"ipsec tunnel\", \"ipsec user\", \"timestamping\", \"ocsp signing\", \"microsoft sgc\", \"netscape sgc\"",
+                          "enum": [
+                            "signing",
+                            "digital signature",
+                            "content commitment",
+                            "key encipherment",
+                            "key agreement",
+                            "data encipherment",
+                            "cert sign",
+                            "crl sign",
+                            "encipher only",
+                            "decipher only",
+                            "any",
+                            "server auth",
+                            "client auth",
+                            "code signing",
+                            "email protection",
+                            "s/mime",
+                            "ipsec end system",
+                            "ipsec tunnel",
+                            "ipsec user",
+                            "timestamping",
+                            "ocsp signing",
+                            "microsoft sgc",
+                            "netscape sgc"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "username": {
+                        "description": "Username contains the name of the user that created the CertificateRequest. Populated by the cert-manager webhook on creation and immutable.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "issuerRef",
+                      "request"
+                    ],
+                    "type": "object"
+                  },
+                  "status": {
+                    "description": "Status of the CertificateRequest. This is set and managed automatically.",
+                    "properties": {
+                      "ca": {
+                        "description": "The PEM encoded x509 certificate of the signer, also known as the CA (Certificate Authority). This is set on a best-effort basis by different issuers. If not set, the CA is assumed to be unknown/not available.",
+                        "format": "byte",
+                        "type": "string"
+                      },
+                      "certificate": {
+                        "description": "The PEM encoded x509 certificate resulting from the certificate signing request. If not set, the CertificateRequest has either not been completed or has failed. More information on failure can be found by checking the `conditions` field.",
+                        "format": "byte",
+                        "type": "string"
+                      },
+                      "conditions": {
+                        "description": "List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready` and `InvalidRequest`.",
+                        "items": {
+                          "description": "CertificateRequestCondition contains condition information for a CertificateRequest.",
+                          "properties": {
+                            "lastTransitionTime": {
+                              "description": "LastTransitionTime is the timestamp corresponding to the last status change of this condition.",
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "message": {
+                              "description": "Message is a human readable description of the details of the last transition, complementing reason.",
+                              "type": "string"
+                            },
+                            "reason": {
+                              "description": "Reason is a brief machine readable explanation for the condition's last transition.",
+                              "type": "string"
+                            },
+                            "status": {
+                              "description": "Status of the condition, one of (`True`, `False`, `Unknown`).",
+                              "enum": [
+                                "True",
+                                "False",
+                                "Unknown"
+                              ],
+                              "type": "string"
+                            },
+                            "type": {
+                              "description": "Type of the condition, known values are (`Ready`, `InvalidRequest`, `Approved`, `Denied`).",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "status",
+                            "type"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "type"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "failureTime": {
+                        "description": "FailureTime stores the time that this CertificateRequest failed. This is used to influence garbage collection and back-off.",
+                        "format": "date-time",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "spec"
+                ],
+                "type": "object"
+              }
+            },
+            "served": true,
+            "storage": true,
+            "subresources": {
+              "status": {}
+            }
+          }
+        ]
+      },
+      "status": {
+        "acceptedNames": {
+          "categories": [
+            "cert-manager"
+          ],
+          "kind": "CertificateRequest",
+          "listKind": "CertificateRequestList",
+          "plural": "certificaterequests",
+          "shortNames": [
+            "cr",
+            "crs"
+          ],
+          "singular": "certificaterequest"
+        },
+        "conditions": [
+          {
+            "lastTransitionTime": "2022-11-17T16:09:59Z",
+            "message": "no conflicts found",
+            "reason": "NoConflicts",
+            "status": "True",
+            "type": "NamesAccepted"
+          },
+          {
+            "lastTransitionTime": "2022-11-17T16:09:59Z",
+            "message": "the initial names have been accepted",
+            "reason": "InitialNamesAccepted",
+            "status": "True",
+            "type": "Established"
+          }
+        ],
+        "storedVersions": [
+          "v1"
+        ]
+      }
+    },
+    {
+      "apiVersion": "apiextensions.k8s.io/v1",
+      "kind": "CustomResourceDefinition",
+      "metadata": {
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apiextensions.k8s.io/v1\",\"kind\":\"CustomResourceDefinition\",\"metadata\":{\"annotations\":{},\"creationTimestamp\":\"2022-11-17T16:09:59Z\",\"generation\":1,\"labels\":{\"app\":\"cert-manager\",\"app.kubernetes.io/instance\":\"cert-manager\",\"app.kubernetes.io/name\":\"cert-manager\",\"app.kubernetes.io/version\":\"v1.9.2-beta.0\"},\"name\":\"certificates.cert-manager.io\",\"resourceVersion\":\"148275\",\"uid\":\"1445c80a-9210-487d-8b0a-a70b1ba2328f\"},\"spec\":{\"conversion\":{\"strategy\":\"None\"},\"group\":\"cert-manager.io\",\"names\":{\"categories\":[\"cert-manager\"],\"kind\":\"Certificate\",\"listKind\":\"CertificateList\",\"plural\":\"certificates\",\"shortNames\":[\"cert\",\"certs\"],\"singular\":\"certificate\"},\"scope\":\"Namespaced\",\"versions\":[{\"additionalPrinterColumns\":[{\"jsonPath\":\".status.conditions[?(@.type==\\\"Ready\\\")].status\",\"name\":\"Ready\",\"type\":\"string\"},{\"jsonPath\":\".spec.secretName\",\"name\":\"Secret\",\"type\":\"string\"},{\"jsonPath\":\".spec.issuerRef.name\",\"name\":\"Issuer\",\"priority\":1,\"type\":\"string\"},{\"jsonPath\":\".status.conditions[?(@.type==\\\"Ready\\\")].message\",\"name\":\"Status\",\"priority\":1,\"type\":\"string\"},{\"description\":\"CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\",\"jsonPath\":\".metadata.creationTimestamp\",\"name\":\"Age\",\"type\":\"date\"}],\"name\":\"v2\",\"schema\":{\"openAPIV3Schema\":{\"description\":\"A Certificate resource should be created to ensure an up to date and signed x509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`. \\n The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`).\",\"properties\":{\"apiVersion\":{\"description\":\"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources\",\"type\":\"string\"},\"kind\":{\"description\":\"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds\",\"type\":\"string\"},\"metadata\":{\"type\":\"object\"},\"spec\":{\"description\":\"Desired state of the Certificate resource.\",\"properties\":{\"additionalOutputFormats\":{\"description\":\"AdditionalOutputFormats defines extra output formats of the private key and signed certificate chain to be written to this Certificate's target Secret. This is an Alpha Feature and is only enabled with the `--feature-gates=AdditionalCertificateOutputFormats=true` option on both the controller and webhook components.\",\"items\":{\"description\":\"CertificateAdditionalOutputFormat defines an additional output format of a Certificate resource. These contain supplementary data formats of the signed certificate chain and paired private key.\",\"properties\":{\"type\":{\"description\":\"Type is the name of the format type that should be written to the Certificate's target Secret.\",\"enum\":[\"DER\",\"CombinedPEM\"],\"type\":\"string\"}},\"required\":[\"type\"],\"type\":\"object\"},\"type\":\"array\"},\"commonName\":{\"description\":\"CommonName is a common name to be used on the Certificate. The CommonName should have a length of 64 characters or fewer to avoid generating invalid CSRs. This value is ignored by TLS clients when any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4\",\"type\":\"string\"},\"dnsNames\":{\"description\":\"DNSNames is a list of DNS subjectAltNames to be set on the Certificate.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"duration\":{\"description\":\"The requested 'duration' (i.e. lifetime) of the Certificate. This option may be ignored/overridden by some issuer types. If unset this defaults to 90 days. Certificate will be renewed either 2/3 through its duration or `renewBefore` period before its expiry, whichever is later. Minimum accepted duration is 1 hour. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration\",\"type\":\"string\"},\"emailAddresses\":{\"description\":\"EmailAddresses is a list of email subjectAltNames to be set on the Certificate.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"encodeUsagesInRequest\":{\"description\":\"EncodeUsagesInRequest controls whether key usages should be present in the CertificateRequest\",\"type\":\"boolean\"},\"ipAddresses\":{\"description\":\"IPAddresses is a list of IP address subjectAltNames to be set on the Certificate.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"isCA\":{\"description\":\"IsCA will mark this Certificate as valid for certificate signing. This will automatically add the `cert sign` usage to the list of `usages`.\",\"type\":\"boolean\"},\"issuerRef\":{\"description\":\"IssuerRef is a reference to the issuer for this certificate. If the `kind` field is not set, or set to `Issuer`, an Issuer resource with the given name in the same namespace as the Certificate will be used. If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the provided name will be used. The `name` field in this stanza is required at all times.\",\"properties\":{\"group\":{\"description\":\"Group of the resource being referred to.\",\"type\":\"string\"},\"kind\":{\"description\":\"Kind of the resource being referred to.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to.\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"keystores\":{\"description\":\"Keystores configures additional keystore output formats stored in the `secretName` Secret resource.\",\"properties\":{\"jks\":{\"description\":\"JKS configures options for storing a JKS keystore in the `spec.secretName` Secret resource.\",\"properties\":{\"create\":{\"description\":\"Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.jks` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority\",\"type\":\"boolean\"},\"passwordSecretRef\":{\"description\":\"PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the JKS keystore.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"required\":[\"create\",\"passwordSecretRef\"],\"type\":\"object\"},\"pkcs12\":{\"description\":\"PKCS12 configures options for storing a PKCS12 keystore in the `spec.secretName` Secret resource.\",\"properties\":{\"create\":{\"description\":\"Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.p12` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority\",\"type\":\"boolean\"},\"passwordSecretRef\":{\"description\":\"PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the PKCS12 keystore.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"required\":[\"create\",\"passwordSecretRef\"],\"type\":\"object\"}},\"type\":\"object\"},\"literalSubject\":{\"description\":\"LiteralSubject is an LDAP formatted string that represents the [X.509 Subject field](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6). Use this *instead* of the Subject field if you need to ensure the correct ordering of the RDN sequence, such as when issuing certs for LDAP authentication. See https://github.com/cert-manager/cert-manager/issues/3203, https://github.com/cert-manager/cert-manager/issues/4424. This field is alpha level and is only supported by cert-manager installations where LiteralCertificateSubject feature gate is enabled on both cert-manager controller and webhook.\",\"type\":\"string\"},\"privateKey\":{\"description\":\"Options to control private keys used for the Certificate.\",\"properties\":{\"algorithm\":{\"description\":\"Algorithm is the private key algorithm of the corresponding private key for this certificate. If provided, allowed values are either `RSA`,`Ed25519` or `ECDSA` If `algorithm` is specified and `size` is not provided, key size of 256 will be used for `ECDSA` key algorithm and key size of 2048 will be used for `RSA` key algorithm. key size is ignored when using the `Ed25519` key algorithm.\",\"enum\":[\"RSA\",\"ECDSA\",\"Ed25519\"],\"type\":\"string\"},\"encoding\":{\"description\":\"The private key cryptography standards (PKCS) encoding for this certificate's private key to be encoded in. If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1 and PKCS#8, respectively. Defaults to `PKCS1` if not specified.\",\"enum\":[\"PKCS1\",\"PKCS8\"],\"type\":\"string\"},\"rotationPolicy\":{\"description\":\"RotationPolicy controls how private keys should be regenerated when a re-issuance is being processed. If set to Never, a private key will only be generated if one does not already exist in the target `spec.secretName`. If one does exists but it does not have the correct algorithm or size, a warning will be raised to await user intervention. If set to Always, a private key matching the specified requirements will be generated whenever a re-issuance occurs. Default is 'Never' for backward compatibility.\",\"enum\":[\"Never\",\"Always\"],\"type\":\"string\"},\"size\":{\"description\":\"Size is the key bit size of the corresponding private key for this certificate. If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`, and will default to `2048` if not specified. If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`, and will default to `256` if not specified. If `algorithm` is set to `Ed25519`, Size is ignored. No other values are allowed.\",\"type\":\"integer\"}},\"type\":\"object\"},\"renewBefore\":{\"description\":\"How long before the currently issued certificate's expiry cert-manager should renew the certificate. The default is 2/3 of the issued certificate's duration. Minimum accepted value is 5 minutes. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration\",\"type\":\"string\"},\"revisionHistoryLimit\":{\"description\":\"revisionHistoryLimit is the maximum number of CertificateRequest revisions that are maintained in the Certificate's history. Each revision represents a single `CertificateRequest` created by this Certificate, either when it was created, renewed, or Spec was changed. Revisions will be removed by oldest first if the number of revisions exceeds this number. If set, revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`), revisions will not be garbage collected. Default value is `nil`.\",\"format\":\"int32\",\"type\":\"integer\"},\"secretName\":{\"description\":\"SecretName is the name of the secret resource that will be automatically created and managed by this Certificate resource. It will be populated with a private key and certificate, signed by the denoted issuer.\",\"type\":\"string\"},\"secretTemplate\":{\"description\":\"SecretTemplate defines annotations and labels to be copied to the Certificate's Secret. Labels and annotations on the Secret will be changed as they appear on the SecretTemplate when added or removed. SecretTemplate annotations are added in conjunction with, and cannot overwrite, the base set of annotations cert-manager sets on the Certificate's Secret.\",\"properties\":{\"annotations\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"Annotations is a key value map to be copied to the target Kubernetes Secret.\",\"type\":\"object\"},\"labels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"Labels is a key value map to be copied to the target Kubernetes Secret.\",\"type\":\"object\"}},\"type\":\"object\"},\"subject\":{\"description\":\"Full X509 name specification (https://golang.org/pkg/crypto/x509/pkix/#Name).\",\"properties\":{\"countries\":{\"description\":\"Countries to be used on the Certificate.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"localities\":{\"description\":\"Cities to be used on the Certificate.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"organizationalUnits\":{\"description\":\"Organizational Units to be used on the Certificate.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"organizations\":{\"description\":\"Organizations to be used on the Certificate.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"postalCodes\":{\"description\":\"Postal codes to be used on the Certificate.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"provinces\":{\"description\":\"State/Provinces to be used on the Certificate.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"serialNumber\":{\"description\":\"Serial number to be used on the Certificate.\",\"type\":\"string\"},\"streetAddresses\":{\"description\":\"Street addresses to be used on the Certificate.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"type\":\"object\"},\"uris\":{\"description\":\"URIs is a list of URI subjectAltNames to be set on the Certificate.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"usages\":{\"description\":\"Usages is the set of x509 usages that are requested for the certificate. Defaults to `digital signature` and `key encipherment` if not specified.\",\"items\":{\"description\":\"KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12 Valid KeyUsage values are as follows: \\\"signing\\\", \\\"digital signature\\\", \\\"content commitment\\\", \\\"key encipherment\\\", \\\"key agreement\\\", \\\"data encipherment\\\", \\\"cert sign\\\", \\\"crl sign\\\", \\\"encipher only\\\", \\\"decipher only\\\", \\\"any\\\", \\\"server auth\\\", \\\"client auth\\\", \\\"code signing\\\", \\\"email protection\\\", \\\"s/mime\\\", \\\"ipsec end system\\\", \\\"ipsec tunnel\\\", \\\"ipsec user\\\", \\\"timestamping\\\", \\\"ocsp signing\\\", \\\"microsoft sgc\\\", \\\"netscape sgc\\\"\",\"enum\":[\"signing\",\"digital signature\",\"content commitment\",\"key encipherment\",\"key agreement\",\"data encipherment\",\"cert sign\",\"crl sign\",\"encipher only\",\"decipher only\",\"any\",\"server auth\",\"client auth\",\"code signing\",\"email protection\",\"s/mime\",\"ipsec end system\",\"ipsec tunnel\",\"ipsec user\",\"timestamping\",\"ocsp signing\",\"microsoft sgc\",\"netscape sgc\"],\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"issuerRef\",\"secretName\"],\"type\":\"object\"},\"status\":{\"description\":\"Status of the Certificate. This is set and managed automatically.\",\"properties\":{\"conditions\":{\"description\":\"List of status conditions to indicate the status of certificates. Known condition types are `Ready` and `Issuing`.\",\"items\":{\"description\":\"CertificateCondition contains condition information for an Certificate.\",\"properties\":{\"lastTransitionTime\":{\"description\":\"LastTransitionTime is the timestamp corresponding to the last status change of this condition.\",\"format\":\"date-time\",\"type\":\"string\"},\"message\":{\"description\":\"Message is a human readable description of the details of the last transition, complementing reason.\",\"type\":\"string\"},\"observedGeneration\":{\"description\":\"If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Certificate.\",\"format\":\"int64\",\"type\":\"integer\"},\"reason\":{\"description\":\"Reason is a brief machine readable explanation for the condition's last transition.\",\"type\":\"string\"},\"status\":{\"description\":\"Status of the condition, one of (`True`, `False`, `Unknown`).\",\"enum\":[\"True\",\"False\",\"Unknown\"],\"type\":\"string\"},\"type\":{\"description\":\"Type of the condition, known values are (`Ready`, `Issuing`).\",\"type\":\"string\"}},\"required\":[\"status\",\"type\"],\"type\":\"object\"},\"type\":\"array\",\"x-kubernetes-list-map-keys\":[\"type\"],\"x-kubernetes-list-type\":\"map\"},\"failedIssuanceAttempts\":{\"description\":\"The number of continuous failed issuance attempts up till now. This field gets removed (if set) on a successful issuance and gets set to 1 if unset and an issuance has failed. If an issuance has failed, the delay till the next issuance will be calculated using formula time.Hour * 2 ^ (failedIssuanceAttempts - 1).\",\"type\":\"integer\"},\"lastFailureTime\":{\"description\":\"LastFailureTime is the time as recorded by the Certificate controller of the most recent failure to complete a CertificateRequest for this Certificate resource. If set, cert-manager will not re-request another Certificate until 1 hour has elapsed from this time.\",\"format\":\"date-time\",\"type\":\"string\"},\"nextPrivateKeySecretName\":{\"description\":\"The name of the Secret resource containing the private key to be used for the next certificate iteration. The keymanager controller will automatically set this field if the `Issuing` condition is set to `True`. It will automatically unset this field when the Issuing condition is not set or False.\",\"type\":\"string\"},\"notAfter\":{\"description\":\"The expiration time of the certificate stored in the secret named by this resource in `spec.secretName`.\",\"format\":\"date-time\",\"type\":\"string\"},\"notBefore\":{\"description\":\"The time after which the certificate stored in the secret named by this resource in spec.secretName is valid.\",\"format\":\"date-time\",\"type\":\"string\"},\"renewalTime\":{\"description\":\"RenewalTime is the time at which the certificate will be next renewed. If not set, no upcoming renewal is scheduled.\",\"format\":\"date-time\",\"type\":\"string\"},\"revision\":{\"description\":\"The current 'revision' of the certificate as issued. \\n When a CertificateRequest resource is created, it will have the `cert-manager.io/certificate-revision` set to one greater than the current value of this field. \\n Upon issuance, this field will be set to the value of the annotation on the CertificateRequest resource used to issue the certificate. \\n Persisting the value on the CertificateRequest resource allows the certificates controller to know whether a request is part of an old issuance or if it is part of the ongoing revision's issuance by checking if the revision value in the annotation is greater than this field.\",\"type\":\"integer\"}},\"type\":\"object\"}},\"required\":[\"spec\"],\"type\":\"object\"}},\"served\":true,\"storage\":true,\"subresources\":{\"status\":{}}},{\"additionalPrinterColumns\":[{\"jsonPath\":\".status.conditions[?(@.type==\\\"Ready\\\")].status\",\"name\":\"Ready\",\"type\":\"string\"},{\"jsonPath\":\".spec.secretName\",\"name\":\"Secret\",\"type\":\"string\"},{\"jsonPath\":\".spec.issuerRef.name\",\"name\":\"Issuer\",\"priority\":1,\"type\":\"string\"},{\"jsonPath\":\".status.conditions[?(@.type==\\\"Ready\\\")].message\",\"name\":\"Status\",\"priority\":1,\"type\":\"string\"},{\"description\":\"CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\",\"jsonPath\":\".metadata.creationTimestamp\",\"name\":\"Age\",\"type\":\"date\"}],\"name\":\"v1\",\"schema\":{\"openAPIV3Schema\":{\"description\":\"A Certificate resource should be created to ensure an up to date and signed x509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`. \\n The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`).\",\"properties\":{\"apiVersion\":{\"description\":\"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources\",\"type\":\"string\"},\"kind\":{\"description\":\"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds\",\"type\":\"string\"},\"metadata\":{\"type\":\"object\"},\"spec\":{\"description\":\"Desired state of the Certificate resource.\",\"properties\":{\"additionalOutputFormats\":{\"description\":\"AdditionalOutputFormats defines extra output formats of the private key and signed certificate chain to be written to this Certificate's target Secret. This is an Alpha Feature and is only enabled with the `--feature-gates=AdditionalCertificateOutputFormats=true` option on both the controller and webhook components.\",\"items\":{\"description\":\"CertificateAdditionalOutputFormat defines an additional output format of a Certificate resource. These contain supplementary data formats of the signed certificate chain and paired private key.\",\"properties\":{\"type\":{\"description\":\"Type is the name of the format type that should be written to the Certificate's target Secret.\",\"enum\":[\"DER\",\"CombinedPEM\"],\"type\":\"string\"}},\"required\":[\"type\"],\"type\":\"object\"},\"type\":\"array\"},\"commonName\":{\"description\":\"CommonName is a common name to be used on the Certificate. The CommonName should have a length of 64 characters or fewer to avoid generating invalid CSRs. This value is ignored by TLS clients when any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4\",\"type\":\"string\"},\"dnsNames\":{\"description\":\"DNSNames is a list of DNS subjectAltNames to be set on the Certificate.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"duration\":{\"description\":\"The requested 'duration' (i.e. lifetime) of the Certificate. This option may be ignored/overridden by some issuer types. If unset this defaults to 90 days. Certificate will be renewed either 2/3 through its duration or `renewBefore` period before its expiry, whichever is later. Minimum accepted duration is 1 hour. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration\",\"type\":\"string\"},\"emailAddresses\":{\"description\":\"EmailAddresses is a list of email subjectAltNames to be set on the Certificate.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"encodeUsagesInRequest\":{\"description\":\"EncodeUsagesInRequest controls whether key usages should be present in the CertificateRequest\",\"type\":\"boolean\"},\"ipAddresses\":{\"description\":\"IPAddresses is a list of IP address subjectAltNames to be set on the Certificate.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"isCA\":{\"description\":\"IsCA will mark this Certificate as valid for certificate signing. This will automatically add the `cert sign` usage to the list of `usages`.\",\"type\":\"boolean\"},\"issuerRef\":{\"description\":\"IssuerRef is a reference to the issuer for this certificate. If the `kind` field is not set, or set to `Issuer`, an Issuer resource with the given name in the same namespace as the Certificate will be used. If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the provided name will be used. The `name` field in this stanza is required at all times.\",\"properties\":{\"group\":{\"description\":\"Group of the resource being referred to.\",\"type\":\"string\"},\"kind\":{\"description\":\"Kind of the resource being referred to.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to.\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"keystores\":{\"description\":\"Keystores configures additional keystore output formats stored in the `secretName` Secret resource.\",\"properties\":{\"jks\":{\"description\":\"JKS configures options for storing a JKS keystore in the `spec.secretName` Secret resource.\",\"properties\":{\"create\":{\"description\":\"Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.jks` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority\",\"type\":\"boolean\"},\"passwordSecretRef\":{\"description\":\"PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the JKS keystore.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"required\":[\"create\",\"passwordSecretRef\"],\"type\":\"object\"},\"pkcs12\":{\"description\":\"PKCS12 configures options for storing a PKCS12 keystore in the `spec.secretName` Secret resource.\",\"properties\":{\"create\":{\"description\":\"Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.p12` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority\",\"type\":\"boolean\"},\"passwordSecretRef\":{\"description\":\"PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the PKCS12 keystore.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"required\":[\"create\",\"passwordSecretRef\"],\"type\":\"object\"}},\"type\":\"object\"},\"literalSubject\":{\"description\":\"LiteralSubject is an LDAP formatted string that represents the [X.509 Subject field](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6). Use this *instead* of the Subject field if you need to ensure the correct ordering of the RDN sequence, such as when issuing certs for LDAP authentication. See https://github.com/cert-manager/cert-manager/issues/3203, https://github.com/cert-manager/cert-manager/issues/4424. This field is alpha level and is only supported by cert-manager installations where LiteralCertificateSubject feature gate is enabled on both cert-manager controller and webhook.\",\"type\":\"string\"},\"privateKey\":{\"description\":\"Options to control private keys used for the Certificate.\",\"properties\":{\"algorithm\":{\"description\":\"Algorithm is the private key algorithm of the corresponding private key for this certificate. If provided, allowed values are either `RSA`,`Ed25519` or `ECDSA` If `algorithm` is specified and `size` is not provided, key size of 256 will be used for `ECDSA` key algorithm and key size of 2048 will be used for `RSA` key algorithm. key size is ignored when using the `Ed25519` key algorithm.\",\"enum\":[\"RSA\",\"ECDSA\",\"Ed25519\"],\"type\":\"string\"},\"encoding\":{\"description\":\"The private key cryptography standards (PKCS) encoding for this certificate's private key to be encoded in. If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1 and PKCS#8, respectively. Defaults to `PKCS1` if not specified.\",\"enum\":[\"PKCS1\",\"PKCS8\"],\"type\":\"string\"},\"rotationPolicy\":{\"description\":\"RotationPolicy controls how private keys should be regenerated when a re-issuance is being processed. If set to Never, a private key will only be generated if one does not already exist in the target `spec.secretName`. If one does exists but it does not have the correct algorithm or size, a warning will be raised to await user intervention. If set to Always, a private key matching the specified requirements will be generated whenever a re-issuance occurs. Default is 'Never' for backward compatibility.\",\"enum\":[\"Never\",\"Always\"],\"type\":\"string\"},\"size\":{\"description\":\"Size is the key bit size of the corresponding private key for this certificate. If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`, and will default to `2048` if not specified. If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`, and will default to `256` if not specified. If `algorithm` is set to `Ed25519`, Size is ignored. No other values are allowed.\",\"type\":\"integer\"}},\"type\":\"object\"},\"renewBefore\":{\"description\":\"How long before the currently issued certificate's expiry cert-manager should renew the certificate. The default is 2/3 of the issued certificate's duration. Minimum accepted value is 5 minutes. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration\",\"type\":\"string\"},\"revisionHistoryLimit\":{\"description\":\"revisionHistoryLimit is the maximum number of CertificateRequest revisions that are maintained in the Certificate's history. Each revision represents a single `CertificateRequest` created by this Certificate, either when it was created, renewed, or Spec was changed. Revisions will be removed by oldest first if the number of revisions exceeds this number. If set, revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`), revisions will not be garbage collected. Default value is `nil`.\",\"format\":\"int32\",\"type\":\"integer\"},\"secretName\":{\"description\":\"SecretName is the name of the secret resource that will be automatically created and managed by this Certificate resource. It will be populated with a private key and certificate, signed by the denoted issuer.\",\"type\":\"string\"},\"secretTemplate\":{\"description\":\"SecretTemplate defines annotations and labels to be copied to the Certificate's Secret. Labels and annotations on the Secret will be changed as they appear on the SecretTemplate when added or removed. SecretTemplate annotations are added in conjunction with, and cannot overwrite, the base set of annotations cert-manager sets on the Certificate's Secret.\",\"properties\":{\"annotations\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"Annotations is a key value map to be copied to the target Kubernetes Secret.\",\"type\":\"object\"},\"labels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"Labels is a key value map to be copied to the target Kubernetes Secret.\",\"type\":\"object\"}},\"type\":\"object\"},\"subject\":{\"description\":\"Full X509 name specification (https://golang.org/pkg/crypto/x509/pkix/#Name).\",\"properties\":{\"countries\":{\"description\":\"Countries to be used on the Certificate.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"localities\":{\"description\":\"Cities to be used on the Certificate.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"organizationalUnits\":{\"description\":\"Organizational Units to be used on the Certificate.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"organizations\":{\"description\":\"Organizations to be used on the Certificate.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"postalCodes\":{\"description\":\"Postal codes to be used on the Certificate.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"provinces\":{\"description\":\"State/Provinces to be used on the Certificate.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"serialNumber\":{\"description\":\"Serial number to be used on the Certificate.\",\"type\":\"string\"},\"streetAddresses\":{\"description\":\"Street addresses to be used on the Certificate.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"type\":\"object\"},\"uris\":{\"description\":\"URIs is a list of URI subjectAltNames to be set on the Certificate.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"usages\":{\"description\":\"Usages is the set of x509 usages that are requested for the certificate. Defaults to `digital signature` and `key encipherment` if not specified.\",\"items\":{\"description\":\"KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12 Valid KeyUsage values are as follows: \\\"signing\\\", \\\"digital signature\\\", \\\"content commitment\\\", \\\"key encipherment\\\", \\\"key agreement\\\", \\\"data encipherment\\\", \\\"cert sign\\\", \\\"crl sign\\\", \\\"encipher only\\\", \\\"decipher only\\\", \\\"any\\\", \\\"server auth\\\", \\\"client auth\\\", \\\"code signing\\\", \\\"email protection\\\", \\\"s/mime\\\", \\\"ipsec end system\\\", \\\"ipsec tunnel\\\", \\\"ipsec user\\\", \\\"timestamping\\\", \\\"ocsp signing\\\", \\\"microsoft sgc\\\", \\\"netscape sgc\\\"\",\"enum\":[\"signing\",\"digital signature\",\"content commitment\",\"key encipherment\",\"key agreement\",\"data encipherment\",\"cert sign\",\"crl sign\",\"encipher only\",\"decipher only\",\"any\",\"server auth\",\"client auth\",\"code signing\",\"email protection\",\"s/mime\",\"ipsec end system\",\"ipsec tunnel\",\"ipsec user\",\"timestamping\",\"ocsp signing\",\"microsoft sgc\",\"netscape sgc\"],\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"issuerRef\",\"secretName\"],\"type\":\"object\"},\"status\":{\"description\":\"Status of the Certificate. This is set and managed automatically.\",\"properties\":{\"conditions\":{\"description\":\"List of status conditions to indicate the status of certificates. Known condition types are `Ready` and `Issuing`.\",\"items\":{\"description\":\"CertificateCondition contains condition information for an Certificate.\",\"properties\":{\"lastTransitionTime\":{\"description\":\"LastTransitionTime is the timestamp corresponding to the last status change of this condition.\",\"format\":\"date-time\",\"type\":\"string\"},\"message\":{\"description\":\"Message is a human readable description of the details of the last transition, complementing reason.\",\"type\":\"string\"},\"observedGeneration\":{\"description\":\"If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Certificate.\",\"format\":\"int64\",\"type\":\"integer\"},\"reason\":{\"description\":\"Reason is a brief machine readable explanation for the condition's last transition.\",\"type\":\"string\"},\"status\":{\"description\":\"Status of the condition, one of (`True`, `False`, `Unknown`).\",\"enum\":[\"True\",\"False\",\"Unknown\"],\"type\":\"string\"},\"type\":{\"description\":\"Type of the condition, known values are (`Ready`, `Issuing`).\",\"type\":\"string\"}},\"required\":[\"status\",\"type\"],\"type\":\"object\"},\"type\":\"array\",\"x-kubernetes-list-map-keys\":[\"type\"],\"x-kubernetes-list-type\":\"map\"},\"failedIssuanceAttempts\":{\"description\":\"The number of continuous failed issuance attempts up till now. This field gets removed (if set) on a successful issuance and gets set to 1 if unset and an issuance has failed. If an issuance has failed, the delay till the next issuance will be calculated using formula time.Hour * 2 ^ (failedIssuanceAttempts - 1).\",\"type\":\"integer\"},\"lastFailureTime\":{\"description\":\"LastFailureTime is the time as recorded by the Certificate controller of the most recent failure to complete a CertificateRequest for this Certificate resource. If set, cert-manager will not re-request another Certificate until 1 hour has elapsed from this time.\",\"format\":\"date-time\",\"type\":\"string\"},\"nextPrivateKeySecretName\":{\"description\":\"The name of the Secret resource containing the private key to be used for the next certificate iteration. The keymanager controller will automatically set this field if the `Issuing` condition is set to `True`. It will automatically unset this field when the Issuing condition is not set or False.\",\"type\":\"string\"},\"notAfter\":{\"description\":\"The expiration time of the certificate stored in the secret named by this resource in `spec.secretName`.\",\"format\":\"date-time\",\"type\":\"string\"},\"notBefore\":{\"description\":\"The time after which the certificate stored in the secret named by this resource in spec.secretName is valid.\",\"format\":\"date-time\",\"type\":\"string\"},\"renewalTime\":{\"description\":\"RenewalTime is the time at which the certificate will be next renewed. If not set, no upcoming renewal is scheduled.\",\"format\":\"date-time\",\"type\":\"string\"},\"revision\":{\"description\":\"The current 'revision' of the certificate as issued. \\n When a CertificateRequest resource is created, it will have the `cert-manager.io/certificate-revision` set to one greater than the current value of this field. \\n Upon issuance, this field will be set to the value of the annotation on the CertificateRequest resource used to issue the certificate. \\n Persisting the value on the CertificateRequest resource allows the certificates controller to know whether a request is part of an old issuance or if it is part of the ongoing revision's issuance by checking if the revision value in the annotation is greater than this field.\",\"type\":\"integer\"}},\"type\":\"object\"}},\"required\":[\"spec\"],\"type\":\"object\"}},\"served\":false,\"storage\":false,\"subresources\":{\"status\":{}}}]},\"status\":{\"acceptedNames\":{\"categories\":[\"cert-manager\"],\"kind\":\"Certificate\",\"listKind\":\"CertificateList\",\"plural\":\"certificates\",\"shortNames\":[\"cert\",\"certs\"],\"singular\":\"certificate\"},\"conditions\":[{\"lastTransitionTime\":\"2022-11-17T16:09:59Z\",\"message\":\"no conflicts found\",\"reason\":\"NoConflicts\",\"status\":\"True\",\"type\":\"NamesAccepted\"},{\"lastTransitionTime\":\"2022-11-17T16:09:59Z\",\"message\":\"the initial names have been accepted\",\"reason\":\"InitialNamesAccepted\",\"status\":\"True\",\"type\":\"Established\"}],\"storedVersions\":[\"v1\"]}}\n"
+        },
+        "creationTimestamp": "2022-11-17T16:09:59Z",
+        "generation": 2,
+        "labels": {
+          "app": "cert-manager",
+          "app.kubernetes.io/instance": "cert-manager",
+          "app.kubernetes.io/name": "cert-manager",
+          "app.kubernetes.io/version": "v1.9.2-beta.0"
+        },
+        "name": "certificates.cert-manager.io",
+        "resourceVersion": "150128",
+        "uid": "1445c80a-9210-487d-8b0a-a70b1ba2328f"
+      },
+      "spec": {
+        "conversion": {
+          "strategy": "None"
+        },
+        "group": "cert-manager.io",
+        "names": {
+          "categories": [
+            "cert-manager"
+          ],
+          "kind": "Certificate",
+          "listKind": "CertificateList",
+          "plural": "certificates",
+          "shortNames": [
+            "cert",
+            "certs"
+          ],
+          "singular": "certificate"
+        },
+        "scope": "Namespaced",
+        "versions": [
+          {
+            "additionalPrinterColumns": [
+              {
+                "jsonPath": ".status.conditions[?(@.type==\"Ready\")].status",
+                "name": "Ready",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".spec.secretName",
+                "name": "Secret",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".spec.issuerRef.name",
+                "name": "Issuer",
+                "priority": 1,
+                "type": "string"
+              },
+              {
+                "jsonPath": ".status.conditions[?(@.type==\"Ready\")].message",
+                "name": "Status",
+                "priority": 1,
+                "type": "string"
+              },
+              {
+                "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.",
+                "jsonPath": ".metadata.creationTimestamp",
+                "name": "Age",
+                "type": "date"
+              }
+            ],
+            "name": "v2",
+            "schema": {
+              "openAPIV3Schema": {
+                "description": "A Certificate resource should be created to ensure an up to date and signed x509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`. \n The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`).",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "type": "object"
+                  },
+                  "spec": {
+                    "description": "Desired state of the Certificate resource.",
+                    "properties": {
+                      "additionalOutputFormats": {
+                        "description": "AdditionalOutputFormats defines extra output formats of the private key and signed certificate chain to be written to this Certificate's target Secret. This is an Alpha Feature and is only enabled with the `--feature-gates=AdditionalCertificateOutputFormats=true` option on both the controller and webhook components.",
+                        "items": {
+                          "description": "CertificateAdditionalOutputFormat defines an additional output format of a Certificate resource. These contain supplementary data formats of the signed certificate chain and paired private key.",
+                          "properties": {
+                            "type": {
+                              "description": "Type is the name of the format type that should be written to the Certificate's target Secret.",
+                              "enum": [
+                                "DER",
+                                "CombinedPEM"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "commonName": {
+                        "description": "CommonName is a common name to be used on the Certificate. The CommonName should have a length of 64 characters or fewer to avoid generating invalid CSRs. This value is ignored by TLS clients when any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4",
+                        "type": "string"
+                      },
+                      "dnsNames": {
+                        "description": "DNSNames is a list of DNS subjectAltNames to be set on the Certificate.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "duration": {
+                        "description": "The requested 'duration' (i.e. lifetime) of the Certificate. This option may be ignored/overridden by some issuer types. If unset this defaults to 90 days. Certificate will be renewed either 2/3 through its duration or `renewBefore` period before its expiry, whichever is later. Minimum accepted duration is 1 hour. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration",
+                        "type": "string"
+                      },
+                      "emailAddresses": {
+                        "description": "EmailAddresses is a list of email subjectAltNames to be set on the Certificate.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "encodeUsagesInRequest": {
+                        "description": "EncodeUsagesInRequest controls whether key usages should be present in the CertificateRequest",
+                        "type": "boolean"
+                      },
+                      "ipAddresses": {
+                        "description": "IPAddresses is a list of IP address subjectAltNames to be set on the Certificate.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "isCA": {
+                        "description": "IsCA will mark this Certificate as valid for certificate signing. This will automatically add the `cert sign` usage to the list of `usages`.",
+                        "type": "boolean"
+                      },
+                      "issuerRef": {
+                        "description": "IssuerRef is a reference to the issuer for this certificate. If the `kind` field is not set, or set to `Issuer`, an Issuer resource with the given name in the same namespace as the Certificate will be used. If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the provided name will be used. The `name` field in this stanza is required at all times.",
+                        "properties": {
+                          "group": {
+                            "description": "Group of the resource being referred to.",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "Kind of the resource being referred to.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the resource being referred to.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object"
+                      },
+                      "keystores": {
+                        "description": "Keystores configures additional keystore output formats stored in the `secretName` Secret resource.",
+                        "properties": {
+                          "jks": {
+                            "description": "JKS configures options for storing a JKS keystore in the `spec.secretName` Secret resource.",
+                            "properties": {
+                              "create": {
+                                "description": "Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.jks` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority",
+                                "type": "boolean"
+                              },
+                              "passwordSecretRef": {
+                                "description": "PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the JKS keystore.",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "required": [
+                              "create",
+                              "passwordSecretRef"
+                            ],
+                            "type": "object"
+                          },
+                          "pkcs12": {
+                            "description": "PKCS12 configures options for storing a PKCS12 keystore in the `spec.secretName` Secret resource.",
+                            "properties": {
+                              "create": {
+                                "description": "Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.p12` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority",
+                                "type": "boolean"
+                              },
+                              "passwordSecretRef": {
+                                "description": "PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the PKCS12 keystore.",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "required": [
+                              "create",
+                              "passwordSecretRef"
+                            ],
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "literalSubject": {
+                        "description": "LiteralSubject is an LDAP formatted string that represents the [X.509 Subject field](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6). Use this *instead* of the Subject field if you need to ensure the correct ordering of the RDN sequence, such as when issuing certs for LDAP authentication. See https://github.com/cert-manager/cert-manager/issues/3203, https://github.com/cert-manager/cert-manager/issues/4424. This field is alpha level and is only supported by cert-manager installations where LiteralCertificateSubject feature gate is enabled on both cert-manager controller and webhook.",
+                        "type": "string"
+                      },
+                      "privateKey": {
+                        "description": "Options to control private keys used for the Certificate.",
+                        "properties": {
+                          "algorithm": {
+                            "description": "Algorithm is the private key algorithm of the corresponding private key for this certificate. If provided, allowed values are either `RSA`,`Ed25519` or `ECDSA` If `algorithm` is specified and `size` is not provided, key size of 256 will be used for `ECDSA` key algorithm and key size of 2048 will be used for `RSA` key algorithm. key size is ignored when using the `Ed25519` key algorithm.",
+                            "enum": [
+                              "RSA",
+                              "ECDSA",
+                              "Ed25519"
+                            ],
+                            "type": "string"
+                          },
+                          "encoding": {
+                            "description": "The private key cryptography standards (PKCS) encoding for this certificate's private key to be encoded in. If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1 and PKCS#8, respectively. Defaults to `PKCS1` if not specified.",
+                            "enum": [
+                              "PKCS1",
+                              "PKCS8"
+                            ],
+                            "type": "string"
+                          },
+                          "rotationPolicy": {
+                            "description": "RotationPolicy controls how private keys should be regenerated when a re-issuance is being processed. If set to Never, a private key will only be generated if one does not already exist in the target `spec.secretName`. If one does exists but it does not have the correct algorithm or size, a warning will be raised to await user intervention. If set to Always, a private key matching the specified requirements will be generated whenever a re-issuance occurs. Default is 'Never' for backward compatibility.",
+                            "enum": [
+                              "Never",
+                              "Always"
+                            ],
+                            "type": "string"
+                          },
+                          "size": {
+                            "description": "Size is the key bit size of the corresponding private key for this certificate. If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`, and will default to `2048` if not specified. If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`, and will default to `256` if not specified. If `algorithm` is set to `Ed25519`, Size is ignored. No other values are allowed.",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "renewBefore": {
+                        "description": "How long before the currently issued certificate's expiry cert-manager should renew the certificate. The default is 2/3 of the issued certificate's duration. Minimum accepted value is 5 minutes. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration",
+                        "type": "string"
+                      },
+                      "revisionHistoryLimit": {
+                        "description": "revisionHistoryLimit is the maximum number of CertificateRequest revisions that are maintained in the Certificate's history. Each revision represents a single `CertificateRequest` created by this Certificate, either when it was created, renewed, or Spec was changed. Revisions will be removed by oldest first if the number of revisions exceeds this number. If set, revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`), revisions will not be garbage collected. Default value is `nil`.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "secretName": {
+                        "description": "SecretName is the name of the secret resource that will be automatically created and managed by this Certificate resource. It will be populated with a private key and certificate, signed by the denoted issuer.",
+                        "type": "string"
+                      },
+                      "secretTemplate": {
+                        "description": "SecretTemplate defines annotations and labels to be copied to the Certificate's Secret. Labels and annotations on the Secret will be changed as they appear on the SecretTemplate when added or removed. SecretTemplate annotations are added in conjunction with, and cannot overwrite, the base set of annotations cert-manager sets on the Certificate's Secret.",
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Annotations is a key value map to be copied to the target Kubernetes Secret.",
+                            "type": "object"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Labels is a key value map to be copied to the target Kubernetes Secret.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "subject": {
+                        "description": "Full X509 name specification (https://golang.org/pkg/crypto/x509/pkix/#Name).",
+                        "properties": {
+                          "countries": {
+                            "description": "Countries to be used on the Certificate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "localities": {
+                            "description": "Cities to be used on the Certificate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "organizationalUnits": {
+                            "description": "Organizational Units to be used on the Certificate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "organizations": {
+                            "description": "Organizations to be used on the Certificate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "postalCodes": {
+                            "description": "Postal codes to be used on the Certificate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "provinces": {
+                            "description": "State/Provinces to be used on the Certificate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "serialNumber": {
+                            "description": "Serial number to be used on the Certificate.",
+                            "type": "string"
+                          },
+                          "streetAddresses": {
+                            "description": "Street addresses to be used on the Certificate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "uris": {
+                        "description": "URIs is a list of URI subjectAltNames to be set on the Certificate.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "usages": {
+                        "description": "Usages is the set of x509 usages that are requested for the certificate. Defaults to `digital signature` and `key encipherment` if not specified.",
+                        "items": {
+                          "description": "KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12 Valid KeyUsage values are as follows: \"signing\", \"digital signature\", \"content commitment\", \"key encipherment\", \"key agreement\", \"data encipherment\", \"cert sign\", \"crl sign\", \"encipher only\", \"decipher only\", \"any\", \"server auth\", \"client auth\", \"code signing\", \"email protection\", \"s/mime\", \"ipsec end system\", \"ipsec tunnel\", \"ipsec user\", \"timestamping\", \"ocsp signing\", \"microsoft sgc\", \"netscape sgc\"",
+                          "enum": [
+                            "signing",
+                            "digital signature",
+                            "content commitment",
+                            "key encipherment",
+                            "key agreement",
+                            "data encipherment",
+                            "cert sign",
+                            "crl sign",
+                            "encipher only",
+                            "decipher only",
+                            "any",
+                            "server auth",
+                            "client auth",
+                            "code signing",
+                            "email protection",
+                            "s/mime",
+                            "ipsec end system",
+                            "ipsec tunnel",
+                            "ipsec user",
+                            "timestamping",
+                            "ocsp signing",
+                            "microsoft sgc",
+                            "netscape sgc"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "issuerRef",
+                      "secretName"
+                    ],
+                    "type": "object"
+                  },
+                  "status": {
+                    "description": "Status of the Certificate. This is set and managed automatically.",
+                    "properties": {
+                      "conditions": {
+                        "description": "List of status conditions to indicate the status of certificates. Known condition types are `Ready` and `Issuing`.",
+                        "items": {
+                          "description": "CertificateCondition contains condition information for an Certificate.",
+                          "properties": {
+                            "lastTransitionTime": {
+                              "description": "LastTransitionTime is the timestamp corresponding to the last status change of this condition.",
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "message": {
+                              "description": "Message is a human readable description of the details of the last transition, complementing reason.",
+                              "type": "string"
+                            },
+                            "observedGeneration": {
+                              "description": "If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Certificate.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "reason": {
+                              "description": "Reason is a brief machine readable explanation for the condition's last transition.",
+                              "type": "string"
+                            },
+                            "status": {
+                              "description": "Status of the condition, one of (`True`, `False`, `Unknown`).",
+                              "enum": [
+                                "True",
+                                "False",
+                                "Unknown"
+                              ],
+                              "type": "string"
+                            },
+                            "type": {
+                              "description": "Type of the condition, known values are (`Ready`, `Issuing`).",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "status",
+                            "type"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "type"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "failedIssuanceAttempts": {
+                        "description": "The number of continuous failed issuance attempts up till now. This field gets removed (if set) on a successful issuance and gets set to 1 if unset and an issuance has failed. If an issuance has failed, the delay till the next issuance will be calculated using formula time.Hour * 2 ^ (failedIssuanceAttempts - 1).",
+                        "type": "integer"
+                      },
+                      "lastFailureTime": {
+                        "description": "LastFailureTime is the time as recorded by the Certificate controller of the most recent failure to complete a CertificateRequest for this Certificate resource. If set, cert-manager will not re-request another Certificate until 1 hour has elapsed from this time.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "nextPrivateKeySecretName": {
+                        "description": "The name of the Secret resource containing the private key to be used for the next certificate iteration. The keymanager controller will automatically set this field if the `Issuing` condition is set to `True`. It will automatically unset this field when the Issuing condition is not set or False.",
+                        "type": "string"
+                      },
+                      "notAfter": {
+                        "description": "The expiration time of the certificate stored in the secret named by this resource in `spec.secretName`.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "notBefore": {
+                        "description": "The time after which the certificate stored in the secret named by this resource in spec.secretName is valid.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "renewalTime": {
+                        "description": "RenewalTime is the time at which the certificate will be next renewed. If not set, no upcoming renewal is scheduled.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "revision": {
+                        "description": "The current 'revision' of the certificate as issued. \n When a CertificateRequest resource is created, it will have the `cert-manager.io/certificate-revision` set to one greater than the current value of this field. \n Upon issuance, this field will be set to the value of the annotation on the CertificateRequest resource used to issue the certificate. \n Persisting the value on the CertificateRequest resource allows the certificates controller to know whether a request is part of an old issuance or if it is part of the ongoing revision's issuance by checking if the revision value in the annotation is greater than this field.",
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "spec"
+                ],
+                "type": "object"
+              }
+            },
+            "served": true,
+            "storage": true,
+            "subresources": {
+              "status": {}
+            }
+          },
+          {
+            "additionalPrinterColumns": [
+              {
+                "jsonPath": ".status.conditions[?(@.type==\"Ready\")].status",
+                "name": "Ready",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".spec.secretName",
+                "name": "Secret",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".spec.issuerRef.name",
+                "name": "Issuer",
+                "priority": 1,
+                "type": "string"
+              },
+              {
+                "jsonPath": ".status.conditions[?(@.type==\"Ready\")].message",
+                "name": "Status",
+                "priority": 1,
+                "type": "string"
+              },
+              {
+                "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.",
+                "jsonPath": ".metadata.creationTimestamp",
+                "name": "Age",
+                "type": "date"
+              }
+            ],
+            "name": "v1",
+            "schema": {
+              "openAPIV3Schema": {
+                "description": "A Certificate resource should be created to ensure an up to date and signed x509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`. \n The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`).",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "type": "object"
+                  },
+                  "spec": {
+                    "description": "Desired state of the Certificate resource.",
+                    "properties": {
+                      "additionalOutputFormats": {
+                        "description": "AdditionalOutputFormats defines extra output formats of the private key and signed certificate chain to be written to this Certificate's target Secret. This is an Alpha Feature and is only enabled with the `--feature-gates=AdditionalCertificateOutputFormats=true` option on both the controller and webhook components.",
+                        "items": {
+                          "description": "CertificateAdditionalOutputFormat defines an additional output format of a Certificate resource. These contain supplementary data formats of the signed certificate chain and paired private key.",
+                          "properties": {
+                            "type": {
+                              "description": "Type is the name of the format type that should be written to the Certificate's target Secret.",
+                              "enum": [
+                                "DER",
+                                "CombinedPEM"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "commonName": {
+                        "description": "CommonName is a common name to be used on the Certificate. The CommonName should have a length of 64 characters or fewer to avoid generating invalid CSRs. This value is ignored by TLS clients when any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4",
+                        "type": "string"
+                      },
+                      "dnsNames": {
+                        "description": "DNSNames is a list of DNS subjectAltNames to be set on the Certificate.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "duration": {
+                        "description": "The requested 'duration' (i.e. lifetime) of the Certificate. This option may be ignored/overridden by some issuer types. If unset this defaults to 90 days. Certificate will be renewed either 2/3 through its duration or `renewBefore` period before its expiry, whichever is later. Minimum accepted duration is 1 hour. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration",
+                        "type": "string"
+                      },
+                      "emailAddresses": {
+                        "description": "EmailAddresses is a list of email subjectAltNames to be set on the Certificate.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "encodeUsagesInRequest": {
+                        "description": "EncodeUsagesInRequest controls whether key usages should be present in the CertificateRequest",
+                        "type": "boolean"
+                      },
+                      "ipAddresses": {
+                        "description": "IPAddresses is a list of IP address subjectAltNames to be set on the Certificate.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "isCA": {
+                        "description": "IsCA will mark this Certificate as valid for certificate signing. This will automatically add the `cert sign` usage to the list of `usages`.",
+                        "type": "boolean"
+                      },
+                      "issuerRef": {
+                        "description": "IssuerRef is a reference to the issuer for this certificate. If the `kind` field is not set, or set to `Issuer`, an Issuer resource with the given name in the same namespace as the Certificate will be used. If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the provided name will be used. The `name` field in this stanza is required at all times.",
+                        "properties": {
+                          "group": {
+                            "description": "Group of the resource being referred to.",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "Kind of the resource being referred to.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the resource being referred to.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object"
+                      },
+                      "keystores": {
+                        "description": "Keystores configures additional keystore output formats stored in the `secretName` Secret resource.",
+                        "properties": {
+                          "jks": {
+                            "description": "JKS configures options for storing a JKS keystore in the `spec.secretName` Secret resource.",
+                            "properties": {
+                              "create": {
+                                "description": "Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.jks` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority",
+                                "type": "boolean"
+                              },
+                              "passwordSecretRef": {
+                                "description": "PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the JKS keystore.",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "required": [
+                              "create",
+                              "passwordSecretRef"
+                            ],
+                            "type": "object"
+                          },
+                          "pkcs12": {
+                            "description": "PKCS12 configures options for storing a PKCS12 keystore in the `spec.secretName` Secret resource.",
+                            "properties": {
+                              "create": {
+                                "description": "Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.p12` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority",
+                                "type": "boolean"
+                              },
+                              "passwordSecretRef": {
+                                "description": "PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the PKCS12 keystore.",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "required": [
+                              "create",
+                              "passwordSecretRef"
+                            ],
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "literalSubject": {
+                        "description": "LiteralSubject is an LDAP formatted string that represents the [X.509 Subject field](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6). Use this *instead* of the Subject field if you need to ensure the correct ordering of the RDN sequence, such as when issuing certs for LDAP authentication. See https://github.com/cert-manager/cert-manager/issues/3203, https://github.com/cert-manager/cert-manager/issues/4424. This field is alpha level and is only supported by cert-manager installations where LiteralCertificateSubject feature gate is enabled on both cert-manager controller and webhook.",
+                        "type": "string"
+                      },
+                      "privateKey": {
+                        "description": "Options to control private keys used for the Certificate.",
+                        "properties": {
+                          "algorithm": {
+                            "description": "Algorithm is the private key algorithm of the corresponding private key for this certificate. If provided, allowed values are either `RSA`,`Ed25519` or `ECDSA` If `algorithm` is specified and `size` is not provided, key size of 256 will be used for `ECDSA` key algorithm and key size of 2048 will be used for `RSA` key algorithm. key size is ignored when using the `Ed25519` key algorithm.",
+                            "enum": [
+                              "RSA",
+                              "ECDSA",
+                              "Ed25519"
+                            ],
+                            "type": "string"
+                          },
+                          "encoding": {
+                            "description": "The private key cryptography standards (PKCS) encoding for this certificate's private key to be encoded in. If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1 and PKCS#8, respectively. Defaults to `PKCS1` if not specified.",
+                            "enum": [
+                              "PKCS1",
+                              "PKCS8"
+                            ],
+                            "type": "string"
+                          },
+                          "rotationPolicy": {
+                            "description": "RotationPolicy controls how private keys should be regenerated when a re-issuance is being processed. If set to Never, a private key will only be generated if one does not already exist in the target `spec.secretName`. If one does exists but it does not have the correct algorithm or size, a warning will be raised to await user intervention. If set to Always, a private key matching the specified requirements will be generated whenever a re-issuance occurs. Default is 'Never' for backward compatibility.",
+                            "enum": [
+                              "Never",
+                              "Always"
+                            ],
+                            "type": "string"
+                          },
+                          "size": {
+                            "description": "Size is the key bit size of the corresponding private key for this certificate. If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`, and will default to `2048` if not specified. If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`, and will default to `256` if not specified. If `algorithm` is set to `Ed25519`, Size is ignored. No other values are allowed.",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "renewBefore": {
+                        "description": "How long before the currently issued certificate's expiry cert-manager should renew the certificate. The default is 2/3 of the issued certificate's duration. Minimum accepted value is 5 minutes. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration",
+                        "type": "string"
+                      },
+                      "revisionHistoryLimit": {
+                        "description": "revisionHistoryLimit is the maximum number of CertificateRequest revisions that are maintained in the Certificate's history. Each revision represents a single `CertificateRequest` created by this Certificate, either when it was created, renewed, or Spec was changed. Revisions will be removed by oldest first if the number of revisions exceeds this number. If set, revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`), revisions will not be garbage collected. Default value is `nil`.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "secretName": {
+                        "description": "SecretName is the name of the secret resource that will be automatically created and managed by this Certificate resource. It will be populated with a private key and certificate, signed by the denoted issuer.",
+                        "type": "string"
+                      },
+                      "secretTemplate": {
+                        "description": "SecretTemplate defines annotations and labels to be copied to the Certificate's Secret. Labels and annotations on the Secret will be changed as they appear on the SecretTemplate when added or removed. SecretTemplate annotations are added in conjunction with, and cannot overwrite, the base set of annotations cert-manager sets on the Certificate's Secret.",
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Annotations is a key value map to be copied to the target Kubernetes Secret.",
+                            "type": "object"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Labels is a key value map to be copied to the target Kubernetes Secret.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "subject": {
+                        "description": "Full X509 name specification (https://golang.org/pkg/crypto/x509/pkix/#Name).",
+                        "properties": {
+                          "countries": {
+                            "description": "Countries to be used on the Certificate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "localities": {
+                            "description": "Cities to be used on the Certificate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "organizationalUnits": {
+                            "description": "Organizational Units to be used on the Certificate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "organizations": {
+                            "description": "Organizations to be used on the Certificate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "postalCodes": {
+                            "description": "Postal codes to be used on the Certificate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "provinces": {
+                            "description": "State/Provinces to be used on the Certificate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "serialNumber": {
+                            "description": "Serial number to be used on the Certificate.",
+                            "type": "string"
+                          },
+                          "streetAddresses": {
+                            "description": "Street addresses to be used on the Certificate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "uris": {
+                        "description": "URIs is a list of URI subjectAltNames to be set on the Certificate.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "usages": {
+                        "description": "Usages is the set of x509 usages that are requested for the certificate. Defaults to `digital signature` and `key encipherment` if not specified.",
+                        "items": {
+                          "description": "KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12 Valid KeyUsage values are as follows: \"signing\", \"digital signature\", \"content commitment\", \"key encipherment\", \"key agreement\", \"data encipherment\", \"cert sign\", \"crl sign\", \"encipher only\", \"decipher only\", \"any\", \"server auth\", \"client auth\", \"code signing\", \"email protection\", \"s/mime\", \"ipsec end system\", \"ipsec tunnel\", \"ipsec user\", \"timestamping\", \"ocsp signing\", \"microsoft sgc\", \"netscape sgc\"",
+                          "enum": [
+                            "signing",
+                            "digital signature",
+                            "content commitment",
+                            "key encipherment",
+                            "key agreement",
+                            "data encipherment",
+                            "cert sign",
+                            "crl sign",
+                            "encipher only",
+                            "decipher only",
+                            "any",
+                            "server auth",
+                            "client auth",
+                            "code signing",
+                            "email protection",
+                            "s/mime",
+                            "ipsec end system",
+                            "ipsec tunnel",
+                            "ipsec user",
+                            "timestamping",
+                            "ocsp signing",
+                            "microsoft sgc",
+                            "netscape sgc"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "issuerRef",
+                      "secretName"
+                    ],
+                    "type": "object"
+                  },
+                  "status": {
+                    "description": "Status of the Certificate. This is set and managed automatically.",
+                    "properties": {
+                      "conditions": {
+                        "description": "List of status conditions to indicate the status of certificates. Known condition types are `Ready` and `Issuing`.",
+                        "items": {
+                          "description": "CertificateCondition contains condition information for an Certificate.",
+                          "properties": {
+                            "lastTransitionTime": {
+                              "description": "LastTransitionTime is the timestamp corresponding to the last status change of this condition.",
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "message": {
+                              "description": "Message is a human readable description of the details of the last transition, complementing reason.",
+                              "type": "string"
+                            },
+                            "observedGeneration": {
+                              "description": "If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Certificate.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "reason": {
+                              "description": "Reason is a brief machine readable explanation for the condition's last transition.",
+                              "type": "string"
+                            },
+                            "status": {
+                              "description": "Status of the condition, one of (`True`, `False`, `Unknown`).",
+                              "enum": [
+                                "True",
+                                "False",
+                                "Unknown"
+                              ],
+                              "type": "string"
+                            },
+                            "type": {
+                              "description": "Type of the condition, known values are (`Ready`, `Issuing`).",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "status",
+                            "type"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "type"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "failedIssuanceAttempts": {
+                        "description": "The number of continuous failed issuance attempts up till now. This field gets removed (if set) on a successful issuance and gets set to 1 if unset and an issuance has failed. If an issuance has failed, the delay till the next issuance will be calculated using formula time.Hour * 2 ^ (failedIssuanceAttempts - 1).",
+                        "type": "integer"
+                      },
+                      "lastFailureTime": {
+                        "description": "LastFailureTime is the time as recorded by the Certificate controller of the most recent failure to complete a CertificateRequest for this Certificate resource. If set, cert-manager will not re-request another Certificate until 1 hour has elapsed from this time.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "nextPrivateKeySecretName": {
+                        "description": "The name of the Secret resource containing the private key to be used for the next certificate iteration. The keymanager controller will automatically set this field if the `Issuing` condition is set to `True`. It will automatically unset this field when the Issuing condition is not set or False.",
+                        "type": "string"
+                      },
+                      "notAfter": {
+                        "description": "The expiration time of the certificate stored in the secret named by this resource in `spec.secretName`.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "notBefore": {
+                        "description": "The time after which the certificate stored in the secret named by this resource in spec.secretName is valid.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "renewalTime": {
+                        "description": "RenewalTime is the time at which the certificate will be next renewed. If not set, no upcoming renewal is scheduled.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "revision": {
+                        "description": "The current 'revision' of the certificate as issued. \n When a CertificateRequest resource is created, it will have the `cert-manager.io/certificate-revision` set to one greater than the current value of this field. \n Upon issuance, this field will be set to the value of the annotation on the CertificateRequest resource used to issue the certificate. \n Persisting the value on the CertificateRequest resource allows the certificates controller to know whether a request is part of an old issuance or if it is part of the ongoing revision's issuance by checking if the revision value in the annotation is greater than this field.",
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "spec"
+                ],
+                "type": "object"
+              }
+            },
+            "served": false,
+            "storage": false,
+            "subresources": {
+              "status": {}
+            }
+          }
+        ]
+      },
+      "status": {
+        "acceptedNames": {
+          "categories": [
+            "cert-manager"
+          ],
+          "kind": "Certificate",
+          "listKind": "CertificateList",
+          "plural": "certificates",
+          "shortNames": [
+            "cert",
+            "certs"
+          ],
+          "singular": "certificate"
+        },
+        "conditions": [
+          {
+            "lastTransitionTime": "2022-11-17T16:09:59Z",
+            "message": "no conflicts found",
+            "reason": "NoConflicts",
+            "status": "True",
+            "type": "NamesAccepted"
+          },
+          {
+            "lastTransitionTime": "2022-11-17T16:09:59Z",
+            "message": "the initial names have been accepted",
+            "reason": "InitialNamesAccepted",
+            "status": "True",
+            "type": "Established"
+          }
+        ],
+        "storedVersions": [
+          "v1",
+          "v2"
+        ]
+      }
+    },
+    {
+      "apiVersion": "apiextensions.k8s.io/v1",
+      "kind": "CustomResourceDefinition",
+      "metadata": {
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apiextensions.k8s.io/v1\",\"kind\":\"CustomResourceDefinition\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"cert-manager\",\"app.kubernetes.io/instance\":\"cert-manager\",\"app.kubernetes.io/name\":\"cert-manager\",\"app.kubernetes.io/version\":\"v1.9.2-beta.0\"},\"name\":\"challenges.acme.cert-manager.io\"},\"spec\":{\"group\":\"acme.cert-manager.io\",\"names\":{\"categories\":[\"cert-manager\",\"cert-manager-acme\"],\"kind\":\"Challenge\",\"listKind\":\"ChallengeList\",\"plural\":\"challenges\",\"singular\":\"challenge\"},\"scope\":\"Namespaced\",\"versions\":[{\"additionalPrinterColumns\":[{\"jsonPath\":\".status.state\",\"name\":\"State\",\"type\":\"string\"},{\"jsonPath\":\".spec.dnsName\",\"name\":\"Domain\",\"type\":\"string\"},{\"jsonPath\":\".status.reason\",\"name\":\"Reason\",\"priority\":1,\"type\":\"string\"},{\"description\":\"CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\",\"jsonPath\":\".metadata.creationTimestamp\",\"name\":\"Age\",\"type\":\"date\"}],\"name\":\"v1\",\"schema\":{\"openAPIV3Schema\":{\"description\":\"Challenge is a type to represent a Challenge request with an ACME server\",\"properties\":{\"apiVersion\":{\"description\":\"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources\",\"type\":\"string\"},\"kind\":{\"description\":\"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds\",\"type\":\"string\"},\"metadata\":{\"type\":\"object\"},\"spec\":{\"properties\":{\"authorizationURL\":{\"description\":\"The URL to the ACME Authorization resource that this challenge is a part of.\",\"type\":\"string\"},\"dnsName\":{\"description\":\"dnsName is the identifier that this challenge is for, e.g. example.com. If the requested DNSName is a 'wildcard', this field MUST be set to the non-wildcard domain, e.g. for `*.example.com`, it must be `example.com`.\",\"type\":\"string\"},\"issuerRef\":{\"description\":\"References a properly configured ACME-type Issuer which should be used to create this Challenge. If the Issuer does not exist, processing will be retried. If the Issuer is not an 'ACME' Issuer, an error will be returned and the Challenge will be marked as failed.\",\"properties\":{\"group\":{\"description\":\"Group of the resource being referred to.\",\"type\":\"string\"},\"kind\":{\"description\":\"Kind of the resource being referred to.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to.\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"key\":{\"description\":\"The ACME challenge key for this challenge For HTTP01 challenges, this is the value that must be responded with to complete the HTTP01 challenge in the format: `\\u003cprivate key JWK thumbprint\\u003e.\\u003ckey from acme server for challenge\\u003e`. For DNS01 challenges, this is the base64 encoded SHA256 sum of the `\\u003cprivate key JWK thumbprint\\u003e.\\u003ckey from acme server for challenge\\u003e` text that must be set as the TXT record content.\",\"type\":\"string\"},\"solver\":{\"description\":\"Contains the domain solving configuration that should be used to solve this challenge resource.\",\"properties\":{\"dns01\":{\"description\":\"Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.\",\"properties\":{\"acmeDNS\":{\"description\":\"Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.\",\"properties\":{\"accountSecretRef\":{\"description\":\"A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"host\":{\"type\":\"string\"}},\"required\":[\"accountSecretRef\",\"host\"],\"type\":\"object\"},\"akamai\":{\"description\":\"Use the Akamai DNS zone management API to manage DNS01 challenge records.\",\"properties\":{\"accessTokenSecretRef\":{\"description\":\"A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"clientSecretSecretRef\":{\"description\":\"A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"clientTokenSecretRef\":{\"description\":\"A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"serviceConsumerDomain\":{\"type\":\"string\"}},\"required\":[\"accessTokenSecretRef\",\"clientSecretSecretRef\",\"clientTokenSecretRef\",\"serviceConsumerDomain\"],\"type\":\"object\"},\"azureDNS\":{\"description\":\"Use the Microsoft Azure DNS API to manage DNS01 challenge records.\",\"properties\":{\"clientID\":{\"description\":\"if both this and ClientSecret are left unset MSI will be used\",\"type\":\"string\"},\"clientSecretSecretRef\":{\"description\":\"if both this and ClientID are left unset MSI will be used\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"environment\":{\"description\":\"name of the Azure environment (default AzurePublicCloud)\",\"enum\":[\"AzurePublicCloud\",\"AzureChinaCloud\",\"AzureGermanCloud\",\"AzureUSGovernmentCloud\"],\"type\":\"string\"},\"hostedZoneName\":{\"description\":\"name of the DNS zone that should be used\",\"type\":\"string\"},\"managedIdentity\":{\"description\":\"managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID\",\"properties\":{\"clientID\":{\"description\":\"client ID of the managed identity, can not be used at the same time as resourceID\",\"type\":\"string\"},\"resourceID\":{\"description\":\"resource ID of the managed identity, can not be used at the same time as clientID\",\"type\":\"string\"}},\"type\":\"object\"},\"resourceGroupName\":{\"description\":\"resource group the DNS zone is located in\",\"type\":\"string\"},\"subscriptionID\":{\"description\":\"ID of the Azure subscription\",\"type\":\"string\"},\"tenantID\":{\"description\":\"when specifying ClientID and ClientSecret then this field is also needed\",\"type\":\"string\"}},\"required\":[\"resourceGroupName\",\"subscriptionID\"],\"type\":\"object\"},\"cloudDNS\":{\"description\":\"Use the Google Cloud DNS API to manage DNS01 challenge records.\",\"properties\":{\"hostedZoneName\":{\"description\":\"HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.\",\"type\":\"string\"},\"project\":{\"type\":\"string\"},\"serviceAccountSecretRef\":{\"description\":\"A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"required\":[\"project\"],\"type\":\"object\"},\"cloudflare\":{\"description\":\"Use the Cloudflare API to manage DNS01 challenge records.\",\"properties\":{\"apiKeySecretRef\":{\"description\":\"API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"apiTokenSecretRef\":{\"description\":\"API token used to authenticate with Cloudflare.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"email\":{\"description\":\"Email of the account, only required when using API key based authentication.\",\"type\":\"string\"}},\"type\":\"object\"},\"cnameStrategy\":{\"description\":\"CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.\",\"enum\":[\"None\",\"Follow\"],\"type\":\"string\"},\"digitalocean\":{\"description\":\"Use the DigitalOcean DNS API to manage DNS01 challenge records.\",\"properties\":{\"tokenSecretRef\":{\"description\":\"A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"required\":[\"tokenSecretRef\"],\"type\":\"object\"},\"rfc2136\":{\"description\":\"Use RFC2136 (\\\"Dynamic Updates in the Domain Name System\\\") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.\",\"properties\":{\"nameserver\":{\"description\":\"The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.\",\"type\":\"string\"},\"tsigAlgorithm\":{\"description\":\"The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.\",\"type\":\"string\"},\"tsigKeyName\":{\"description\":\"The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.\",\"type\":\"string\"},\"tsigSecretSecretRef\":{\"description\":\"The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"required\":[\"nameserver\"],\"type\":\"object\"},\"route53\":{\"description\":\"Use the AWS Route53 API to manage DNS01 challenge records.\",\"properties\":{\"accessKeyID\":{\"description\":\"The AccessKeyID is used for authentication. Cannot be set when SecretAccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials\",\"type\":\"string\"},\"accessKeyIDSecretRef\":{\"description\":\"The SecretAccessKey is used for authentication. If set, pull the AWS access key ID from a key within a Kubernetes Secret. Cannot be set when AccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"hostedZoneID\":{\"description\":\"If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.\",\"type\":\"string\"},\"region\":{\"description\":\"Always set the region when using AccessKeyID and SecretAccessKey\",\"type\":\"string\"},\"role\":{\"description\":\"Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata\",\"type\":\"string\"},\"secretAccessKeySecretRef\":{\"description\":\"The SecretAccessKey is used for authentication. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"required\":[\"region\"],\"type\":\"object\"},\"webhook\":{\"description\":\"Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.\",\"properties\":{\"config\":{\"description\":\"Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.\",\"x-kubernetes-preserve-unknown-fields\":true},\"groupName\":{\"description\":\"The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.\",\"type\":\"string\"},\"solverName\":{\"description\":\"The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.\",\"type\":\"string\"}},\"required\":[\"groupName\",\"solverName\"],\"type\":\"object\"}},\"type\":\"object\"},\"http01\":{\"description\":\"Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.\",\"properties\":{\"gatewayHTTPRoute\":{\"description\":\"The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.\",\"properties\":{\"labels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.\",\"type\":\"object\"},\"parentRefs\":{\"description\":\"When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways\",\"items\":{\"description\":\"ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \\\"Core\\\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \\n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \\n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object.\",\"properties\":{\"group\":{\"default\":\"gateway.networking.k8s.io\",\"description\":\"Group is the group of the referent. \\n Support: Core\",\"maxLength\":253,\"pattern\":\"^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$\",\"type\":\"string\"},\"kind\":{\"default\":\"Gateway\",\"description\":\"Kind is kind of the referent. \\n Support: Core (Gateway) Support: Custom (Other Resources)\",\"maxLength\":63,\"minLength\":1,\"pattern\":\"^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$\",\"type\":\"string\"},\"name\":{\"description\":\"Name is the name of the referent. \\n Support: Core\",\"maxLength\":253,\"minLength\":1,\"type\":\"string\"},\"namespace\":{\"description\":\"Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \\n Support: Core\",\"maxLength\":63,\"minLength\":1,\"pattern\":\"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$\",\"type\":\"string\"},\"sectionName\":{\"description\":\"SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \\n * Gateway: Listener Name \\n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \\n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \\n Support: Core\",\"maxLength\":253,\"minLength\":1,\"pattern\":\"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"type\":\"array\"},\"serviceType\":{\"description\":\"Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.\",\"type\":\"string\"}},\"type\":\"object\"},\"ingress\":{\"description\":\"The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.\",\"properties\":{\"class\":{\"description\":\"The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.\",\"type\":\"string\"},\"ingressTemplate\":{\"description\":\"Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.\",\"properties\":{\"metadata\":{\"description\":\"ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.\",\"properties\":{\"annotations\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"Annotations that should be added to the created ACME HTTP01 solver ingress.\",\"type\":\"object\"},\"labels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"Labels that should be added to the created ACME HTTP01 solver ingress.\",\"type\":\"object\"}},\"type\":\"object\"}},\"type\":\"object\"},\"name\":{\"description\":\"The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.\",\"type\":\"string\"},\"podTemplate\":{\"description\":\"Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.\",\"properties\":{\"metadata\":{\"description\":\"ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.\",\"properties\":{\"annotations\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"Annotations that should be added to the create ACME HTTP01 solver pods.\",\"type\":\"object\"},\"labels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"Labels that should be added to the created ACME HTTP01 solver pods.\",\"type\":\"object\"}},\"type\":\"object\"},\"spec\":{\"description\":\"PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.\",\"properties\":{\"affinity\":{\"description\":\"If specified, the pod's scheduling constraints\",\"properties\":{\"nodeAffinity\":{\"description\":\"Describes node affinity scheduling rules for the pod.\",\"properties\":{\"preferredDuringSchedulingIgnoredDuringExecution\":{\"description\":\"The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\\"weight\\\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.\",\"items\":{\"description\":\"An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).\",\"properties\":{\"preference\":{\"description\":\"A node selector term, associated with the corresponding weight.\",\"properties\":{\"matchExpressions\":{\"description\":\"A list of node selector requirements by node's labels.\",\"items\":{\"description\":\"A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"The label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.\",\"type\":\"string\"},\"values\":{\"description\":\"An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchFields\":{\"description\":\"A list of node selector requirements by node's fields.\",\"items\":{\"description\":\"A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"The label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.\",\"type\":\"string\"},\"values\":{\"description\":\"An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"}},\"type\":\"object\"},\"weight\":{\"description\":\"Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.\",\"format\":\"int32\",\"type\":\"integer\"}},\"required\":[\"preference\",\"weight\"],\"type\":\"object\"},\"type\":\"array\"},\"requiredDuringSchedulingIgnoredDuringExecution\":{\"description\":\"If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.\",\"properties\":{\"nodeSelectorTerms\":{\"description\":\"Required. A list of node selector terms. The terms are ORed.\",\"items\":{\"description\":\"A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.\",\"properties\":{\"matchExpressions\":{\"description\":\"A list of node selector requirements by node's labels.\",\"items\":{\"description\":\"A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"The label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.\",\"type\":\"string\"},\"values\":{\"description\":\"An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchFields\":{\"description\":\"A list of node selector requirements by node's fields.\",\"items\":{\"description\":\"A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"The label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.\",\"type\":\"string\"},\"values\":{\"description\":\"An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"}},\"type\":\"object\"},\"type\":\"array\"}},\"required\":[\"nodeSelectorTerms\"],\"type\":\"object\"}},\"type\":\"object\"},\"podAffinity\":{\"description\":\"Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).\",\"properties\":{\"preferredDuringSchedulingIgnoredDuringExecution\":{\"description\":\"The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\\"weight\\\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.\",\"items\":{\"description\":\"The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)\",\"properties\":{\"podAffinityTerm\":{\"description\":\"Required. A pod affinity term, associated with the corresponding weight.\",\"properties\":{\"labelSelector\":{\"description\":\"A label query over a set of resources, in this case pods.\",\"properties\":{\"matchExpressions\":{\"description\":\"matchExpressions is a list of label selector requirements. The requirements are ANDed.\",\"items\":{\"description\":\"A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"key is the label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\",\"type\":\"string\"},\"values\":{\"description\":\"values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\\"key\\\", the operator is \\\"In\\\", and the values array contains only \\\"value\\\". The requirements are ANDed.\",\"type\":\"object\"}},\"type\":\"object\"},\"namespaceSelector\":{\"description\":\"A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \\\"this pod's namespace\\\". An empty selector ({}) matches all namespaces.\",\"properties\":{\"matchExpressions\":{\"description\":\"matchExpressions is a list of label selector requirements. The requirements are ANDed.\",\"items\":{\"description\":\"A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"key is the label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\",\"type\":\"string\"},\"values\":{\"description\":\"values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\\"key\\\", the operator is \\\"In\\\", and the values array contains only \\\"value\\\". The requirements are ANDed.\",\"type\":\"object\"}},\"type\":\"object\"},\"namespaces\":{\"description\":\"namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\\"this pod's namespace\\\".\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"topologyKey\":{\"description\":\"This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.\",\"type\":\"string\"}},\"required\":[\"topologyKey\"],\"type\":\"object\"},\"weight\":{\"description\":\"weight associated with matching the corresponding podAffinityTerm, in the range 1-100.\",\"format\":\"int32\",\"type\":\"integer\"}},\"required\":[\"podAffinityTerm\",\"weight\"],\"type\":\"object\"},\"type\":\"array\"},\"requiredDuringSchedulingIgnoredDuringExecution\":{\"description\":\"If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.\",\"items\":{\"description\":\"Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \\u003ctopologyKey\\u003e matches that of any node on which a pod of the set of pods is running\",\"properties\":{\"labelSelector\":{\"description\":\"A label query over a set of resources, in this case pods.\",\"properties\":{\"matchExpressions\":{\"description\":\"matchExpressions is a list of label selector requirements. The requirements are ANDed.\",\"items\":{\"description\":\"A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"key is the label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\",\"type\":\"string\"},\"values\":{\"description\":\"values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\\"key\\\", the operator is \\\"In\\\", and the values array contains only \\\"value\\\". The requirements are ANDed.\",\"type\":\"object\"}},\"type\":\"object\"},\"namespaceSelector\":{\"description\":\"A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \\\"this pod's namespace\\\". An empty selector ({}) matches all namespaces.\",\"properties\":{\"matchExpressions\":{\"description\":\"matchExpressions is a list of label selector requirements. The requirements are ANDed.\",\"items\":{\"description\":\"A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"key is the label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\",\"type\":\"string\"},\"values\":{\"description\":\"values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\\"key\\\", the operator is \\\"In\\\", and the values array contains only \\\"value\\\". The requirements are ANDed.\",\"type\":\"object\"}},\"type\":\"object\"},\"namespaces\":{\"description\":\"namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\\"this pod's namespace\\\".\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"topologyKey\":{\"description\":\"This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.\",\"type\":\"string\"}},\"required\":[\"topologyKey\"],\"type\":\"object\"},\"type\":\"array\"}},\"type\":\"object\"},\"podAntiAffinity\":{\"description\":\"Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).\",\"properties\":{\"preferredDuringSchedulingIgnoredDuringExecution\":{\"description\":\"The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\\"weight\\\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.\",\"items\":{\"description\":\"The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)\",\"properties\":{\"podAffinityTerm\":{\"description\":\"Required. A pod affinity term, associated with the corresponding weight.\",\"properties\":{\"labelSelector\":{\"description\":\"A label query over a set of resources, in this case pods.\",\"properties\":{\"matchExpressions\":{\"description\":\"matchExpressions is a list of label selector requirements. The requirements are ANDed.\",\"items\":{\"description\":\"A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"key is the label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\",\"type\":\"string\"},\"values\":{\"description\":\"values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\\"key\\\", the operator is \\\"In\\\", and the values array contains only \\\"value\\\". The requirements are ANDed.\",\"type\":\"object\"}},\"type\":\"object\"},\"namespaceSelector\":{\"description\":\"A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \\\"this pod's namespace\\\". An empty selector ({}) matches all namespaces.\",\"properties\":{\"matchExpressions\":{\"description\":\"matchExpressions is a list of label selector requirements. The requirements are ANDed.\",\"items\":{\"description\":\"A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"key is the label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\",\"type\":\"string\"},\"values\":{\"description\":\"values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\\"key\\\", the operator is \\\"In\\\", and the values array contains only \\\"value\\\". The requirements are ANDed.\",\"type\":\"object\"}},\"type\":\"object\"},\"namespaces\":{\"description\":\"namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\\"this pod's namespace\\\".\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"topologyKey\":{\"description\":\"This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.\",\"type\":\"string\"}},\"required\":[\"topologyKey\"],\"type\":\"object\"},\"weight\":{\"description\":\"weight associated with matching the corresponding podAffinityTerm, in the range 1-100.\",\"format\":\"int32\",\"type\":\"integer\"}},\"required\":[\"podAffinityTerm\",\"weight\"],\"type\":\"object\"},\"type\":\"array\"},\"requiredDuringSchedulingIgnoredDuringExecution\":{\"description\":\"If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.\",\"items\":{\"description\":\"Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \\u003ctopologyKey\\u003e matches that of any node on which a pod of the set of pods is running\",\"properties\":{\"labelSelector\":{\"description\":\"A label query over a set of resources, in this case pods.\",\"properties\":{\"matchExpressions\":{\"description\":\"matchExpressions is a list of label selector requirements. The requirements are ANDed.\",\"items\":{\"description\":\"A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"key is the label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\",\"type\":\"string\"},\"values\":{\"description\":\"values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\\"key\\\", the operator is \\\"In\\\", and the values array contains only \\\"value\\\". The requirements are ANDed.\",\"type\":\"object\"}},\"type\":\"object\"},\"namespaceSelector\":{\"description\":\"A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \\\"this pod's namespace\\\". An empty selector ({}) matches all namespaces.\",\"properties\":{\"matchExpressions\":{\"description\":\"matchExpressions is a list of label selector requirements. The requirements are ANDed.\",\"items\":{\"description\":\"A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"key is the label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\",\"type\":\"string\"},\"values\":{\"description\":\"values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\\"key\\\", the operator is \\\"In\\\", and the values array contains only \\\"value\\\". The requirements are ANDed.\",\"type\":\"object\"}},\"type\":\"object\"},\"namespaces\":{\"description\":\"namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\\"this pod's namespace\\\".\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"topologyKey\":{\"description\":\"This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.\",\"type\":\"string\"}},\"required\":[\"topologyKey\"],\"type\":\"object\"},\"type\":\"array\"}},\"type\":\"object\"}},\"type\":\"object\"},\"nodeSelector\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/\",\"type\":\"object\"},\"priorityClassName\":{\"description\":\"If specified, the pod's priorityClassName.\",\"type\":\"string\"},\"serviceAccountName\":{\"description\":\"If specified, the pod's service account\",\"type\":\"string\"},\"tolerations\":{\"description\":\"If specified, the pod's tolerations.\",\"items\":{\"description\":\"The pod this Toleration is attached to tolerates any taint that matches the triple \\u003ckey,value,effect\\u003e using the matching operator \\u003coperator\\u003e.\",\"properties\":{\"effect\":{\"description\":\"Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.\",\"type\":\"string\"},\"key\":{\"description\":\"Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.\",\"type\":\"string\"},\"operator\":{\"description\":\"Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.\",\"type\":\"string\"},\"tolerationSeconds\":{\"description\":\"TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.\",\"format\":\"int64\",\"type\":\"integer\"},\"value\":{\"description\":\"Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.\",\"type\":\"string\"}},\"type\":\"object\"},\"type\":\"array\"}},\"type\":\"object\"}},\"type\":\"object\"},\"serviceType\":{\"description\":\"Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.\",\"type\":\"string\"}},\"type\":\"object\"}},\"type\":\"object\"},\"selector\":{\"description\":\"Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.\",\"properties\":{\"dnsNames\":{\"description\":\"List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"dnsZones\":{\"description\":\"List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"A label selector that is used to refine the set of certificate's that this challenge solver will apply to.\",\"type\":\"object\"}},\"type\":\"object\"}},\"type\":\"object\"},\"token\":{\"description\":\"The ACME challenge token for this challenge. This is the raw value returned from the ACME server.\",\"type\":\"string\"},\"type\":{\"description\":\"The type of ACME challenge this resource represents. One of \\\"HTTP-01\\\" or \\\"DNS-01\\\".\",\"enum\":[\"HTTP-01\",\"DNS-01\"],\"type\":\"string\"},\"url\":{\"description\":\"The URL of the ACME Challenge resource for this challenge. This can be used to lookup details about the status of this challenge.\",\"type\":\"string\"},\"wildcard\":{\"description\":\"wildcard will be true if this challenge is for a wildcard identifier, for example '*.example.com'.\",\"type\":\"boolean\"}},\"required\":[\"authorizationURL\",\"dnsName\",\"issuerRef\",\"key\",\"solver\",\"token\",\"type\",\"url\"],\"type\":\"object\"},\"status\":{\"properties\":{\"presented\":{\"description\":\"presented will be set to true if the challenge values for this challenge are currently 'presented'. This *does not* imply the self check is passing. Only that the values have been 'submitted' for the appropriate challenge mechanism (i.e. the DNS01 TXT record has been presented, or the HTTP01 configuration has been configured).\",\"type\":\"boolean\"},\"processing\":{\"description\":\"Used to denote whether this challenge should be processed or not. This field will only be set to true by the 'scheduling' component. It will only be set to false by the 'challenges' controller, after the challenge has reached a final state or timed out. If this field is set to false, the challenge controller will not take any more action.\",\"type\":\"boolean\"},\"reason\":{\"description\":\"Contains human readable information on why the Challenge is in the current state.\",\"type\":\"string\"},\"state\":{\"description\":\"Contains the current 'state' of the challenge. If not set, the state of the challenge is unknown.\",\"enum\":[\"valid\",\"ready\",\"pending\",\"processing\",\"invalid\",\"expired\",\"errored\"],\"type\":\"string\"}},\"type\":\"object\"}},\"required\":[\"metadata\",\"spec\"],\"type\":\"object\"}},\"served\":true,\"storage\":true,\"subresources\":{\"status\":{}}}]}}\n"
+        },
+        "creationTimestamp": "2022-11-17T16:09:59Z",
+        "generation": 1,
+        "labels": {
+          "app": "cert-manager",
+          "app.kubernetes.io/instance": "cert-manager",
+          "app.kubernetes.io/name": "cert-manager",
+          "app.kubernetes.io/version": "v1.9.2-beta.0"
+        },
+        "name": "challenges.acme.cert-manager.io",
+        "resourceVersion": "148279",
+        "uid": "b4219c0e-7874-40f5-b995-1a6bf7651b29"
+      },
+      "spec": {
+        "conversion": {
+          "strategy": "None"
+        },
+        "group": "acme.cert-manager.io",
+        "names": {
+          "categories": [
+            "cert-manager",
+            "cert-manager-acme"
+          ],
+          "kind": "Challenge",
+          "listKind": "ChallengeList",
+          "plural": "challenges",
+          "singular": "challenge"
+        },
+        "scope": "Namespaced",
+        "versions": [
+          {
+            "additionalPrinterColumns": [
+              {
+                "jsonPath": ".status.state",
+                "name": "State",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".spec.dnsName",
+                "name": "Domain",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".status.reason",
+                "name": "Reason",
+                "priority": 1,
+                "type": "string"
+              },
+              {
+                "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.",
+                "jsonPath": ".metadata.creationTimestamp",
+                "name": "Age",
+                "type": "date"
+              }
+            ],
+            "name": "v1",
+            "schema": {
+              "openAPIV3Schema": {
+                "description": "Challenge is a type to represent a Challenge request with an ACME server",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "type": "object"
+                  },
+                  "spec": {
+                    "properties": {
+                      "authorizationURL": {
+                        "description": "The URL to the ACME Authorization resource that this challenge is a part of.",
+                        "type": "string"
+                      },
+                      "dnsName": {
+                        "description": "dnsName is the identifier that this challenge is for, e.g. example.com. If the requested DNSName is a 'wildcard', this field MUST be set to the non-wildcard domain, e.g. for `*.example.com`, it must be `example.com`.",
+                        "type": "string"
+                      },
+                      "issuerRef": {
+                        "description": "References a properly configured ACME-type Issuer which should be used to create this Challenge. If the Issuer does not exist, processing will be retried. If the Issuer is not an 'ACME' Issuer, an error will be returned and the Challenge will be marked as failed.",
+                        "properties": {
+                          "group": {
+                            "description": "Group of the resource being referred to.",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "Kind of the resource being referred to.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the resource being referred to.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object"
+                      },
+                      "key": {
+                        "description": "The ACME challenge key for this challenge For HTTP01 challenges, this is the value that must be responded with to complete the HTTP01 challenge in the format: `\u003cprivate key JWK thumbprint\u003e.\u003ckey from acme server for challenge\u003e`. For DNS01 challenges, this is the base64 encoded SHA256 sum of the `\u003cprivate key JWK thumbprint\u003e.\u003ckey from acme server for challenge\u003e` text that must be set as the TXT record content.",
+                        "type": "string"
+                      },
+                      "solver": {
+                        "description": "Contains the domain solving configuration that should be used to solve this challenge resource.",
+                        "properties": {
+                          "dns01": {
+                            "description": "Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.",
+                            "properties": {
+                              "acmeDNS": {
+                                "description": "Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.",
+                                "properties": {
+                                  "accountSecretRef": {
+                                    "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "host": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "accountSecretRef",
+                                  "host"
+                                ],
+                                "type": "object"
+                              },
+                              "akamai": {
+                                "description": "Use the Akamai DNS zone management API to manage DNS01 challenge records.",
+                                "properties": {
+                                  "accessTokenSecretRef": {
+                                    "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "clientSecretSecretRef": {
+                                    "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "clientTokenSecretRef": {
+                                    "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "serviceConsumerDomain": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "accessTokenSecretRef",
+                                  "clientSecretSecretRef",
+                                  "clientTokenSecretRef",
+                                  "serviceConsumerDomain"
+                                ],
+                                "type": "object"
+                              },
+                              "azureDNS": {
+                                "description": "Use the Microsoft Azure DNS API to manage DNS01 challenge records.",
+                                "properties": {
+                                  "clientID": {
+                                    "description": "if both this and ClientSecret are left unset MSI will be used",
+                                    "type": "string"
+                                  },
+                                  "clientSecretSecretRef": {
+                                    "description": "if both this and ClientID are left unset MSI will be used",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "environment": {
+                                    "description": "name of the Azure environment (default AzurePublicCloud)",
+                                    "enum": [
+                                      "AzurePublicCloud",
+                                      "AzureChinaCloud",
+                                      "AzureGermanCloud",
+                                      "AzureUSGovernmentCloud"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "hostedZoneName": {
+                                    "description": "name of the DNS zone that should be used",
+                                    "type": "string"
+                                  },
+                                  "managedIdentity": {
+                                    "description": "managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID",
+                                    "properties": {
+                                      "clientID": {
+                                        "description": "client ID of the managed identity, can not be used at the same time as resourceID",
+                                        "type": "string"
+                                      },
+                                      "resourceID": {
+                                        "description": "resource ID of the managed identity, can not be used at the same time as clientID",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "resourceGroupName": {
+                                    "description": "resource group the DNS zone is located in",
+                                    "type": "string"
+                                  },
+                                  "subscriptionID": {
+                                    "description": "ID of the Azure subscription",
+                                    "type": "string"
+                                  },
+                                  "tenantID": {
+                                    "description": "when specifying ClientID and ClientSecret then this field is also needed",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "resourceGroupName",
+                                  "subscriptionID"
+                                ],
+                                "type": "object"
+                              },
+                              "cloudDNS": {
+                                "description": "Use the Google Cloud DNS API to manage DNS01 challenge records.",
+                                "properties": {
+                                  "hostedZoneName": {
+                                    "description": "HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.",
+                                    "type": "string"
+                                  },
+                                  "project": {
+                                    "type": "string"
+                                  },
+                                  "serviceAccountSecretRef": {
+                                    "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "project"
+                                ],
+                                "type": "object"
+                              },
+                              "cloudflare": {
+                                "description": "Use the Cloudflare API to manage DNS01 challenge records.",
+                                "properties": {
+                                  "apiKeySecretRef": {
+                                    "description": "API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "apiTokenSecretRef": {
+                                    "description": "API token used to authenticate with Cloudflare.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "email": {
+                                    "description": "Email of the account, only required when using API key based authentication.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "cnameStrategy": {
+                                "description": "CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.",
+                                "enum": [
+                                  "None",
+                                  "Follow"
+                                ],
+                                "type": "string"
+                              },
+                              "digitalocean": {
+                                "description": "Use the DigitalOcean DNS API to manage DNS01 challenge records.",
+                                "properties": {
+                                  "tokenSecretRef": {
+                                    "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "tokenSecretRef"
+                                ],
+                                "type": "object"
+                              },
+                              "rfc2136": {
+                                "description": "Use RFC2136 (\"Dynamic Updates in the Domain Name System\") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.",
+                                "properties": {
+                                  "nameserver": {
+                                    "description": "The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.",
+                                    "type": "string"
+                                  },
+                                  "tsigAlgorithm": {
+                                    "description": "The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.",
+                                    "type": "string"
+                                  },
+                                  "tsigKeyName": {
+                                    "description": "The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.",
+                                    "type": "string"
+                                  },
+                                  "tsigSecretSecretRef": {
+                                    "description": "The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "nameserver"
+                                ],
+                                "type": "object"
+                              },
+                              "route53": {
+                                "description": "Use the AWS Route53 API to manage DNS01 challenge records.",
+                                "properties": {
+                                  "accessKeyID": {
+                                    "description": "The AccessKeyID is used for authentication. Cannot be set when SecretAccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                                    "type": "string"
+                                  },
+                                  "accessKeyIDSecretRef": {
+                                    "description": "The SecretAccessKey is used for authentication. If set, pull the AWS access key ID from a key within a Kubernetes Secret. Cannot be set when AccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "hostedZoneID": {
+                                    "description": "If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.",
+                                    "type": "string"
+                                  },
+                                  "region": {
+                                    "description": "Always set the region when using AccessKeyID and SecretAccessKey",
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "description": "Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata",
+                                    "type": "string"
+                                  },
+                                  "secretAccessKeySecretRef": {
+                                    "description": "The SecretAccessKey is used for authentication. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "region"
+                                ],
+                                "type": "object"
+                              },
+                              "webhook": {
+                                "description": "Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.",
+                                "properties": {
+                                  "config": {
+                                    "description": "Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "groupName": {
+                                    "description": "The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.",
+                                    "type": "string"
+                                  },
+                                  "solverName": {
+                                    "description": "The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "groupName",
+                                  "solverName"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "http01": {
+                            "description": "Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.",
+                            "properties": {
+                              "gatewayHTTPRoute": {
+                                "description": "The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.",
+                                "properties": {
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.",
+                                    "type": "object"
+                                  },
+                                  "parentRefs": {
+                                    "description": "When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways",
+                                    "items": {
+                                      "description": "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object.",
+                                      "properties": {
+                                        "group": {
+                                          "default": "gateway.networking.k8s.io",
+                                          "description": "Group is the group of the referent. \n Support: Core",
+                                          "maxLength": 253,
+                                          "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                          "type": "string"
+                                        },
+                                        "kind": {
+                                          "default": "Gateway",
+                                          "description": "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)",
+                                          "maxLength": 63,
+                                          "minLength": 1,
+                                          "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name is the name of the referent. \n Support: Core",
+                                          "maxLength": 253,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "description": "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core",
+                                          "maxLength": 63,
+                                          "minLength": 1,
+                                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                          "type": "string"
+                                        },
+                                        "sectionName": {
+                                          "description": "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core",
+                                          "maxLength": 253,
+                                          "minLength": 1,
+                                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "serviceType": {
+                                    "description": "Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "ingress": {
+                                "description": "The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.",
+                                "properties": {
+                                  "class": {
+                                    "description": "The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.",
+                                    "type": "string"
+                                  },
+                                  "ingressTemplate": {
+                                    "description": "Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.",
+                                    "properties": {
+                                      "metadata": {
+                                        "description": "ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.",
+                                        "properties": {
+                                          "annotations": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "Annotations that should be added to the created ACME HTTP01 solver ingress.",
+                                            "type": "object"
+                                          },
+                                          "labels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "Labels that should be added to the created ACME HTTP01 solver ingress.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "name": {
+                                    "description": "The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.",
+                                    "type": "string"
+                                  },
+                                  "podTemplate": {
+                                    "description": "Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.",
+                                    "properties": {
+                                      "metadata": {
+                                        "description": "ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.",
+                                        "properties": {
+                                          "annotations": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "Annotations that should be added to the create ACME HTTP01 solver pods.",
+                                            "type": "object"
+                                          },
+                                          "labels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "Labels that should be added to the created ACME HTTP01 solver pods.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "spec": {
+                                        "description": "PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.",
+                                        "properties": {
+                                          "affinity": {
+                                            "description": "If specified, the pod's scheduling constraints",
+                                            "properties": {
+                                              "nodeAffinity": {
+                                                "description": "Describes node affinity scheduling rules for the pod.",
+                                                "properties": {
+                                                  "preferredDuringSchedulingIgnoredDuringExecution": {
+                                                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                                    "items": {
+                                                      "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                                      "properties": {
+                                                        "preference": {
+                                                          "description": "A node selector term, associated with the corresponding weight.",
+                                                          "properties": {
+                                                            "matchExpressions": {
+                                                              "description": "A list of node selector requirements by node's labels.",
+                                                              "items": {
+                                                                "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                "properties": {
+                                                                  "key": {
+                                                                    "description": "The label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "operator": {
+                                                                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "values": {
+                                                                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "key",
+                                                                  "operator"
+                                                                ],
+                                                                "type": "object"
+                                                              },
+                                                              "type": "array"
+                                                            },
+                                                            "matchFields": {
+                                                              "description": "A list of node selector requirements by node's fields.",
+                                                              "items": {
+                                                                "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                "properties": {
+                                                                  "key": {
+                                                                    "description": "The label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "operator": {
+                                                                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "values": {
+                                                                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "key",
+                                                                  "operator"
+                                                                ],
+                                                                "type": "object"
+                                                              },
+                                                              "type": "array"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "weight": {
+                                                          "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                                          "format": "int32",
+                                                          "type": "integer"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "preference",
+                                                        "weight"
+                                                      ],
+                                                      "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                    "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                                    "properties": {
+                                                      "nodeSelectorTerms": {
+                                                        "description": "Required. A list of node selector terms. The terms are ORed.",
+                                                        "items": {
+                                                          "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                                          "properties": {
+                                                            "matchExpressions": {
+                                                              "description": "A list of node selector requirements by node's labels.",
+                                                              "items": {
+                                                                "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                "properties": {
+                                                                  "key": {
+                                                                    "description": "The label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "operator": {
+                                                                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "values": {
+                                                                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "key",
+                                                                  "operator"
+                                                                ],
+                                                                "type": "object"
+                                                              },
+                                                              "type": "array"
+                                                            },
+                                                            "matchFields": {
+                                                              "description": "A list of node selector requirements by node's fields.",
+                                                              "items": {
+                                                                "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                "properties": {
+                                                                  "key": {
+                                                                    "description": "The label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "operator": {
+                                                                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "values": {
+                                                                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "key",
+                                                                  "operator"
+                                                                ],
+                                                                "type": "object"
+                                                              },
+                                                              "type": "array"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "nodeSelectorTerms"
+                                                    ],
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "podAffinity": {
+                                                "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                                                "properties": {
+                                                  "preferredDuringSchedulingIgnoredDuringExecution": {
+                                                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                                    "items": {
+                                                      "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                                      "properties": {
+                                                        "podAffinityTerm": {
+                                                          "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                          "properties": {
+                                                            "labelSelector": {
+                                                              "description": "A label query over a set of resources, in this case pods.",
+                                                              "properties": {
+                                                                "matchExpressions": {
+                                                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                  "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                    "properties": {
+                                                                      "key": {
+                                                                        "description": "key is the label key that the selector applies to.",
+                                                                        "type": "string"
+                                                                      },
+                                                                      "operator": {
+                                                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                        "type": "string"
+                                                                      },
+                                                                      "values": {
+                                                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                        "items": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "type": "array"
+                                                                      }
+                                                                    },
+                                                                    "required": [
+                                                                      "key",
+                                                                      "operator"
+                                                                    ],
+                                                                    "type": "object"
+                                                                  },
+                                                                  "type": "array"
+                                                                },
+                                                                "matchLabels": {
+                                                                  "additionalProperties": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                  "type": "object"
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            "namespaceSelector": {
+                                                              "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                              "properties": {
+                                                                "matchExpressions": {
+                                                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                  "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                    "properties": {
+                                                                      "key": {
+                                                                        "description": "key is the label key that the selector applies to.",
+                                                                        "type": "string"
+                                                                      },
+                                                                      "operator": {
+                                                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                        "type": "string"
+                                                                      },
+                                                                      "values": {
+                                                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                        "items": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "type": "array"
+                                                                      }
+                                                                    },
+                                                                    "required": [
+                                                                      "key",
+                                                                      "operator"
+                                                                    ],
+                                                                    "type": "object"
+                                                                  },
+                                                                  "type": "array"
+                                                                },
+                                                                "matchLabels": {
+                                                                  "additionalProperties": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                  "type": "object"
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            "namespaces": {
+                                                              "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                              "items": {
+                                                                "type": "string"
+                                                              },
+                                                              "type": "array"
+                                                            },
+                                                            "topologyKey": {
+                                                              "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "topologyKey"
+                                                          ],
+                                                          "type": "object"
+                                                        },
+                                                        "weight": {
+                                                          "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                                          "format": "int32",
+                                                          "type": "integer"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "podAffinityTerm",
+                                                        "weight"
+                                                      ],
+                                                      "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                    "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                                    "items": {
+                                                      "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \u003ctopologyKey\u003e matches that of any node on which a pod of the set of pods is running",
+                                                      "properties": {
+                                                        "labelSelector": {
+                                                          "description": "A label query over a set of resources, in this case pods.",
+                                                          "properties": {
+                                                            "matchExpressions": {
+                                                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                              "items": {
+                                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                "properties": {
+                                                                  "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "key",
+                                                                  "operator"
+                                                                ],
+                                                                "type": "object"
+                                                              },
+                                                              "type": "array"
+                                                            },
+                                                            "matchLabels": {
+                                                              "additionalProperties": {
+                                                                "type": "string"
+                                                              },
+                                                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                              "type": "object"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "namespaceSelector": {
+                                                          "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                          "properties": {
+                                                            "matchExpressions": {
+                                                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                              "items": {
+                                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                "properties": {
+                                                                  "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "key",
+                                                                  "operator"
+                                                                ],
+                                                                "type": "object"
+                                                              },
+                                                              "type": "array"
+                                                            },
+                                                            "matchLabels": {
+                                                              "additionalProperties": {
+                                                                "type": "string"
+                                                              },
+                                                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                              "type": "object"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "namespaces": {
+                                                          "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "topologyKey": {
+                                                          "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "topologyKey"
+                                                      ],
+                                                      "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "podAntiAffinity": {
+                                                "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                                                "properties": {
+                                                  "preferredDuringSchedulingIgnoredDuringExecution": {
+                                                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                                    "items": {
+                                                      "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                                      "properties": {
+                                                        "podAffinityTerm": {
+                                                          "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                          "properties": {
+                                                            "labelSelector": {
+                                                              "description": "A label query over a set of resources, in this case pods.",
+                                                              "properties": {
+                                                                "matchExpressions": {
+                                                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                  "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                    "properties": {
+                                                                      "key": {
+                                                                        "description": "key is the label key that the selector applies to.",
+                                                                        "type": "string"
+                                                                      },
+                                                                      "operator": {
+                                                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                        "type": "string"
+                                                                      },
+                                                                      "values": {
+                                                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                        "items": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "type": "array"
+                                                                      }
+                                                                    },
+                                                                    "required": [
+                                                                      "key",
+                                                                      "operator"
+                                                                    ],
+                                                                    "type": "object"
+                                                                  },
+                                                                  "type": "array"
+                                                                },
+                                                                "matchLabels": {
+                                                                  "additionalProperties": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                  "type": "object"
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            "namespaceSelector": {
+                                                              "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                              "properties": {
+                                                                "matchExpressions": {
+                                                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                  "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                    "properties": {
+                                                                      "key": {
+                                                                        "description": "key is the label key that the selector applies to.",
+                                                                        "type": "string"
+                                                                      },
+                                                                      "operator": {
+                                                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                        "type": "string"
+                                                                      },
+                                                                      "values": {
+                                                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                        "items": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "type": "array"
+                                                                      }
+                                                                    },
+                                                                    "required": [
+                                                                      "key",
+                                                                      "operator"
+                                                                    ],
+                                                                    "type": "object"
+                                                                  },
+                                                                  "type": "array"
+                                                                },
+                                                                "matchLabels": {
+                                                                  "additionalProperties": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                  "type": "object"
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            "namespaces": {
+                                                              "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                              "items": {
+                                                                "type": "string"
+                                                              },
+                                                              "type": "array"
+                                                            },
+                                                            "topologyKey": {
+                                                              "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "topologyKey"
+                                                          ],
+                                                          "type": "object"
+                                                        },
+                                                        "weight": {
+                                                          "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                                          "format": "int32",
+                                                          "type": "integer"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "podAffinityTerm",
+                                                        "weight"
+                                                      ],
+                                                      "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                    "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                                    "items": {
+                                                      "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \u003ctopologyKey\u003e matches that of any node on which a pod of the set of pods is running",
+                                                      "properties": {
+                                                        "labelSelector": {
+                                                          "description": "A label query over a set of resources, in this case pods.",
+                                                          "properties": {
+                                                            "matchExpressions": {
+                                                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                              "items": {
+                                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                "properties": {
+                                                                  "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "key",
+                                                                  "operator"
+                                                                ],
+                                                                "type": "object"
+                                                              },
+                                                              "type": "array"
+                                                            },
+                                                            "matchLabels": {
+                                                              "additionalProperties": {
+                                                                "type": "string"
+                                                              },
+                                                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                              "type": "object"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "namespaceSelector": {
+                                                          "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                          "properties": {
+                                                            "matchExpressions": {
+                                                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                              "items": {
+                                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                "properties": {
+                                                                  "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "key",
+                                                                  "operator"
+                                                                ],
+                                                                "type": "object"
+                                                              },
+                                                              "type": "array"
+                                                            },
+                                                            "matchLabels": {
+                                                              "additionalProperties": {
+                                                                "type": "string"
+                                                              },
+                                                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                              "type": "object"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "namespaces": {
+                                                          "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "topologyKey": {
+                                                          "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "topologyKey"
+                                                      ],
+                                                      "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "nodeSelector": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+                                            "type": "object"
+                                          },
+                                          "priorityClassName": {
+                                            "description": "If specified, the pod's priorityClassName.",
+                                            "type": "string"
+                                          },
+                                          "serviceAccountName": {
+                                            "description": "If specified, the pod's service account",
+                                            "type": "string"
+                                          },
+                                          "tolerations": {
+                                            "description": "If specified, the pod's tolerations.",
+                                            "items": {
+                                              "description": "The pod this Toleration is attached to tolerates any taint that matches the triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
+                                              "properties": {
+                                                "effect": {
+                                                  "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                                  "type": "string"
+                                                },
+                                                "key": {
+                                                  "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                                  "type": "string"
+                                                },
+                                                "tolerationSeconds": {
+                                                  "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                                  "format": "int64",
+                                                  "type": "integer"
+                                                },
+                                                "value": {
+                                                  "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "serviceType": {
+                                    "description": "Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "selector": {
+                            "description": "Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.",
+                            "properties": {
+                              "dnsNames": {
+                                "description": "List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "dnsZones": {
+                                "description": "List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "A label selector that is used to refine the set of certificate's that this challenge solver will apply to.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "token": {
+                        "description": "The ACME challenge token for this challenge. This is the raw value returned from the ACME server.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "The type of ACME challenge this resource represents. One of \"HTTP-01\" or \"DNS-01\".",
+                        "enum": [
+                          "HTTP-01",
+                          "DNS-01"
+                        ],
+                        "type": "string"
+                      },
+                      "url": {
+                        "description": "The URL of the ACME Challenge resource for this challenge. This can be used to lookup details about the status of this challenge.",
+                        "type": "string"
+                      },
+                      "wildcard": {
+                        "description": "wildcard will be true if this challenge is for a wildcard identifier, for example '*.example.com'.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "authorizationURL",
+                      "dnsName",
+                      "issuerRef",
+                      "key",
+                      "solver",
+                      "token",
+                      "type",
+                      "url"
+                    ],
+                    "type": "object"
+                  },
+                  "status": {
+                    "properties": {
+                      "presented": {
+                        "description": "presented will be set to true if the challenge values for this challenge are currently 'presented'. This *does not* imply the self check is passing. Only that the values have been 'submitted' for the appropriate challenge mechanism (i.e. the DNS01 TXT record has been presented, or the HTTP01 configuration has been configured).",
+                        "type": "boolean"
+                      },
+                      "processing": {
+                        "description": "Used to denote whether this challenge should be processed or not. This field will only be set to true by the 'scheduling' component. It will only be set to false by the 'challenges' controller, after the challenge has reached a final state or timed out. If this field is set to false, the challenge controller will not take any more action.",
+                        "type": "boolean"
+                      },
+                      "reason": {
+                        "description": "Contains human readable information on why the Challenge is in the current state.",
+                        "type": "string"
+                      },
+                      "state": {
+                        "description": "Contains the current 'state' of the challenge. If not set, the state of the challenge is unknown.",
+                        "enum": [
+                          "valid",
+                          "ready",
+                          "pending",
+                          "processing",
+                          "invalid",
+                          "expired",
+                          "errored"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "metadata",
+                  "spec"
+                ],
+                "type": "object"
+              }
+            },
+            "served": true,
+            "storage": true,
+            "subresources": {
+              "status": {}
+            }
+          }
+        ]
+      },
+      "status": {
+        "acceptedNames": {
+          "categories": [
+            "cert-manager",
+            "cert-manager-acme"
+          ],
+          "kind": "Challenge",
+          "listKind": "ChallengeList",
+          "plural": "challenges",
+          "singular": "challenge"
+        },
+        "conditions": [
+          {
+            "lastTransitionTime": "2022-11-17T16:09:59Z",
+            "message": "no conflicts found",
+            "reason": "NoConflicts",
+            "status": "True",
+            "type": "NamesAccepted"
+          },
+          {
+            "lastTransitionTime": "2022-11-17T16:09:59Z",
+            "message": "the initial names have been accepted",
+            "reason": "InitialNamesAccepted",
+            "status": "True",
+            "type": "Established"
+          }
+        ],
+        "storedVersions": [
+          "v1"
+        ]
+      }
+    },
+    {
+      "apiVersion": "apiextensions.k8s.io/v1",
+      "kind": "CustomResourceDefinition",
+      "metadata": {
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apiextensions.k8s.io/v1\",\"kind\":\"CustomResourceDefinition\",\"metadata\":{\"annotations\":{\"operator.jetstack.io/component\":\"cert-manager\",\"operator.jetstack.io/component-version\":\"v1.9.1\"},\"creationTimestamp\":\"2022-11-11T15:53:16Z\",\"finalizers\":[\"operator.jetstack.io/crd-controller\"],\"generation\":1,\"labels\":{\"app\":\"cert-manager\",\"app.kubernetes.io/instance\":\"cert-manager\",\"app.kubernetes.io/name\":\"cert-manager\",\"app.kubernetes.io/version\":\"v1.9.1\"},\"name\":\"clusterissuers.cert-manager.io\",\"ownerReferences\":[{\"apiVersion\":\"operator.jetstack.io/v1alpha1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"Installation\",\"name\":\"installation\",\"uid\":\"36ea7a42-2dfa-48de-b3bc-acb8d9c29f6d\"}],\"resourceVersion\":\"1320\",\"uid\":\"b274e4b7-0bba-4d3d-a0fe-c8b1c8a558a1\"},\"spec\":{\"conversion\":{\"strategy\":\"None\"},\"group\":\"cert-manager.io\",\"names\":{\"categories\":[\"cert-manager\"],\"kind\":\"ClusterIssuer\",\"listKind\":\"ClusterIssuerList\",\"plural\":\"clusterissuers\",\"singular\":\"clusterissuer\"},\"scope\":\"Cluster\",\"versions\":[{\"additionalPrinterColumns\":[{\"jsonPath\":\".status.conditions[?(@.type==\\\"Ready\\\")].status\",\"name\":\"Ready\",\"type\":\"string\"},{\"jsonPath\":\".status.conditions[?(@.type==\\\"Ready\\\")].message\",\"name\":\"Status\",\"priority\":1,\"type\":\"string\"},{\"description\":\"CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\",\"jsonPath\":\".metadata.creationTimestamp\",\"name\":\"Age\",\"type\":\"date\"}],\"name\":\"v1\",\"schema\":{\"openAPIV3Schema\":{\"description\":\"A ClusterIssuer represents a certificate issuing authority which can be referenced as part of `issuerRef` fields. It is similar to an Issuer, however it is cluster-scoped and therefore can be referenced by resources that exist in *any* namespace, not just the same namespace as the referent.\",\"properties\":{\"apiVersion\":{\"description\":\"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources\",\"type\":\"string\"},\"kind\":{\"description\":\"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds\",\"type\":\"string\"},\"metadata\":{\"type\":\"object\"},\"spec\":{\"description\":\"Desired state of the ClusterIssuer resource.\",\"properties\":{\"acme\":{\"description\":\"ACME configures this issuer to communicate with a RFC8555 (ACME) server to obtain signed x509 certificates.\",\"properties\":{\"disableAccountKeyGeneration\":{\"description\":\"Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.\",\"type\":\"boolean\"},\"email\":{\"description\":\"Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.\",\"type\":\"string\"},\"enableDurationFeature\":{\"description\":\"Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.\",\"type\":\"boolean\"},\"externalAccountBinding\":{\"description\":\"ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.\",\"properties\":{\"keyAlgorithm\":{\"description\":\"Deprecated: keyAlgorithm field exists for historical compatibility reasons and should not be used. The algorithm is now hardcoded to HS256 in golang/x/crypto/acme.\",\"enum\":[\"HS256\",\"HS384\",\"HS512\"],\"type\":\"string\"},\"keyID\":{\"description\":\"keyID is the ID of the CA key that the External Account is bound to.\",\"type\":\"string\"},\"keySecretRef\":{\"description\":\"keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes Secret which holds the symmetric MAC key of the External Account Binding. The `key` is the index string that is paired with the key data in the Secret and should not be confused with the key data itself, or indeed with the External Account Binding keyID above. The secret key stored in the Secret **must** be un-padded, base64 URL encoded data.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"required\":[\"keyID\",\"keySecretRef\"],\"type\":\"object\"},\"preferredChain\":{\"description\":\"PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let's Encrypt's DST crosssign you would use: \\\"DST Root CA X3\\\" or \\\"ISRG Root X1\\\" for the newer Let's Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer's CN\",\"maxLength\":64,\"type\":\"string\"},\"privateKeySecretRef\":{\"description\":\"PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"server\":{\"description\":\"Server is the URL used to access the ACME server's 'directory' endpoint. For example, for Let's Encrypt's staging endpoint, you would use: \\\"https://acme-staging-v02.api.letsencrypt.org/directory\\\". Only ACME v2 endpoints (i.e. RFC 8555) are supported.\",\"type\":\"string\"},\"skipTLSVerify\":{\"description\":\"Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have their TLS certificate validated (i.e. insecure connections will be allowed). Only enable this option in development environments. The cert-manager system installed roots will be used to verify connections to the ACME server if this is false. Defaults to false.\",\"type\":\"boolean\"},\"solvers\":{\"description\":\"Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/\",\"items\":{\"description\":\"An ACMEChallengeSolver describes how to solve ACME challenges for the issuer it is part of. A selector may be provided to use different solving strategies for different DNS names. Only one of HTTP01 or DNS01 must be provided.\",\"properties\":{\"dns01\":{\"description\":\"Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.\",\"properties\":{\"acmeDNS\":{\"description\":\"Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.\",\"properties\":{\"accountSecretRef\":{\"description\":\"A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"host\":{\"type\":\"string\"}},\"required\":[\"accountSecretRef\",\"host\"],\"type\":\"object\"},\"akamai\":{\"description\":\"Use the Akamai DNS zone management API to manage DNS01 challenge records.\",\"properties\":{\"accessTokenSecretRef\":{\"description\":\"A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"clientSecretSecretRef\":{\"description\":\"A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"clientTokenSecretRef\":{\"description\":\"A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"serviceConsumerDomain\":{\"type\":\"string\"}},\"required\":[\"accessTokenSecretRef\",\"clientSecretSecretRef\",\"clientTokenSecretRef\",\"serviceConsumerDomain\"],\"type\":\"object\"},\"azureDNS\":{\"description\":\"Use the Microsoft Azure DNS API to manage DNS01 challenge records.\",\"properties\":{\"clientID\":{\"description\":\"if both this and ClientSecret are left unset MSI will be used\",\"type\":\"string\"},\"clientSecretSecretRef\":{\"description\":\"if both this and ClientID are left unset MSI will be used\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"environment\":{\"description\":\"name of the Azure environment (default AzurePublicCloud)\",\"enum\":[\"AzurePublicCloud\",\"AzureChinaCloud\",\"AzureGermanCloud\",\"AzureUSGovernmentCloud\"],\"type\":\"string\"},\"hostedZoneName\":{\"description\":\"name of the DNS zone that should be used\",\"type\":\"string\"},\"managedIdentity\":{\"description\":\"managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID\",\"properties\":{\"clientID\":{\"description\":\"client ID of the managed identity, can not be used at the same time as resourceID\",\"type\":\"string\"},\"resourceID\":{\"description\":\"resource ID of the managed identity, can not be used at the same time as clientID\",\"type\":\"string\"}},\"type\":\"object\"},\"resourceGroupName\":{\"description\":\"resource group the DNS zone is located in\",\"type\":\"string\"},\"subscriptionID\":{\"description\":\"ID of the Azure subscription\",\"type\":\"string\"},\"tenantID\":{\"description\":\"when specifying ClientID and ClientSecret then this field is also needed\",\"type\":\"string\"}},\"required\":[\"resourceGroupName\",\"subscriptionID\"],\"type\":\"object\"},\"cloudDNS\":{\"description\":\"Use the Google Cloud DNS API to manage DNS01 challenge records.\",\"properties\":{\"hostedZoneName\":{\"description\":\"HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.\",\"type\":\"string\"},\"project\":{\"type\":\"string\"},\"serviceAccountSecretRef\":{\"description\":\"A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"required\":[\"project\"],\"type\":\"object\"},\"cloudflare\":{\"description\":\"Use the Cloudflare API to manage DNS01 challenge records.\",\"properties\":{\"apiKeySecretRef\":{\"description\":\"API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"apiTokenSecretRef\":{\"description\":\"API token used to authenticate with Cloudflare.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"email\":{\"description\":\"Email of the account, only required when using API key based authentication.\",\"type\":\"string\"}},\"type\":\"object\"},\"cnameStrategy\":{\"description\":\"CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.\",\"enum\":[\"None\",\"Follow\"],\"type\":\"string\"},\"digitalocean\":{\"description\":\"Use the DigitalOcean DNS API to manage DNS01 challenge records.\",\"properties\":{\"tokenSecretRef\":{\"description\":\"A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"required\":[\"tokenSecretRef\"],\"type\":\"object\"},\"rfc2136\":{\"description\":\"Use RFC2136 (\\\"Dynamic Updates in the Domain Name System\\\") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.\",\"properties\":{\"nameserver\":{\"description\":\"The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.\",\"type\":\"string\"},\"tsigAlgorithm\":{\"description\":\"The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.\",\"type\":\"string\"},\"tsigKeyName\":{\"description\":\"The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.\",\"type\":\"string\"},\"tsigSecretSecretRef\":{\"description\":\"The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"required\":[\"nameserver\"],\"type\":\"object\"},\"route53\":{\"description\":\"Use the AWS Route53 API to manage DNS01 challenge records.\",\"properties\":{\"accessKeyID\":{\"description\":\"The AccessKeyID is used for authentication. Cannot be set when SecretAccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials\",\"type\":\"string\"},\"accessKeyIDSecretRef\":{\"description\":\"The SecretAccessKey is used for authentication. If set, pull the AWS access key ID from a key within a Kubernetes Secret. Cannot be set when AccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"hostedZoneID\":{\"description\":\"If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.\",\"type\":\"string\"},\"region\":{\"description\":\"Always set the region when using AccessKeyID and SecretAccessKey\",\"type\":\"string\"},\"role\":{\"description\":\"Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata\",\"type\":\"string\"},\"secretAccessKeySecretRef\":{\"description\":\"The SecretAccessKey is used for authentication. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"required\":[\"region\"],\"type\":\"object\"},\"webhook\":{\"description\":\"Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.\",\"properties\":{\"config\":{\"description\":\"Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.\",\"x-kubernetes-preserve-unknown-fields\":true},\"groupName\":{\"description\":\"The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.\",\"type\":\"string\"},\"solverName\":{\"description\":\"The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.\",\"type\":\"string\"}},\"required\":[\"groupName\",\"solverName\"],\"type\":\"object\"}},\"type\":\"object\"},\"http01\":{\"description\":\"Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.\",\"properties\":{\"gatewayHTTPRoute\":{\"description\":\"The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.\",\"properties\":{\"labels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.\",\"type\":\"object\"},\"parentRefs\":{\"description\":\"When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways\",\"items\":{\"description\":\"ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \\\"Core\\\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \\n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \\n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object.\",\"properties\":{\"group\":{\"default\":\"gateway.networking.k8s.io\",\"description\":\"Group is the group of the referent. \\n Support: Core\",\"maxLength\":253,\"pattern\":\"^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$\",\"type\":\"string\"},\"kind\":{\"default\":\"Gateway\",\"description\":\"Kind is kind of the referent. \\n Support: Core (Gateway) Support: Custom (Other Resources)\",\"maxLength\":63,\"minLength\":1,\"pattern\":\"^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$\",\"type\":\"string\"},\"name\":{\"description\":\"Name is the name of the referent. \\n Support: Core\",\"maxLength\":253,\"minLength\":1,\"type\":\"string\"},\"namespace\":{\"description\":\"Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \\n Support: Core\",\"maxLength\":63,\"minLength\":1,\"pattern\":\"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$\",\"type\":\"string\"},\"sectionName\":{\"description\":\"SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \\n * Gateway: Listener Name \\n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \\n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \\n Support: Core\",\"maxLength\":253,\"minLength\":1,\"pattern\":\"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"type\":\"array\"},\"serviceType\":{\"description\":\"Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.\",\"type\":\"string\"}},\"type\":\"object\"},\"ingress\":{\"description\":\"The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.\",\"properties\":{\"class\":{\"description\":\"The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.\",\"type\":\"string\"},\"ingressTemplate\":{\"description\":\"Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.\",\"properties\":{\"metadata\":{\"description\":\"ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.\",\"properties\":{\"annotations\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"Annotations that should be added to the created ACME HTTP01 solver ingress.\",\"type\":\"object\"},\"labels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"Labels that should be added to the created ACME HTTP01 solver ingress.\",\"type\":\"object\"}},\"type\":\"object\"}},\"type\":\"object\"},\"name\":{\"description\":\"The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.\",\"type\":\"string\"},\"podTemplate\":{\"description\":\"Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.\",\"properties\":{\"metadata\":{\"description\":\"ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.\",\"properties\":{\"annotations\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"Annotations that should be added to the create ACME HTTP01 solver pods.\",\"type\":\"object\"},\"labels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"Labels that should be added to the created ACME HTTP01 solver pods.\",\"type\":\"object\"}},\"type\":\"object\"},\"spec\":{\"description\":\"PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.\",\"properties\":{\"affinity\":{\"description\":\"If specified, the pod's scheduling constraints\",\"properties\":{\"nodeAffinity\":{\"description\":\"Describes node affinity scheduling rules for the pod.\",\"properties\":{\"preferredDuringSchedulingIgnoredDuringExecution\":{\"description\":\"The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\\"weight\\\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.\",\"items\":{\"description\":\"An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).\",\"properties\":{\"preference\":{\"description\":\"A node selector term, associated with the corresponding weight.\",\"properties\":{\"matchExpressions\":{\"description\":\"A list of node selector requirements by node's labels.\",\"items\":{\"description\":\"A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"The label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.\",\"type\":\"string\"},\"values\":{\"description\":\"An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchFields\":{\"description\":\"A list of node selector requirements by node's fields.\",\"items\":{\"description\":\"A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"The label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.\",\"type\":\"string\"},\"values\":{\"description\":\"An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"}},\"type\":\"object\"},\"weight\":{\"description\":\"Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.\",\"format\":\"int32\",\"type\":\"integer\"}},\"required\":[\"preference\",\"weight\"],\"type\":\"object\"},\"type\":\"array\"},\"requiredDuringSchedulingIgnoredDuringExecution\":{\"description\":\"If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.\",\"properties\":{\"nodeSelectorTerms\":{\"description\":\"Required. A list of node selector terms. The terms are ORed.\",\"items\":{\"description\":\"A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.\",\"properties\":{\"matchExpressions\":{\"description\":\"A list of node selector requirements by node's labels.\",\"items\":{\"description\":\"A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"The label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.\",\"type\":\"string\"},\"values\":{\"description\":\"An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchFields\":{\"description\":\"A list of node selector requirements by node's fields.\",\"items\":{\"description\":\"A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"The label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.\",\"type\":\"string\"},\"values\":{\"description\":\"An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"}},\"type\":\"object\"},\"type\":\"array\"}},\"required\":[\"nodeSelectorTerms\"],\"type\":\"object\"}},\"type\":\"object\"},\"podAffinity\":{\"description\":\"Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).\",\"properties\":{\"preferredDuringSchedulingIgnoredDuringExecution\":{\"description\":\"The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\\"weight\\\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.\",\"items\":{\"description\":\"The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)\",\"properties\":{\"podAffinityTerm\":{\"description\":\"Required. A pod affinity term, associated with the corresponding weight.\",\"properties\":{\"labelSelector\":{\"description\":\"A label query over a set of resources, in this case pods.\",\"properties\":{\"matchExpressions\":{\"description\":\"matchExpressions is a list of label selector requirements. The requirements are ANDed.\",\"items\":{\"description\":\"A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"key is the label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\",\"type\":\"string\"},\"values\":{\"description\":\"values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\\"key\\\", the operator is \\\"In\\\", and the values array contains only \\\"value\\\". The requirements are ANDed.\",\"type\":\"object\"}},\"type\":\"object\"},\"namespaceSelector\":{\"description\":\"A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \\\"this pod's namespace\\\". An empty selector ({}) matches all namespaces.\",\"properties\":{\"matchExpressions\":{\"description\":\"matchExpressions is a list of label selector requirements. The requirements are ANDed.\",\"items\":{\"description\":\"A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"key is the label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\",\"type\":\"string\"},\"values\":{\"description\":\"values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\\"key\\\", the operator is \\\"In\\\", and the values array contains only \\\"value\\\". The requirements are ANDed.\",\"type\":\"object\"}},\"type\":\"object\"},\"namespaces\":{\"description\":\"namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\\"this pod's namespace\\\".\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"topologyKey\":{\"description\":\"This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.\",\"type\":\"string\"}},\"required\":[\"topologyKey\"],\"type\":\"object\"},\"weight\":{\"description\":\"weight associated with matching the corresponding podAffinityTerm, in the range 1-100.\",\"format\":\"int32\",\"type\":\"integer\"}},\"required\":[\"podAffinityTerm\",\"weight\"],\"type\":\"object\"},\"type\":\"array\"},\"requiredDuringSchedulingIgnoredDuringExecution\":{\"description\":\"If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.\",\"items\":{\"description\":\"Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \\u003ctopologyKey\\u003e matches that of any node on which a pod of the set of pods is running\",\"properties\":{\"labelSelector\":{\"description\":\"A label query over a set of resources, in this case pods.\",\"properties\":{\"matchExpressions\":{\"description\":\"matchExpressions is a list of label selector requirements. The requirements are ANDed.\",\"items\":{\"description\":\"A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"key is the label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\",\"type\":\"string\"},\"values\":{\"description\":\"values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\\"key\\\", the operator is \\\"In\\\", and the values array contains only \\\"value\\\". The requirements are ANDed.\",\"type\":\"object\"}},\"type\":\"object\"},\"namespaceSelector\":{\"description\":\"A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \\\"this pod's namespace\\\". An empty selector ({}) matches all namespaces.\",\"properties\":{\"matchExpressions\":{\"description\":\"matchExpressions is a list of label selector requirements. The requirements are ANDed.\",\"items\":{\"description\":\"A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"key is the label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\",\"type\":\"string\"},\"values\":{\"description\":\"values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\\"key\\\", the operator is \\\"In\\\", and the values array contains only \\\"value\\\". The requirements are ANDed.\",\"type\":\"object\"}},\"type\":\"object\"},\"namespaces\":{\"description\":\"namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\\"this pod's namespace\\\".\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"topologyKey\":{\"description\":\"This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.\",\"type\":\"string\"}},\"required\":[\"topologyKey\"],\"type\":\"object\"},\"type\":\"array\"}},\"type\":\"object\"},\"podAntiAffinity\":{\"description\":\"Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).\",\"properties\":{\"preferredDuringSchedulingIgnoredDuringExecution\":{\"description\":\"The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\\"weight\\\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.\",\"items\":{\"description\":\"The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)\",\"properties\":{\"podAffinityTerm\":{\"description\":\"Required. A pod affinity term, associated with the corresponding weight.\",\"properties\":{\"labelSelector\":{\"description\":\"A label query over a set of resources, in this case pods.\",\"properties\":{\"matchExpressions\":{\"description\":\"matchExpressions is a list of label selector requirements. The requirements are ANDed.\",\"items\":{\"description\":\"A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"key is the label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\",\"type\":\"string\"},\"values\":{\"description\":\"values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\\"key\\\", the operator is \\\"In\\\", and the values array contains only \\\"value\\\". The requirements are ANDed.\",\"type\":\"object\"}},\"type\":\"object\"},\"namespaceSelector\":{\"description\":\"A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \\\"this pod's namespace\\\". An empty selector ({}) matches all namespaces.\",\"properties\":{\"matchExpressions\":{\"description\":\"matchExpressions is a list of label selector requirements. The requirements are ANDed.\",\"items\":{\"description\":\"A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"key is the label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\",\"type\":\"string\"},\"values\":{\"description\":\"values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\\"key\\\", the operator is \\\"In\\\", and the values array contains only \\\"value\\\". The requirements are ANDed.\",\"type\":\"object\"}},\"type\":\"object\"},\"namespaces\":{\"description\":\"namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\\"this pod's namespace\\\".\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"topologyKey\":{\"description\":\"This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.\",\"type\":\"string\"}},\"required\":[\"topologyKey\"],\"type\":\"object\"},\"weight\":{\"description\":\"weight associated with matching the corresponding podAffinityTerm, in the range 1-100.\",\"format\":\"int32\",\"type\":\"integer\"}},\"required\":[\"podAffinityTerm\",\"weight\"],\"type\":\"object\"},\"type\":\"array\"},\"requiredDuringSchedulingIgnoredDuringExecution\":{\"description\":\"If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.\",\"items\":{\"description\":\"Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \\u003ctopologyKey\\u003e matches that of any node on which a pod of the set of pods is running\",\"properties\":{\"labelSelector\":{\"description\":\"A label query over a set of resources, in this case pods.\",\"properties\":{\"matchExpressions\":{\"description\":\"matchExpressions is a list of label selector requirements. The requirements are ANDed.\",\"items\":{\"description\":\"A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"key is the label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\",\"type\":\"string\"},\"values\":{\"description\":\"values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\\"key\\\", the operator is \\\"In\\\", and the values array contains only \\\"value\\\". The requirements are ANDed.\",\"type\":\"object\"}},\"type\":\"object\"},\"namespaceSelector\":{\"description\":\"A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \\\"this pod's namespace\\\". An empty selector ({}) matches all namespaces.\",\"properties\":{\"matchExpressions\":{\"description\":\"matchExpressions is a list of label selector requirements. The requirements are ANDed.\",\"items\":{\"description\":\"A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"key is the label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\",\"type\":\"string\"},\"values\":{\"description\":\"values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\\"key\\\", the operator is \\\"In\\\", and the values array contains only \\\"value\\\". The requirements are ANDed.\",\"type\":\"object\"}},\"type\":\"object\"},\"namespaces\":{\"description\":\"namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\\"this pod's namespace\\\".\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"topologyKey\":{\"description\":\"This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.\",\"type\":\"string\"}},\"required\":[\"topologyKey\"],\"type\":\"object\"},\"type\":\"array\"}},\"type\":\"object\"}},\"type\":\"object\"},\"nodeSelector\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/\",\"type\":\"object\"},\"priorityClassName\":{\"description\":\"If specified, the pod's priorityClassName.\",\"type\":\"string\"},\"serviceAccountName\":{\"description\":\"If specified, the pod's service account\",\"type\":\"string\"},\"tolerations\":{\"description\":\"If specified, the pod's tolerations.\",\"items\":{\"description\":\"The pod this Toleration is attached to tolerates any taint that matches the triple \\u003ckey,value,effect\\u003e using the matching operator \\u003coperator\\u003e.\",\"properties\":{\"effect\":{\"description\":\"Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.\",\"type\":\"string\"},\"key\":{\"description\":\"Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.\",\"type\":\"string\"},\"operator\":{\"description\":\"Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.\",\"type\":\"string\"},\"tolerationSeconds\":{\"description\":\"TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.\",\"format\":\"int64\",\"type\":\"integer\"},\"value\":{\"description\":\"Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.\",\"type\":\"string\"}},\"type\":\"object\"},\"type\":\"array\"}},\"type\":\"object\"}},\"type\":\"object\"},\"serviceType\":{\"description\":\"Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.\",\"type\":\"string\"}},\"type\":\"object\"}},\"type\":\"object\"},\"selector\":{\"description\":\"Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.\",\"properties\":{\"dnsNames\":{\"description\":\"List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"dnsZones\":{\"description\":\"List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"A label selector that is used to refine the set of certificate's that this challenge solver will apply to.\",\"type\":\"object\"}},\"type\":\"object\"}},\"type\":\"object\"},\"type\":\"array\"}},\"required\":[\"privateKeySecretRef\",\"server\"],\"type\":\"object\"},\"ca\":{\"description\":\"CA configures this issuer to sign certificates using a signing CA keypair stored in a Secret resource. This is used to build internal PKIs that are managed by cert-manager.\",\"properties\":{\"crlDistributionPoints\":{\"description\":\"The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set, certificates will be issued without distribution points set.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"ocspServers\":{\"description\":\"The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be \\\"http://ocsp.int-x3.letsencrypt.org\\\".\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"secretName\":{\"description\":\"SecretName is the name of the secret used to sign Certificates issued by this Issuer.\",\"type\":\"string\"}},\"required\":[\"secretName\"],\"type\":\"object\"},\"selfSigned\":{\"description\":\"SelfSigned configures this issuer to 'self sign' certificates using the private key used to create the CertificateRequest object.\",\"properties\":{\"crlDistributionPoints\":{\"description\":\"The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set certificate will be issued without CDP. Values are strings.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"type\":\"object\"},\"vault\":{\"description\":\"Vault configures this issuer to sign certificates using a HashiCorp Vault PKI backend.\",\"properties\":{\"auth\":{\"description\":\"Auth configures how cert-manager authenticates with the Vault server.\",\"properties\":{\"appRole\":{\"description\":\"AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.\",\"properties\":{\"path\":{\"description\":\"Path where the App Role authentication backend is mounted in Vault, e.g: \\\"approle\\\"\",\"type\":\"string\"},\"roleId\":{\"description\":\"RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.\",\"type\":\"string\"},\"secretRef\":{\"description\":\"Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"required\":[\"path\",\"roleId\",\"secretRef\"],\"type\":\"object\"},\"kubernetes\":{\"description\":\"Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.\",\"properties\":{\"mountPath\":{\"description\":\"The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value \\\"/v1/auth/kubernetes\\\" will be used.\",\"type\":\"string\"},\"role\":{\"description\":\"A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.\",\"type\":\"string\"},\"secretRef\":{\"description\":\"The required Secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. Use of 'ambient credentials' is not supported.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"required\":[\"role\",\"secretRef\"],\"type\":\"object\"},\"tokenSecretRef\":{\"description\":\"TokenSecretRef authenticates with Vault by presenting a token.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"type\":\"object\"},\"caBundle\":{\"description\":\"PEM-encoded CA bundle (base64-encoded) used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.\",\"format\":\"byte\",\"type\":\"string\"},\"namespace\":{\"description\":\"Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: \\\"ns1\\\" More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces\",\"type\":\"string\"},\"path\":{\"description\":\"Path is the mount path of the Vault PKI backend's `sign` endpoint, e.g: \\\"my_pki_mount/sign/my-role-name\\\".\",\"type\":\"string\"},\"server\":{\"description\":\"Server is the connection address for the Vault server, e.g: \\\"https://vault.example.com:8200\\\".\",\"type\":\"string\"}},\"required\":[\"auth\",\"path\",\"server\"],\"type\":\"object\"},\"venafi\":{\"description\":\"Venafi configures this issuer to sign certificates using a Venafi TPP or Venafi Cloud policy zone.\",\"properties\":{\"cloud\":{\"description\":\"Cloud specifies the Venafi cloud configuration settings. Only one of TPP or Cloud may be specified.\",\"properties\":{\"apiTokenSecretRef\":{\"description\":\"APITokenSecretRef is a secret key selector for the Venafi Cloud API token.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"url\":{\"description\":\"URL is the base URL for Venafi Cloud. Defaults to \\\"https://api.venafi.cloud/v1\\\".\",\"type\":\"string\"}},\"required\":[\"apiTokenSecretRef\"],\"type\":\"object\"},\"tpp\":{\"description\":\"TPP specifies Trust Protection Platform configuration settings. Only one of TPP or Cloud may be specified.\",\"properties\":{\"caBundle\":{\"description\":\"CABundle is a PEM encoded TLS certificate to use to verify connections to the TPP instance. If specified, system roots will not be used and the issuing CA for the TPP instance must be verifiable using the provided root. If not specified, the connection will be verified using the cert-manager system root certificates.\",\"format\":\"byte\",\"type\":\"string\"},\"credentialsRef\":{\"description\":\"CredentialsRef is a reference to a Secret containing the username and password for the TPP server. The secret must contain two keys, 'username' and 'password'.\",\"properties\":{\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"url\":{\"description\":\"URL is the base URL for the vedsdk endpoint of the Venafi TPP instance, for example: \\\"https://tpp.example.com/vedsdk\\\".\",\"type\":\"string\"}},\"required\":[\"credentialsRef\",\"url\"],\"type\":\"object\"},\"zone\":{\"description\":\"Zone is the Venafi Policy Zone to use for this issuer. All requests made to the Venafi platform will be restricted by the named zone policy. This field is required.\",\"type\":\"string\"}},\"required\":[\"zone\"],\"type\":\"object\"}},\"type\":\"object\"},\"status\":{\"description\":\"Status of the ClusterIssuer. This is set and managed automatically.\",\"properties\":{\"acme\":{\"description\":\"ACME specific status options. This field should only be set if the Issuer is configured to use an ACME server to issue certificates.\",\"properties\":{\"lastRegisteredEmail\":{\"description\":\"LastRegisteredEmail is the email associated with the latest registered ACME account, in order to track changes made to registered account associated with the  Issuer\",\"type\":\"string\"},\"uri\":{\"description\":\"URI is the unique account identifier, which can also be used to retrieve account details from the CA\",\"type\":\"string\"}},\"type\":\"object\"},\"conditions\":{\"description\":\"List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready`.\",\"items\":{\"description\":\"IssuerCondition contains condition information for an Issuer.\",\"properties\":{\"lastTransitionTime\":{\"description\":\"LastTransitionTime is the timestamp corresponding to the last status change of this condition.\",\"format\":\"date-time\",\"type\":\"string\"},\"message\":{\"description\":\"Message is a human readable description of the details of the last transition, complementing reason.\",\"type\":\"string\"},\"observedGeneration\":{\"description\":\"If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.\",\"format\":\"int64\",\"type\":\"integer\"},\"reason\":{\"description\":\"Reason is a brief machine readable explanation for the condition's last transition.\",\"type\":\"string\"},\"status\":{\"description\":\"Status of the condition, one of (`True`, `False`, `Unknown`).\",\"enum\":[\"True\",\"False\",\"Unknown\"],\"type\":\"string\"},\"type\":{\"description\":\"Type of the condition, known values are (`Ready`).\",\"type\":\"string\"}},\"required\":[\"status\",\"type\"],\"type\":\"object\"},\"type\":\"array\",\"x-kubernetes-list-map-keys\":[\"type\"],\"x-kubernetes-list-type\":\"map\"}},\"type\":\"object\"}},\"required\":[\"spec\"],\"type\":\"object\"}},\"served\":true,\"storage\":true,\"subresources\":{\"status\":{}}}]},\"status\":{\"acceptedNames\":{\"categories\":[\"cert-manager\"],\"kind\":\"ClusterIssuer\",\"listKind\":\"ClusterIssuerList\",\"plural\":\"clusterissuers\",\"singular\":\"clusterissuer\"},\"conditions\":[{\"lastTransitionTime\":\"2022-11-11T15:53:16Z\",\"message\":\"no conflicts found\",\"reason\":\"NoConflicts\",\"status\":\"True\",\"type\":\"NamesAccepted\"},{\"lastTransitionTime\":\"2022-11-11T15:53:16Z\",\"message\":\"the initial names have been accepted\",\"reason\":\"InitialNamesAccepted\",\"status\":\"True\",\"type\":\"Established\"}],\"storedVersions\":[\"v1\"]}}\n",
+          "operator.jetstack.io/component": "cert-manager",
+          "operator.jetstack.io/component-version": "v1.9.1"
+        },
+        "creationTimestamp": "2022-11-11T15:53:16Z",
+        "deletionTimestamp": "2022-11-17T16:07:18Z",
+        "finalizers": [
+          "operator.jetstack.io/crd-controller"
+        ],
+        "generation": 1,
+        "labels": {
+          "app": "cert-manager",
+          "app.kubernetes.io/instance": "cert-manager",
+          "app.kubernetes.io/name": "cert-manager",
+          "app.kubernetes.io/version": "v1.9.1"
+        },
+        "name": "clusterissuers.cert-manager.io",
+        "ownerReferences": [
+          {
+            "apiVersion": "operator.jetstack.io/v1alpha1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Installation",
+            "name": "installation",
+            "uid": "36ea7a42-2dfa-48de-b3bc-acb8d9c29f6d"
+          }
+        ],
+        "resourceVersion": "147979",
+        "uid": "b274e4b7-0bba-4d3d-a0fe-c8b1c8a558a1"
+      },
+      "spec": {
+        "conversion": {
+          "strategy": "None"
+        },
+        "group": "cert-manager.io",
+        "names": {
+          "categories": [
+            "cert-manager"
+          ],
+          "kind": "ClusterIssuer",
+          "listKind": "ClusterIssuerList",
+          "plural": "clusterissuers",
+          "singular": "clusterissuer"
+        },
+        "scope": "Cluster",
+        "versions": [
+          {
+            "additionalPrinterColumns": [
+              {
+                "jsonPath": ".status.conditions[?(@.type==\"Ready\")].status",
+                "name": "Ready",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".status.conditions[?(@.type==\"Ready\")].message",
+                "name": "Status",
+                "priority": 1,
+                "type": "string"
+              },
+              {
+                "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.",
+                "jsonPath": ".metadata.creationTimestamp",
+                "name": "Age",
+                "type": "date"
+              }
+            ],
+            "name": "v1",
+            "schema": {
+              "openAPIV3Schema": {
+                "description": "A ClusterIssuer represents a certificate issuing authority which can be referenced as part of `issuerRef` fields. It is similar to an Issuer, however it is cluster-scoped and therefore can be referenced by resources that exist in *any* namespace, not just the same namespace as the referent.",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "type": "object"
+                  },
+                  "spec": {
+                    "description": "Desired state of the ClusterIssuer resource.",
+                    "properties": {
+                      "acme": {
+                        "description": "ACME configures this issuer to communicate with a RFC8555 (ACME) server to obtain signed x509 certificates.",
+                        "properties": {
+                          "disableAccountKeyGeneration": {
+                            "description": "Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.",
+                            "type": "boolean"
+                          },
+                          "email": {
+                            "description": "Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.",
+                            "type": "string"
+                          },
+                          "enableDurationFeature": {
+                            "description": "Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.",
+                            "type": "boolean"
+                          },
+                          "externalAccountBinding": {
+                            "description": "ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.",
+                            "properties": {
+                              "keyAlgorithm": {
+                                "description": "Deprecated: keyAlgorithm field exists for historical compatibility reasons and should not be used. The algorithm is now hardcoded to HS256 in golang/x/crypto/acme.",
+                                "enum": [
+                                  "HS256",
+                                  "HS384",
+                                  "HS512"
+                                ],
+                                "type": "string"
+                              },
+                              "keyID": {
+                                "description": "keyID is the ID of the CA key that the External Account is bound to.",
+                                "type": "string"
+                              },
+                              "keySecretRef": {
+                                "description": "keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes Secret which holds the symmetric MAC key of the External Account Binding. The `key` is the index string that is paired with the key data in the Secret and should not be confused with the key data itself, or indeed with the External Account Binding keyID above. The secret key stored in the Secret **must** be un-padded, base64 URL encoded data.",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "required": [
+                              "keyID",
+                              "keySecretRef"
+                            ],
+                            "type": "object"
+                          },
+                          "preferredChain": {
+                            "description": "PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let's Encrypt's DST crosssign you would use: \"DST Root CA X3\" or \"ISRG Root X1\" for the newer Let's Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer's CN",
+                            "maxLength": 64,
+                            "type": "string"
+                          },
+                          "privateKeySecretRef": {
+                            "description": "PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "server": {
+                            "description": "Server is the URL used to access the ACME server's 'directory' endpoint. For example, for Let's Encrypt's staging endpoint, you would use: \"https://acme-staging-v02.api.letsencrypt.org/directory\". Only ACME v2 endpoints (i.e. RFC 8555) are supported.",
+                            "type": "string"
+                          },
+                          "skipTLSVerify": {
+                            "description": "Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have their TLS certificate validated (i.e. insecure connections will be allowed). Only enable this option in development environments. The cert-manager system installed roots will be used to verify connections to the ACME server if this is false. Defaults to false.",
+                            "type": "boolean"
+                          },
+                          "solvers": {
+                            "description": "Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/",
+                            "items": {
+                              "description": "An ACMEChallengeSolver describes how to solve ACME challenges for the issuer it is part of. A selector may be provided to use different solving strategies for different DNS names. Only one of HTTP01 or DNS01 must be provided.",
+                              "properties": {
+                                "dns01": {
+                                  "description": "Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.",
+                                  "properties": {
+                                    "acmeDNS": {
+                                      "description": "Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "accountSecretRef": {
+                                          "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "host": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "accountSecretRef",
+                                        "host"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "akamai": {
+                                      "description": "Use the Akamai DNS zone management API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "accessTokenSecretRef": {
+                                          "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "clientSecretSecretRef": {
+                                          "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "clientTokenSecretRef": {
+                                          "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "serviceConsumerDomain": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "accessTokenSecretRef",
+                                        "clientSecretSecretRef",
+                                        "clientTokenSecretRef",
+                                        "serviceConsumerDomain"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "azureDNS": {
+                                      "description": "Use the Microsoft Azure DNS API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "clientID": {
+                                          "description": "if both this and ClientSecret are left unset MSI will be used",
+                                          "type": "string"
+                                        },
+                                        "clientSecretSecretRef": {
+                                          "description": "if both this and ClientID are left unset MSI will be used",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "environment": {
+                                          "description": "name of the Azure environment (default AzurePublicCloud)",
+                                          "enum": [
+                                            "AzurePublicCloud",
+                                            "AzureChinaCloud",
+                                            "AzureGermanCloud",
+                                            "AzureUSGovernmentCloud"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "hostedZoneName": {
+                                          "description": "name of the DNS zone that should be used",
+                                          "type": "string"
+                                        },
+                                        "managedIdentity": {
+                                          "description": "managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID",
+                                          "properties": {
+                                            "clientID": {
+                                              "description": "client ID of the managed identity, can not be used at the same time as resourceID",
+                                              "type": "string"
+                                            },
+                                            "resourceID": {
+                                              "description": "resource ID of the managed identity, can not be used at the same time as clientID",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "resourceGroupName": {
+                                          "description": "resource group the DNS zone is located in",
+                                          "type": "string"
+                                        },
+                                        "subscriptionID": {
+                                          "description": "ID of the Azure subscription",
+                                          "type": "string"
+                                        },
+                                        "tenantID": {
+                                          "description": "when specifying ClientID and ClientSecret then this field is also needed",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "resourceGroupName",
+                                        "subscriptionID"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "cloudDNS": {
+                                      "description": "Use the Google Cloud DNS API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "hostedZoneName": {
+                                          "description": "HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.",
+                                          "type": "string"
+                                        },
+                                        "project": {
+                                          "type": "string"
+                                        },
+                                        "serviceAccountSecretRef": {
+                                          "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [
+                                        "project"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "cloudflare": {
+                                      "description": "Use the Cloudflare API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "apiKeySecretRef": {
+                                          "description": "API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "apiTokenSecretRef": {
+                                          "description": "API token used to authenticate with Cloudflare.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "email": {
+                                          "description": "Email of the account, only required when using API key based authentication.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "cnameStrategy": {
+                                      "description": "CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.",
+                                      "enum": [
+                                        "None",
+                                        "Follow"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "digitalocean": {
+                                      "description": "Use the DigitalOcean DNS API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "tokenSecretRef": {
+                                          "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [
+                                        "tokenSecretRef"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "rfc2136": {
+                                      "description": "Use RFC2136 (\"Dynamic Updates in the Domain Name System\") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "nameserver": {
+                                          "description": "The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.",
+                                          "type": "string"
+                                        },
+                                        "tsigAlgorithm": {
+                                          "description": "The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.",
+                                          "type": "string"
+                                        },
+                                        "tsigKeyName": {
+                                          "description": "The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.",
+                                          "type": "string"
+                                        },
+                                        "tsigSecretSecretRef": {
+                                          "description": "The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [
+                                        "nameserver"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "route53": {
+                                      "description": "Use the AWS Route53 API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "accessKeyID": {
+                                          "description": "The AccessKeyID is used for authentication. Cannot be set when SecretAccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                                          "type": "string"
+                                        },
+                                        "accessKeyIDSecretRef": {
+                                          "description": "The SecretAccessKey is used for authentication. If set, pull the AWS access key ID from a key within a Kubernetes Secret. Cannot be set when AccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "hostedZoneID": {
+                                          "description": "If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.",
+                                          "type": "string"
+                                        },
+                                        "region": {
+                                          "description": "Always set the region when using AccessKeyID and SecretAccessKey",
+                                          "type": "string"
+                                        },
+                                        "role": {
+                                          "description": "Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata",
+                                          "type": "string"
+                                        },
+                                        "secretAccessKeySecretRef": {
+                                          "description": "The SecretAccessKey is used for authentication. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [
+                                        "region"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "webhook": {
+                                      "description": "Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "config": {
+                                          "description": "Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.",
+                                          "x-kubernetes-preserve-unknown-fields": true
+                                        },
+                                        "groupName": {
+                                          "description": "The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.",
+                                          "type": "string"
+                                        },
+                                        "solverName": {
+                                          "description": "The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "groupName",
+                                        "solverName"
+                                      ],
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "http01": {
+                                  "description": "Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.",
+                                  "properties": {
+                                    "gatewayHTTPRoute": {
+                                      "description": "The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.",
+                                      "properties": {
+                                        "labels": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "description": "Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.",
+                                          "type": "object"
+                                        },
+                                        "parentRefs": {
+                                          "description": "When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways",
+                                          "items": {
+                                            "description": "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object.",
+                                            "properties": {
+                                              "group": {
+                                                "default": "gateway.networking.k8s.io",
+                                                "description": "Group is the group of the referent. \n Support: Core",
+                                                "maxLength": 253,
+                                                "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "default": "Gateway",
+                                                "description": "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)",
+                                                "maxLength": 63,
+                                                "minLength": 1,
+                                                "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "Name is the name of the referent. \n Support: Core",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "description": "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core",
+                                                "maxLength": 63,
+                                                "minLength": 1,
+                                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                                "type": "string"
+                                              },
+                                              "sectionName": {
+                                                "description": "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "serviceType": {
+                                          "description": "Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "ingress": {
+                                      "description": "The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.",
+                                      "properties": {
+                                        "class": {
+                                          "description": "The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.",
+                                          "type": "string"
+                                        },
+                                        "ingressTemplate": {
+                                          "description": "Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.",
+                                          "properties": {
+                                            "metadata": {
+                                              "description": "ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.",
+                                              "properties": {
+                                                "annotations": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": "Annotations that should be added to the created ACME HTTP01 solver ingress.",
+                                                  "type": "object"
+                                                },
+                                                "labels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": "Labels that should be added to the created ACME HTTP01 solver ingress.",
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "description": "The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.",
+                                          "type": "string"
+                                        },
+                                        "podTemplate": {
+                                          "description": "Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.",
+                                          "properties": {
+                                            "metadata": {
+                                              "description": "ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.",
+                                              "properties": {
+                                                "annotations": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": "Annotations that should be added to the create ACME HTTP01 solver pods.",
+                                                  "type": "object"
+                                                },
+                                                "labels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": "Labels that should be added to the created ACME HTTP01 solver pods.",
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "spec": {
+                                              "description": "PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.",
+                                              "properties": {
+                                                "affinity": {
+                                                  "description": "If specified, the pod's scheduling constraints",
+                                                  "properties": {
+                                                    "nodeAffinity": {
+                                                      "description": "Describes node affinity scheduling rules for the pod.",
+                                                      "properties": {
+                                                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                                                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                                          "items": {
+                                                            "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                                            "properties": {
+                                                              "preference": {
+                                                                "description": "A node selector term, associated with the corresponding weight.",
+                                                                "properties": {
+                                                                  "matchExpressions": {
+                                                                    "description": "A list of node selector requirements by node's labels.",
+                                                                    "items": {
+                                                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "The label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "matchFields": {
+                                                                    "description": "A list of node selector requirements by node's fields.",
+                                                                    "items": {
+                                                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "The label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "weight": {
+                                                                "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                                                "format": "int32",
+                                                                "type": "integer"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "preference",
+                                                              "weight"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                          "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                                          "properties": {
+                                                            "nodeSelectorTerms": {
+                                                              "description": "Required. A list of node selector terms. The terms are ORed.",
+                                                              "items": {
+                                                                "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                                                "properties": {
+                                                                  "matchExpressions": {
+                                                                    "description": "A list of node selector requirements by node's labels.",
+                                                                    "items": {
+                                                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "The label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "matchFields": {
+                                                                    "description": "A list of node selector requirements by node's fields.",
+                                                                    "items": {
+                                                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "The label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "type": "array"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "nodeSelectorTerms"
+                                                          ],
+                                                          "type": "object"
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "podAffinity": {
+                                                      "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                                                      "properties": {
+                                                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                                                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                                          "items": {
+                                                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                                            "properties": {
+                                                              "podAffinityTerm": {
+                                                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                                "properties": {
+                                                                  "labelSelector": {
+                                                                    "description": "A label query over a set of resources, in this case pods.",
+                                                                    "properties": {
+                                                                      "matchExpressions": {
+                                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                        "items": {
+                                                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                          "properties": {
+                                                                            "key": {
+                                                                              "description": "key is the label key that the selector applies to.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            }
+                                                                          },
+                                                                          "required": [
+                                                                            "key",
+                                                                            "operator"
+                                                                          ],
+                                                                          "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                      },
+                                                                      "matchLabels": {
+                                                                        "additionalProperties": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                        "type": "object"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  "namespaceSelector": {
+                                                                    "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                                    "properties": {
+                                                                      "matchExpressions": {
+                                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                        "items": {
+                                                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                          "properties": {
+                                                                            "key": {
+                                                                              "description": "key is the label key that the selector applies to.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            }
+                                                                          },
+                                                                          "required": [
+                                                                            "key",
+                                                                            "operator"
+                                                                          ],
+                                                                          "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                      },
+                                                                      "matchLabels": {
+                                                                        "additionalProperties": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                        "type": "object"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  "namespaces": {
+                                                                    "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "topologyKey": {
+                                                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "topologyKey"
+                                                                ],
+                                                                "type": "object"
+                                                              },
+                                                              "weight": {
+                                                                "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                                                "format": "int32",
+                                                                "type": "integer"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "podAffinityTerm",
+                                                              "weight"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                          "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                                          "items": {
+                                                            "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \u003ctopologyKey\u003e matches that of any node on which a pod of the set of pods is running",
+                                                            "properties": {
+                                                              "labelSelector": {
+                                                                "description": "A label query over a set of resources, in this case pods.",
+                                                                "properties": {
+                                                                  "matchExpressions": {
+                                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                    "items": {
+                                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "key is the label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "matchLabels": {
+                                                                    "additionalProperties": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                    "type": "object"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "namespaceSelector": {
+                                                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                                "properties": {
+                                                                  "matchExpressions": {
+                                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                    "items": {
+                                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "key is the label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "matchLabels": {
+                                                                    "additionalProperties": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                    "type": "object"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "namespaces": {
+                                                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                                "items": {
+                                                                  "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              "topologyKey": {
+                                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "topologyKey"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "podAntiAffinity": {
+                                                      "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                                                      "properties": {
+                                                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                                                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                                          "items": {
+                                                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                                            "properties": {
+                                                              "podAffinityTerm": {
+                                                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                                "properties": {
+                                                                  "labelSelector": {
+                                                                    "description": "A label query over a set of resources, in this case pods.",
+                                                                    "properties": {
+                                                                      "matchExpressions": {
+                                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                        "items": {
+                                                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                          "properties": {
+                                                                            "key": {
+                                                                              "description": "key is the label key that the selector applies to.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            }
+                                                                          },
+                                                                          "required": [
+                                                                            "key",
+                                                                            "operator"
+                                                                          ],
+                                                                          "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                      },
+                                                                      "matchLabels": {
+                                                                        "additionalProperties": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                        "type": "object"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  "namespaceSelector": {
+                                                                    "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                                    "properties": {
+                                                                      "matchExpressions": {
+                                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                        "items": {
+                                                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                          "properties": {
+                                                                            "key": {
+                                                                              "description": "key is the label key that the selector applies to.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            }
+                                                                          },
+                                                                          "required": [
+                                                                            "key",
+                                                                            "operator"
+                                                                          ],
+                                                                          "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                      },
+                                                                      "matchLabels": {
+                                                                        "additionalProperties": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                        "type": "object"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  "namespaces": {
+                                                                    "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "topologyKey": {
+                                                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "topologyKey"
+                                                                ],
+                                                                "type": "object"
+                                                              },
+                                                              "weight": {
+                                                                "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                                                "format": "int32",
+                                                                "type": "integer"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "podAffinityTerm",
+                                                              "weight"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                          "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                                          "items": {
+                                                            "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \u003ctopologyKey\u003e matches that of any node on which a pod of the set of pods is running",
+                                                            "properties": {
+                                                              "labelSelector": {
+                                                                "description": "A label query over a set of resources, in this case pods.",
+                                                                "properties": {
+                                                                  "matchExpressions": {
+                                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                    "items": {
+                                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "key is the label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "matchLabels": {
+                                                                    "additionalProperties": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                    "type": "object"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "namespaceSelector": {
+                                                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                                "properties": {
+                                                                  "matchExpressions": {
+                                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                    "items": {
+                                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "key is the label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "matchLabels": {
+                                                                    "additionalProperties": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                    "type": "object"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "namespaces": {
+                                                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                                "items": {
+                                                                  "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              "topologyKey": {
+                                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "topologyKey"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "nodeSelector": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+                                                  "type": "object"
+                                                },
+                                                "priorityClassName": {
+                                                  "description": "If specified, the pod's priorityClassName.",
+                                                  "type": "string"
+                                                },
+                                                "serviceAccountName": {
+                                                  "description": "If specified, the pod's service account",
+                                                  "type": "string"
+                                                },
+                                                "tolerations": {
+                                                  "description": "If specified, the pod's tolerations.",
+                                                  "items": {
+                                                    "description": "The pod this Toleration is attached to tolerates any taint that matches the triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
+                                                    "properties": {
+                                                      "effect": {
+                                                        "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                                        "type": "string"
+                                                      },
+                                                      "key": {
+                                                        "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                                        "type": "string"
+                                                      },
+                                                      "tolerationSeconds": {
+                                                        "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                                        "format": "int64",
+                                                        "type": "integer"
+                                                      },
+                                                      "value": {
+                                                        "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "serviceType": {
+                                          "description": "Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "selector": {
+                                  "description": "Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.",
+                                  "properties": {
+                                    "dnsNames": {
+                                      "description": "List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "dnsZones": {
+                                      "description": "List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "A label selector that is used to refine the set of certificate's that this challenge solver will apply to.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "privateKeySecretRef",
+                          "server"
+                        ],
+                        "type": "object"
+                      },
+                      "ca": {
+                        "description": "CA configures this issuer to sign certificates using a signing CA keypair stored in a Secret resource. This is used to build internal PKIs that are managed by cert-manager.",
+                        "properties": {
+                          "crlDistributionPoints": {
+                            "description": "The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set, certificates will be issued without distribution points set.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "ocspServers": {
+                            "description": "The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be \"http://ocsp.int-x3.letsencrypt.org\".",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "secretName": {
+                            "description": "SecretName is the name of the secret used to sign Certificates issued by this Issuer.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "secretName"
+                        ],
+                        "type": "object"
+                      },
+                      "selfSigned": {
+                        "description": "SelfSigned configures this issuer to 'self sign' certificates using the private key used to create the CertificateRequest object.",
+                        "properties": {
+                          "crlDistributionPoints": {
+                            "description": "The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set certificate will be issued without CDP. Values are strings.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "vault": {
+                        "description": "Vault configures this issuer to sign certificates using a HashiCorp Vault PKI backend.",
+                        "properties": {
+                          "auth": {
+                            "description": "Auth configures how cert-manager authenticates with the Vault server.",
+                            "properties": {
+                              "appRole": {
+                                "description": "AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.",
+                                "properties": {
+                                  "path": {
+                                    "description": "Path where the App Role authentication backend is mounted in Vault, e.g: \"approle\"",
+                                    "type": "string"
+                                  },
+                                  "roleId": {
+                                    "description": "RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.",
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "description": "Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "path",
+                                  "roleId",
+                                  "secretRef"
+                                ],
+                                "type": "object"
+                              },
+                              "kubernetes": {
+                                "description": "Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.",
+                                "properties": {
+                                  "mountPath": {
+                                    "description": "The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value \"/v1/auth/kubernetes\" will be used.",
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "description": "A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.",
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "description": "The required Secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. Use of 'ambient credentials' is not supported.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "role",
+                                  "secretRef"
+                                ],
+                                "type": "object"
+                              },
+                              "tokenSecretRef": {
+                                "description": "TokenSecretRef authenticates with Vault by presenting a token.",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "caBundle": {
+                            "description": "PEM-encoded CA bundle (base64-encoded) used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.",
+                            "format": "byte",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: \"ns1\" More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "Path is the mount path of the Vault PKI backend's `sign` endpoint, e.g: \"my_pki_mount/sign/my-role-name\".",
+                            "type": "string"
+                          },
+                          "server": {
+                            "description": "Server is the connection address for the Vault server, e.g: \"https://vault.example.com:8200\".",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "auth",
+                          "path",
+                          "server"
+                        ],
+                        "type": "object"
+                      },
+                      "venafi": {
+                        "description": "Venafi configures this issuer to sign certificates using a Venafi TPP or Venafi Cloud policy zone.",
+                        "properties": {
+                          "cloud": {
+                            "description": "Cloud specifies the Venafi cloud configuration settings. Only one of TPP or Cloud may be specified.",
+                            "properties": {
+                              "apiTokenSecretRef": {
+                                "description": "APITokenSecretRef is a secret key selector for the Venafi Cloud API token.",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "url": {
+                                "description": "URL is the base URL for Venafi Cloud. Defaults to \"https://api.venafi.cloud/v1\".",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "apiTokenSecretRef"
+                            ],
+                            "type": "object"
+                          },
+                          "tpp": {
+                            "description": "TPP specifies Trust Protection Platform configuration settings. Only one of TPP or Cloud may be specified.",
+                            "properties": {
+                              "caBundle": {
+                                "description": "CABundle is a PEM encoded TLS certificate to use to verify connections to the TPP instance. If specified, system roots will not be used and the issuing CA for the TPP instance must be verifiable using the provided root. If not specified, the connection will be verified using the cert-manager system root certificates.",
+                                "format": "byte",
+                                "type": "string"
+                              },
+                              "credentialsRef": {
+                                "description": "CredentialsRef is a reference to a Secret containing the username and password for the TPP server. The secret must contain two keys, 'username' and 'password'.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "url": {
+                                "description": "URL is the base URL for the vedsdk endpoint of the Venafi TPP instance, for example: \"https://tpp.example.com/vedsdk\".",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "credentialsRef",
+                              "url"
+                            ],
+                            "type": "object"
+                          },
+                          "zone": {
+                            "description": "Zone is the Venafi Policy Zone to use for this issuer. All requests made to the Venafi platform will be restricted by the named zone policy. This field is required.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "zone"
+                        ],
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "status": {
+                    "description": "Status of the ClusterIssuer. This is set and managed automatically.",
+                    "properties": {
+                      "acme": {
+                        "description": "ACME specific status options. This field should only be set if the Issuer is configured to use an ACME server to issue certificates.",
+                        "properties": {
+                          "lastRegisteredEmail": {
+                            "description": "LastRegisteredEmail is the email associated with the latest registered ACME account, in order to track changes made to registered account associated with the  Issuer",
+                            "type": "string"
+                          },
+                          "uri": {
+                            "description": "URI is the unique account identifier, which can also be used to retrieve account details from the CA",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "conditions": {
+                        "description": "List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready`.",
+                        "items": {
+                          "description": "IssuerCondition contains condition information for an Issuer.",
+                          "properties": {
+                            "lastTransitionTime": {
+                              "description": "LastTransitionTime is the timestamp corresponding to the last status change of this condition.",
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "message": {
+                              "description": "Message is a human readable description of the details of the last transition, complementing reason.",
+                              "type": "string"
+                            },
+                            "observedGeneration": {
+                              "description": "If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "reason": {
+                              "description": "Reason is a brief machine readable explanation for the condition's last transition.",
+                              "type": "string"
+                            },
+                            "status": {
+                              "description": "Status of the condition, one of (`True`, `False`, `Unknown`).",
+                              "enum": [
+                                "True",
+                                "False",
+                                "Unknown"
+                              ],
+                              "type": "string"
+                            },
+                            "type": {
+                              "description": "Type of the condition, known values are (`Ready`).",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "status",
+                            "type"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "type"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "spec"
+                ],
+                "type": "object"
+              }
+            },
+            "served": true,
+            "storage": true,
+            "subresources": {
+              "status": {}
+            }
+          }
+        ]
+      },
+      "status": {
+        "acceptedNames": {
+          "categories": [
+            "cert-manager"
+          ],
+          "kind": "ClusterIssuer",
+          "listKind": "ClusterIssuerList",
+          "plural": "clusterissuers",
+          "singular": "clusterissuer"
+        },
+        "conditions": [
+          {
+            "lastTransitionTime": "2022-11-11T15:53:16Z",
+            "message": "no conflicts found",
+            "reason": "NoConflicts",
+            "status": "True",
+            "type": "NamesAccepted"
+          },
+          {
+            "lastTransitionTime": "2022-11-11T15:53:16Z",
+            "message": "the initial names have been accepted",
+            "reason": "InitialNamesAccepted",
+            "status": "True",
+            "type": "Established"
+          },
+          {
+            "lastTransitionTime": "2022-11-17T16:07:19Z",
+            "message": "removed all instances",
+            "reason": "InstanceDeletionCompleted",
+            "status": "False",
+            "type": "Terminating"
+          }
+        ],
+        "storedVersions": [
+          "v1"
+        ]
+      }
+    },
+    {
+      "apiVersion": "apiextensions.k8s.io/v1",
+      "kind": "CustomResourceDefinition",
+      "metadata": {
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apiextensions.k8s.io/v1\",\"kind\":\"CustomResourceDefinition\",\"metadata\":{\"annotations\":{\"operator.jetstack.io/component\":\"cert-manager\",\"operator.jetstack.io/component-version\":\"v1.9.1\"},\"creationTimestamp\":\"2022-11-11T15:53:16Z\",\"finalizers\":[\"operator.jetstack.io/crd-controller\"],\"generation\":1,\"labels\":{\"app\":\"cert-manager\",\"app.kubernetes.io/instance\":\"cert-manager\",\"app.kubernetes.io/name\":\"cert-manager\",\"app.kubernetes.io/version\":\"v1.9.1\"},\"name\":\"issuers.cert-manager.io\",\"ownerReferences\":[{\"apiVersion\":\"operator.jetstack.io/v1alpha1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"Installation\",\"name\":\"installation\",\"uid\":\"36ea7a42-2dfa-48de-b3bc-acb8d9c29f6d\"}],\"resourceVersion\":\"1295\",\"uid\":\"9ca20066-4a1e-42fe-81a9-14d0815a3d40\"},\"spec\":{\"conversion\":{\"strategy\":\"None\"},\"group\":\"cert-manager.io\",\"names\":{\"categories\":[\"cert-manager\"],\"kind\":\"Issuer\",\"listKind\":\"IssuerList\",\"plural\":\"issuers\",\"singular\":\"issuer\"},\"scope\":\"Namespaced\",\"versions\":[{\"additionalPrinterColumns\":[{\"jsonPath\":\".status.conditions[?(@.type==\\\"Ready\\\")].status\",\"name\":\"Ready\",\"type\":\"string\"},{\"jsonPath\":\".status.conditions[?(@.type==\\\"Ready\\\")].message\",\"name\":\"Status\",\"priority\":1,\"type\":\"string\"},{\"description\":\"CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\",\"jsonPath\":\".metadata.creationTimestamp\",\"name\":\"Age\",\"type\":\"date\"}],\"name\":\"v1\",\"schema\":{\"openAPIV3Schema\":{\"description\":\"An Issuer represents a certificate issuing authority which can be referenced as part of `issuerRef` fields. It is scoped to a single namespace and can therefore only be referenced by resources within the same namespace.\",\"properties\":{\"apiVersion\":{\"description\":\"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources\",\"type\":\"string\"},\"kind\":{\"description\":\"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds\",\"type\":\"string\"},\"metadata\":{\"type\":\"object\"},\"spec\":{\"description\":\"Desired state of the Issuer resource.\",\"properties\":{\"acme\":{\"description\":\"ACME configures this issuer to communicate with a RFC8555 (ACME) server to obtain signed x509 certificates.\",\"properties\":{\"disableAccountKeyGeneration\":{\"description\":\"Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.\",\"type\":\"boolean\"},\"email\":{\"description\":\"Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.\",\"type\":\"string\"},\"enableDurationFeature\":{\"description\":\"Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.\",\"type\":\"boolean\"},\"externalAccountBinding\":{\"description\":\"ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.\",\"properties\":{\"keyAlgorithm\":{\"description\":\"Deprecated: keyAlgorithm field exists for historical compatibility reasons and should not be used. The algorithm is now hardcoded to HS256 in golang/x/crypto/acme.\",\"enum\":[\"HS256\",\"HS384\",\"HS512\"],\"type\":\"string\"},\"keyID\":{\"description\":\"keyID is the ID of the CA key that the External Account is bound to.\",\"type\":\"string\"},\"keySecretRef\":{\"description\":\"keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes Secret which holds the symmetric MAC key of the External Account Binding. The `key` is the index string that is paired with the key data in the Secret and should not be confused with the key data itself, or indeed with the External Account Binding keyID above. The secret key stored in the Secret **must** be un-padded, base64 URL encoded data.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"required\":[\"keyID\",\"keySecretRef\"],\"type\":\"object\"},\"preferredChain\":{\"description\":\"PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let's Encrypt's DST crosssign you would use: \\\"DST Root CA X3\\\" or \\\"ISRG Root X1\\\" for the newer Let's Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer's CN\",\"maxLength\":64,\"type\":\"string\"},\"privateKeySecretRef\":{\"description\":\"PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"server\":{\"description\":\"Server is the URL used to access the ACME server's 'directory' endpoint. For example, for Let's Encrypt's staging endpoint, you would use: \\\"https://acme-staging-v02.api.letsencrypt.org/directory\\\". Only ACME v2 endpoints (i.e. RFC 8555) are supported.\",\"type\":\"string\"},\"skipTLSVerify\":{\"description\":\"Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have their TLS certificate validated (i.e. insecure connections will be allowed). Only enable this option in development environments. The cert-manager system installed roots will be used to verify connections to the ACME server if this is false. Defaults to false.\",\"type\":\"boolean\"},\"solvers\":{\"description\":\"Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/\",\"items\":{\"description\":\"An ACMEChallengeSolver describes how to solve ACME challenges for the issuer it is part of. A selector may be provided to use different solving strategies for different DNS names. Only one of HTTP01 or DNS01 must be provided.\",\"properties\":{\"dns01\":{\"description\":\"Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.\",\"properties\":{\"acmeDNS\":{\"description\":\"Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.\",\"properties\":{\"accountSecretRef\":{\"description\":\"A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"host\":{\"type\":\"string\"}},\"required\":[\"accountSecretRef\",\"host\"],\"type\":\"object\"},\"akamai\":{\"description\":\"Use the Akamai DNS zone management API to manage DNS01 challenge records.\",\"properties\":{\"accessTokenSecretRef\":{\"description\":\"A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"clientSecretSecretRef\":{\"description\":\"A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"clientTokenSecretRef\":{\"description\":\"A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"serviceConsumerDomain\":{\"type\":\"string\"}},\"required\":[\"accessTokenSecretRef\",\"clientSecretSecretRef\",\"clientTokenSecretRef\",\"serviceConsumerDomain\"],\"type\":\"object\"},\"azureDNS\":{\"description\":\"Use the Microsoft Azure DNS API to manage DNS01 challenge records.\",\"properties\":{\"clientID\":{\"description\":\"if both this and ClientSecret are left unset MSI will be used\",\"type\":\"string\"},\"clientSecretSecretRef\":{\"description\":\"if both this and ClientID are left unset MSI will be used\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"environment\":{\"description\":\"name of the Azure environment (default AzurePublicCloud)\",\"enum\":[\"AzurePublicCloud\",\"AzureChinaCloud\",\"AzureGermanCloud\",\"AzureUSGovernmentCloud\"],\"type\":\"string\"},\"hostedZoneName\":{\"description\":\"name of the DNS zone that should be used\",\"type\":\"string\"},\"managedIdentity\":{\"description\":\"managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID\",\"properties\":{\"clientID\":{\"description\":\"client ID of the managed identity, can not be used at the same time as resourceID\",\"type\":\"string\"},\"resourceID\":{\"description\":\"resource ID of the managed identity, can not be used at the same time as clientID\",\"type\":\"string\"}},\"type\":\"object\"},\"resourceGroupName\":{\"description\":\"resource group the DNS zone is located in\",\"type\":\"string\"},\"subscriptionID\":{\"description\":\"ID of the Azure subscription\",\"type\":\"string\"},\"tenantID\":{\"description\":\"when specifying ClientID and ClientSecret then this field is also needed\",\"type\":\"string\"}},\"required\":[\"resourceGroupName\",\"subscriptionID\"],\"type\":\"object\"},\"cloudDNS\":{\"description\":\"Use the Google Cloud DNS API to manage DNS01 challenge records.\",\"properties\":{\"hostedZoneName\":{\"description\":\"HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.\",\"type\":\"string\"},\"project\":{\"type\":\"string\"},\"serviceAccountSecretRef\":{\"description\":\"A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"required\":[\"project\"],\"type\":\"object\"},\"cloudflare\":{\"description\":\"Use the Cloudflare API to manage DNS01 challenge records.\",\"properties\":{\"apiKeySecretRef\":{\"description\":\"API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"apiTokenSecretRef\":{\"description\":\"API token used to authenticate with Cloudflare.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"email\":{\"description\":\"Email of the account, only required when using API key based authentication.\",\"type\":\"string\"}},\"type\":\"object\"},\"cnameStrategy\":{\"description\":\"CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.\",\"enum\":[\"None\",\"Follow\"],\"type\":\"string\"},\"digitalocean\":{\"description\":\"Use the DigitalOcean DNS API to manage DNS01 challenge records.\",\"properties\":{\"tokenSecretRef\":{\"description\":\"A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"required\":[\"tokenSecretRef\"],\"type\":\"object\"},\"rfc2136\":{\"description\":\"Use RFC2136 (\\\"Dynamic Updates in the Domain Name System\\\") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.\",\"properties\":{\"nameserver\":{\"description\":\"The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.\",\"type\":\"string\"},\"tsigAlgorithm\":{\"description\":\"The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.\",\"type\":\"string\"},\"tsigKeyName\":{\"description\":\"The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.\",\"type\":\"string\"},\"tsigSecretSecretRef\":{\"description\":\"The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"required\":[\"nameserver\"],\"type\":\"object\"},\"route53\":{\"description\":\"Use the AWS Route53 API to manage DNS01 challenge records.\",\"properties\":{\"accessKeyID\":{\"description\":\"The AccessKeyID is used for authentication. Cannot be set when SecretAccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials\",\"type\":\"string\"},\"accessKeyIDSecretRef\":{\"description\":\"The SecretAccessKey is used for authentication. If set, pull the AWS access key ID from a key within a Kubernetes Secret. Cannot be set when AccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"hostedZoneID\":{\"description\":\"If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.\",\"type\":\"string\"},\"region\":{\"description\":\"Always set the region when using AccessKeyID and SecretAccessKey\",\"type\":\"string\"},\"role\":{\"description\":\"Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata\",\"type\":\"string\"},\"secretAccessKeySecretRef\":{\"description\":\"The SecretAccessKey is used for authentication. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"required\":[\"region\"],\"type\":\"object\"},\"webhook\":{\"description\":\"Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.\",\"properties\":{\"config\":{\"description\":\"Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.\",\"x-kubernetes-preserve-unknown-fields\":true},\"groupName\":{\"description\":\"The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.\",\"type\":\"string\"},\"solverName\":{\"description\":\"The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.\",\"type\":\"string\"}},\"required\":[\"groupName\",\"solverName\"],\"type\":\"object\"}},\"type\":\"object\"},\"http01\":{\"description\":\"Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.\",\"properties\":{\"gatewayHTTPRoute\":{\"description\":\"The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.\",\"properties\":{\"labels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.\",\"type\":\"object\"},\"parentRefs\":{\"description\":\"When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways\",\"items\":{\"description\":\"ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \\\"Core\\\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \\n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \\n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object.\",\"properties\":{\"group\":{\"default\":\"gateway.networking.k8s.io\",\"description\":\"Group is the group of the referent. \\n Support: Core\",\"maxLength\":253,\"pattern\":\"^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$\",\"type\":\"string\"},\"kind\":{\"default\":\"Gateway\",\"description\":\"Kind is kind of the referent. \\n Support: Core (Gateway) Support: Custom (Other Resources)\",\"maxLength\":63,\"minLength\":1,\"pattern\":\"^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$\",\"type\":\"string\"},\"name\":{\"description\":\"Name is the name of the referent. \\n Support: Core\",\"maxLength\":253,\"minLength\":1,\"type\":\"string\"},\"namespace\":{\"description\":\"Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \\n Support: Core\",\"maxLength\":63,\"minLength\":1,\"pattern\":\"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$\",\"type\":\"string\"},\"sectionName\":{\"description\":\"SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \\n * Gateway: Listener Name \\n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \\n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \\n Support: Core\",\"maxLength\":253,\"minLength\":1,\"pattern\":\"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"type\":\"array\"},\"serviceType\":{\"description\":\"Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.\",\"type\":\"string\"}},\"type\":\"object\"},\"ingress\":{\"description\":\"The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.\",\"properties\":{\"class\":{\"description\":\"The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.\",\"type\":\"string\"},\"ingressTemplate\":{\"description\":\"Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.\",\"properties\":{\"metadata\":{\"description\":\"ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.\",\"properties\":{\"annotations\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"Annotations that should be added to the created ACME HTTP01 solver ingress.\",\"type\":\"object\"},\"labels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"Labels that should be added to the created ACME HTTP01 solver ingress.\",\"type\":\"object\"}},\"type\":\"object\"}},\"type\":\"object\"},\"name\":{\"description\":\"The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.\",\"type\":\"string\"},\"podTemplate\":{\"description\":\"Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.\",\"properties\":{\"metadata\":{\"description\":\"ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.\",\"properties\":{\"annotations\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"Annotations that should be added to the create ACME HTTP01 solver pods.\",\"type\":\"object\"},\"labels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"Labels that should be added to the created ACME HTTP01 solver pods.\",\"type\":\"object\"}},\"type\":\"object\"},\"spec\":{\"description\":\"PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.\",\"properties\":{\"affinity\":{\"description\":\"If specified, the pod's scheduling constraints\",\"properties\":{\"nodeAffinity\":{\"description\":\"Describes node affinity scheduling rules for the pod.\",\"properties\":{\"preferredDuringSchedulingIgnoredDuringExecution\":{\"description\":\"The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\\"weight\\\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.\",\"items\":{\"description\":\"An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).\",\"properties\":{\"preference\":{\"description\":\"A node selector term, associated with the corresponding weight.\",\"properties\":{\"matchExpressions\":{\"description\":\"A list of node selector requirements by node's labels.\",\"items\":{\"description\":\"A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"The label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.\",\"type\":\"string\"},\"values\":{\"description\":\"An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchFields\":{\"description\":\"A list of node selector requirements by node's fields.\",\"items\":{\"description\":\"A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"The label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.\",\"type\":\"string\"},\"values\":{\"description\":\"An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"}},\"type\":\"object\"},\"weight\":{\"description\":\"Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.\",\"format\":\"int32\",\"type\":\"integer\"}},\"required\":[\"preference\",\"weight\"],\"type\":\"object\"},\"type\":\"array\"},\"requiredDuringSchedulingIgnoredDuringExecution\":{\"description\":\"If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.\",\"properties\":{\"nodeSelectorTerms\":{\"description\":\"Required. A list of node selector terms. The terms are ORed.\",\"items\":{\"description\":\"A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.\",\"properties\":{\"matchExpressions\":{\"description\":\"A list of node selector requirements by node's labels.\",\"items\":{\"description\":\"A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"The label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.\",\"type\":\"string\"},\"values\":{\"description\":\"An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchFields\":{\"description\":\"A list of node selector requirements by node's fields.\",\"items\":{\"description\":\"A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"The label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.\",\"type\":\"string\"},\"values\":{\"description\":\"An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"}},\"type\":\"object\"},\"type\":\"array\"}},\"required\":[\"nodeSelectorTerms\"],\"type\":\"object\"}},\"type\":\"object\"},\"podAffinity\":{\"description\":\"Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).\",\"properties\":{\"preferredDuringSchedulingIgnoredDuringExecution\":{\"description\":\"The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\\"weight\\\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.\",\"items\":{\"description\":\"The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)\",\"properties\":{\"podAffinityTerm\":{\"description\":\"Required. A pod affinity term, associated with the corresponding weight.\",\"properties\":{\"labelSelector\":{\"description\":\"A label query over a set of resources, in this case pods.\",\"properties\":{\"matchExpressions\":{\"description\":\"matchExpressions is a list of label selector requirements. The requirements are ANDed.\",\"items\":{\"description\":\"A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"key is the label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\",\"type\":\"string\"},\"values\":{\"description\":\"values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\\"key\\\", the operator is \\\"In\\\", and the values array contains only \\\"value\\\". The requirements are ANDed.\",\"type\":\"object\"}},\"type\":\"object\"},\"namespaceSelector\":{\"description\":\"A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \\\"this pod's namespace\\\". An empty selector ({}) matches all namespaces.\",\"properties\":{\"matchExpressions\":{\"description\":\"matchExpressions is a list of label selector requirements. The requirements are ANDed.\",\"items\":{\"description\":\"A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"key is the label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\",\"type\":\"string\"},\"values\":{\"description\":\"values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\\"key\\\", the operator is \\\"In\\\", and the values array contains only \\\"value\\\". The requirements are ANDed.\",\"type\":\"object\"}},\"type\":\"object\"},\"namespaces\":{\"description\":\"namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\\"this pod's namespace\\\".\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"topologyKey\":{\"description\":\"This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.\",\"type\":\"string\"}},\"required\":[\"topologyKey\"],\"type\":\"object\"},\"weight\":{\"description\":\"weight associated with matching the corresponding podAffinityTerm, in the range 1-100.\",\"format\":\"int32\",\"type\":\"integer\"}},\"required\":[\"podAffinityTerm\",\"weight\"],\"type\":\"object\"},\"type\":\"array\"},\"requiredDuringSchedulingIgnoredDuringExecution\":{\"description\":\"If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.\",\"items\":{\"description\":\"Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \\u003ctopologyKey\\u003e matches that of any node on which a pod of the set of pods is running\",\"properties\":{\"labelSelector\":{\"description\":\"A label query over a set of resources, in this case pods.\",\"properties\":{\"matchExpressions\":{\"description\":\"matchExpressions is a list of label selector requirements. The requirements are ANDed.\",\"items\":{\"description\":\"A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"key is the label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\",\"type\":\"string\"},\"values\":{\"description\":\"values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\\"key\\\", the operator is \\\"In\\\", and the values array contains only \\\"value\\\". The requirements are ANDed.\",\"type\":\"object\"}},\"type\":\"object\"},\"namespaceSelector\":{\"description\":\"A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \\\"this pod's namespace\\\". An empty selector ({}) matches all namespaces.\",\"properties\":{\"matchExpressions\":{\"description\":\"matchExpressions is a list of label selector requirements. The requirements are ANDed.\",\"items\":{\"description\":\"A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"key is the label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\",\"type\":\"string\"},\"values\":{\"description\":\"values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\\"key\\\", the operator is \\\"In\\\", and the values array contains only \\\"value\\\". The requirements are ANDed.\",\"type\":\"object\"}},\"type\":\"object\"},\"namespaces\":{\"description\":\"namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\\"this pod's namespace\\\".\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"topologyKey\":{\"description\":\"This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.\",\"type\":\"string\"}},\"required\":[\"topologyKey\"],\"type\":\"object\"},\"type\":\"array\"}},\"type\":\"object\"},\"podAntiAffinity\":{\"description\":\"Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).\",\"properties\":{\"preferredDuringSchedulingIgnoredDuringExecution\":{\"description\":\"The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\\"weight\\\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.\",\"items\":{\"description\":\"The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)\",\"properties\":{\"podAffinityTerm\":{\"description\":\"Required. A pod affinity term, associated with the corresponding weight.\",\"properties\":{\"labelSelector\":{\"description\":\"A label query over a set of resources, in this case pods.\",\"properties\":{\"matchExpressions\":{\"description\":\"matchExpressions is a list of label selector requirements. The requirements are ANDed.\",\"items\":{\"description\":\"A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"key is the label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\",\"type\":\"string\"},\"values\":{\"description\":\"values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\\"key\\\", the operator is \\\"In\\\", and the values array contains only \\\"value\\\". The requirements are ANDed.\",\"type\":\"object\"}},\"type\":\"object\"},\"namespaceSelector\":{\"description\":\"A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \\\"this pod's namespace\\\". An empty selector ({}) matches all namespaces.\",\"properties\":{\"matchExpressions\":{\"description\":\"matchExpressions is a list of label selector requirements. The requirements are ANDed.\",\"items\":{\"description\":\"A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"key is the label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\",\"type\":\"string\"},\"values\":{\"description\":\"values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\\"key\\\", the operator is \\\"In\\\", and the values array contains only \\\"value\\\". The requirements are ANDed.\",\"type\":\"object\"}},\"type\":\"object\"},\"namespaces\":{\"description\":\"namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\\"this pod's namespace\\\".\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"topologyKey\":{\"description\":\"This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.\",\"type\":\"string\"}},\"required\":[\"topologyKey\"],\"type\":\"object\"},\"weight\":{\"description\":\"weight associated with matching the corresponding podAffinityTerm, in the range 1-100.\",\"format\":\"int32\",\"type\":\"integer\"}},\"required\":[\"podAffinityTerm\",\"weight\"],\"type\":\"object\"},\"type\":\"array\"},\"requiredDuringSchedulingIgnoredDuringExecution\":{\"description\":\"If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.\",\"items\":{\"description\":\"Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \\u003ctopologyKey\\u003e matches that of any node on which a pod of the set of pods is running\",\"properties\":{\"labelSelector\":{\"description\":\"A label query over a set of resources, in this case pods.\",\"properties\":{\"matchExpressions\":{\"description\":\"matchExpressions is a list of label selector requirements. The requirements are ANDed.\",\"items\":{\"description\":\"A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"key is the label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\",\"type\":\"string\"},\"values\":{\"description\":\"values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\\"key\\\", the operator is \\\"In\\\", and the values array contains only \\\"value\\\". The requirements are ANDed.\",\"type\":\"object\"}},\"type\":\"object\"},\"namespaceSelector\":{\"description\":\"A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \\\"this pod's namespace\\\". An empty selector ({}) matches all namespaces.\",\"properties\":{\"matchExpressions\":{\"description\":\"matchExpressions is a list of label selector requirements. The requirements are ANDed.\",\"items\":{\"description\":\"A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\",\"properties\":{\"key\":{\"description\":\"key is the label key that the selector applies to.\",\"type\":\"string\"},\"operator\":{\"description\":\"operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\",\"type\":\"string\"},\"values\":{\"description\":\"values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"required\":[\"key\",\"operator\"],\"type\":\"object\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\\"key\\\", the operator is \\\"In\\\", and the values array contains only \\\"value\\\". The requirements are ANDed.\",\"type\":\"object\"}},\"type\":\"object\"},\"namespaces\":{\"description\":\"namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\\"this pod's namespace\\\".\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"topologyKey\":{\"description\":\"This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.\",\"type\":\"string\"}},\"required\":[\"topologyKey\"],\"type\":\"object\"},\"type\":\"array\"}},\"type\":\"object\"}},\"type\":\"object\"},\"nodeSelector\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/\",\"type\":\"object\"},\"priorityClassName\":{\"description\":\"If specified, the pod's priorityClassName.\",\"type\":\"string\"},\"serviceAccountName\":{\"description\":\"If specified, the pod's service account\",\"type\":\"string\"},\"tolerations\":{\"description\":\"If specified, the pod's tolerations.\",\"items\":{\"description\":\"The pod this Toleration is attached to tolerates any taint that matches the triple \\u003ckey,value,effect\\u003e using the matching operator \\u003coperator\\u003e.\",\"properties\":{\"effect\":{\"description\":\"Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.\",\"type\":\"string\"},\"key\":{\"description\":\"Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.\",\"type\":\"string\"},\"operator\":{\"description\":\"Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.\",\"type\":\"string\"},\"tolerationSeconds\":{\"description\":\"TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.\",\"format\":\"int64\",\"type\":\"integer\"},\"value\":{\"description\":\"Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.\",\"type\":\"string\"}},\"type\":\"object\"},\"type\":\"array\"}},\"type\":\"object\"}},\"type\":\"object\"},\"serviceType\":{\"description\":\"Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.\",\"type\":\"string\"}},\"type\":\"object\"}},\"type\":\"object\"},\"selector\":{\"description\":\"Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.\",\"properties\":{\"dnsNames\":{\"description\":\"List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"dnsZones\":{\"description\":\"List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"matchLabels\":{\"additionalProperties\":{\"type\":\"string\"},\"description\":\"A label selector that is used to refine the set of certificate's that this challenge solver will apply to.\",\"type\":\"object\"}},\"type\":\"object\"}},\"type\":\"object\"},\"type\":\"array\"}},\"required\":[\"privateKeySecretRef\",\"server\"],\"type\":\"object\"},\"ca\":{\"description\":\"CA configures this issuer to sign certificates using a signing CA keypair stored in a Secret resource. This is used to build internal PKIs that are managed by cert-manager.\",\"properties\":{\"crlDistributionPoints\":{\"description\":\"The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set, certificates will be issued without distribution points set.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"ocspServers\":{\"description\":\"The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be \\\"http://ocsp.int-x3.letsencrypt.org\\\".\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"secretName\":{\"description\":\"SecretName is the name of the secret used to sign Certificates issued by this Issuer.\",\"type\":\"string\"}},\"required\":[\"secretName\"],\"type\":\"object\"},\"selfSigned\":{\"description\":\"SelfSigned configures this issuer to 'self sign' certificates using the private key used to create the CertificateRequest object.\",\"properties\":{\"crlDistributionPoints\":{\"description\":\"The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set certificate will be issued without CDP. Values are strings.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"}},\"type\":\"object\"},\"vault\":{\"description\":\"Vault configures this issuer to sign certificates using a HashiCorp Vault PKI backend.\",\"properties\":{\"auth\":{\"description\":\"Auth configures how cert-manager authenticates with the Vault server.\",\"properties\":{\"appRole\":{\"description\":\"AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.\",\"properties\":{\"path\":{\"description\":\"Path where the App Role authentication backend is mounted in Vault, e.g: \\\"approle\\\"\",\"type\":\"string\"},\"roleId\":{\"description\":\"RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.\",\"type\":\"string\"},\"secretRef\":{\"description\":\"Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"required\":[\"path\",\"roleId\",\"secretRef\"],\"type\":\"object\"},\"kubernetes\":{\"description\":\"Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.\",\"properties\":{\"mountPath\":{\"description\":\"The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value \\\"/v1/auth/kubernetes\\\" will be used.\",\"type\":\"string\"},\"role\":{\"description\":\"A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.\",\"type\":\"string\"},\"secretRef\":{\"description\":\"The required Secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. Use of 'ambient credentials' is not supported.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"required\":[\"role\",\"secretRef\"],\"type\":\"object\"},\"tokenSecretRef\":{\"description\":\"TokenSecretRef authenticates with Vault by presenting a token.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"type\":\"object\"},\"caBundle\":{\"description\":\"PEM-encoded CA bundle (base64-encoded) used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.\",\"format\":\"byte\",\"type\":\"string\"},\"namespace\":{\"description\":\"Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: \\\"ns1\\\" More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces\",\"type\":\"string\"},\"path\":{\"description\":\"Path is the mount path of the Vault PKI backend's `sign` endpoint, e.g: \\\"my_pki_mount/sign/my-role-name\\\".\",\"type\":\"string\"},\"server\":{\"description\":\"Server is the connection address for the Vault server, e.g: \\\"https://vault.example.com:8200\\\".\",\"type\":\"string\"}},\"required\":[\"auth\",\"path\",\"server\"],\"type\":\"object\"},\"venafi\":{\"description\":\"Venafi configures this issuer to sign certificates using a Venafi TPP or Venafi Cloud policy zone.\",\"properties\":{\"cloud\":{\"description\":\"Cloud specifies the Venafi cloud configuration settings. Only one of TPP or Cloud may be specified.\",\"properties\":{\"apiTokenSecretRef\":{\"description\":\"APITokenSecretRef is a secret key selector for the Venafi Cloud API token.\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"url\":{\"description\":\"URL is the base URL for Venafi Cloud. Defaults to \\\"https://api.venafi.cloud/v1\\\".\",\"type\":\"string\"}},\"required\":[\"apiTokenSecretRef\"],\"type\":\"object\"},\"tpp\":{\"description\":\"TPP specifies Trust Protection Platform configuration settings. Only one of TPP or Cloud may be specified.\",\"properties\":{\"caBundle\":{\"description\":\"CABundle is a PEM encoded TLS certificate to use to verify connections to the TPP instance. If specified, system roots will not be used and the issuing CA for the TPP instance must be verifiable using the provided root. If not specified, the connection will be verified using the cert-manager system root certificates.\",\"format\":\"byte\",\"type\":\"string\"},\"credentialsRef\":{\"description\":\"CredentialsRef is a reference to a Secret containing the username and password for the TPP server. The secret must contain two keys, 'username' and 'password'.\",\"properties\":{\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"url\":{\"description\":\"URL is the base URL for the vedsdk endpoint of the Venafi TPP instance, for example: \\\"https://tpp.example.com/vedsdk\\\".\",\"type\":\"string\"}},\"required\":[\"credentialsRef\",\"url\"],\"type\":\"object\"},\"zone\":{\"description\":\"Zone is the Venafi Policy Zone to use for this issuer. All requests made to the Venafi platform will be restricted by the named zone policy. This field is required.\",\"type\":\"string\"}},\"required\":[\"zone\"],\"type\":\"object\"}},\"type\":\"object\"},\"status\":{\"description\":\"Status of the Issuer. This is set and managed automatically.\",\"properties\":{\"acme\":{\"description\":\"ACME specific status options. This field should only be set if the Issuer is configured to use an ACME server to issue certificates.\",\"properties\":{\"lastRegisteredEmail\":{\"description\":\"LastRegisteredEmail is the email associated with the latest registered ACME account, in order to track changes made to registered account associated with the  Issuer\",\"type\":\"string\"},\"uri\":{\"description\":\"URI is the unique account identifier, which can also be used to retrieve account details from the CA\",\"type\":\"string\"}},\"type\":\"object\"},\"conditions\":{\"description\":\"List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready`.\",\"items\":{\"description\":\"IssuerCondition contains condition information for an Issuer.\",\"properties\":{\"lastTransitionTime\":{\"description\":\"LastTransitionTime is the timestamp corresponding to the last status change of this condition.\",\"format\":\"date-time\",\"type\":\"string\"},\"message\":{\"description\":\"Message is a human readable description of the details of the last transition, complementing reason.\",\"type\":\"string\"},\"observedGeneration\":{\"description\":\"If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.\",\"format\":\"int64\",\"type\":\"integer\"},\"reason\":{\"description\":\"Reason is a brief machine readable explanation for the condition's last transition.\",\"type\":\"string\"},\"status\":{\"description\":\"Status of the condition, one of (`True`, `False`, `Unknown`).\",\"enum\":[\"True\",\"False\",\"Unknown\"],\"type\":\"string\"},\"type\":{\"description\":\"Type of the condition, known values are (`Ready`).\",\"type\":\"string\"}},\"required\":[\"status\",\"type\"],\"type\":\"object\"},\"type\":\"array\",\"x-kubernetes-list-map-keys\":[\"type\"],\"x-kubernetes-list-type\":\"map\"}},\"type\":\"object\"}},\"required\":[\"spec\"],\"type\":\"object\"}},\"served\":true,\"storage\":true,\"subresources\":{\"status\":{}}}]},\"status\":{\"acceptedNames\":{\"categories\":[\"cert-manager\"],\"kind\":\"Issuer\",\"listKind\":\"IssuerList\",\"plural\":\"issuers\",\"singular\":\"issuer\"},\"conditions\":[{\"lastTransitionTime\":\"2022-11-11T15:53:16Z\",\"message\":\"no conflicts found\",\"reason\":\"NoConflicts\",\"status\":\"True\",\"type\":\"NamesAccepted\"},{\"lastTransitionTime\":\"2022-11-11T15:53:16Z\",\"message\":\"the initial names have been accepted\",\"reason\":\"InitialNamesAccepted\",\"status\":\"True\",\"type\":\"Established\"}],\"storedVersions\":[\"v1\"]}}\n",
+          "operator.jetstack.io/component": "cert-manager",
+          "operator.jetstack.io/component-version": "v1.9.1"
+        },
+        "creationTimestamp": "2022-11-11T15:53:16Z",
+        "deletionTimestamp": "2022-11-17T16:07:19Z",
+        "finalizers": [
+          "operator.jetstack.io/crd-controller"
+        ],
+        "generation": 1,
+        "labels": {
+          "app": "cert-manager",
+          "app.kubernetes.io/instance": "cert-manager",
+          "app.kubernetes.io/name": "cert-manager",
+          "app.kubernetes.io/version": "v1.9.1"
+        },
+        "name": "issuers.cert-manager.io",
+        "ownerReferences": [
+          {
+            "apiVersion": "operator.jetstack.io/v1alpha1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Installation",
+            "name": "installation",
+            "uid": "36ea7a42-2dfa-48de-b3bc-acb8d9c29f6d"
+          }
+        ],
+        "resourceVersion": "147988",
+        "uid": "9ca20066-4a1e-42fe-81a9-14d0815a3d40"
+      },
+      "spec": {
+        "conversion": {
+          "strategy": "None"
+        },
+        "group": "cert-manager.io",
+        "names": {
+          "categories": [
+            "cert-manager"
+          ],
+          "kind": "Issuer",
+          "listKind": "IssuerList",
+          "plural": "issuers",
+          "singular": "issuer"
+        },
+        "scope": "Namespaced",
+        "versions": [
+          {
+            "additionalPrinterColumns": [
+              {
+                "jsonPath": ".status.conditions[?(@.type==\"Ready\")].status",
+                "name": "Ready",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".status.conditions[?(@.type==\"Ready\")].message",
+                "name": "Status",
+                "priority": 1,
+                "type": "string"
+              },
+              {
+                "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.",
+                "jsonPath": ".metadata.creationTimestamp",
+                "name": "Age",
+                "type": "date"
+              }
+            ],
+            "name": "v1",
+            "schema": {
+              "openAPIV3Schema": {
+                "description": "An Issuer represents a certificate issuing authority which can be referenced as part of `issuerRef` fields. It is scoped to a single namespace and can therefore only be referenced by resources within the same namespace.",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "type": "object"
+                  },
+                  "spec": {
+                    "description": "Desired state of the Issuer resource.",
+                    "properties": {
+                      "acme": {
+                        "description": "ACME configures this issuer to communicate with a RFC8555 (ACME) server to obtain signed x509 certificates.",
+                        "properties": {
+                          "disableAccountKeyGeneration": {
+                            "description": "Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.",
+                            "type": "boolean"
+                          },
+                          "email": {
+                            "description": "Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.",
+                            "type": "string"
+                          },
+                          "enableDurationFeature": {
+                            "description": "Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.",
+                            "type": "boolean"
+                          },
+                          "externalAccountBinding": {
+                            "description": "ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.",
+                            "properties": {
+                              "keyAlgorithm": {
+                                "description": "Deprecated: keyAlgorithm field exists for historical compatibility reasons and should not be used. The algorithm is now hardcoded to HS256 in golang/x/crypto/acme.",
+                                "enum": [
+                                  "HS256",
+                                  "HS384",
+                                  "HS512"
+                                ],
+                                "type": "string"
+                              },
+                              "keyID": {
+                                "description": "keyID is the ID of the CA key that the External Account is bound to.",
+                                "type": "string"
+                              },
+                              "keySecretRef": {
+                                "description": "keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes Secret which holds the symmetric MAC key of the External Account Binding. The `key` is the index string that is paired with the key data in the Secret and should not be confused with the key data itself, or indeed with the External Account Binding keyID above. The secret key stored in the Secret **must** be un-padded, base64 URL encoded data.",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "required": [
+                              "keyID",
+                              "keySecretRef"
+                            ],
+                            "type": "object"
+                          },
+                          "preferredChain": {
+                            "description": "PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let's Encrypt's DST crosssign you would use: \"DST Root CA X3\" or \"ISRG Root X1\" for the newer Let's Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer's CN",
+                            "maxLength": 64,
+                            "type": "string"
+                          },
+                          "privateKeySecretRef": {
+                            "description": "PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "server": {
+                            "description": "Server is the URL used to access the ACME server's 'directory' endpoint. For example, for Let's Encrypt's staging endpoint, you would use: \"https://acme-staging-v02.api.letsencrypt.org/directory\". Only ACME v2 endpoints (i.e. RFC 8555) are supported.",
+                            "type": "string"
+                          },
+                          "skipTLSVerify": {
+                            "description": "Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have their TLS certificate validated (i.e. insecure connections will be allowed). Only enable this option in development environments. The cert-manager system installed roots will be used to verify connections to the ACME server if this is false. Defaults to false.",
+                            "type": "boolean"
+                          },
+                          "solvers": {
+                            "description": "Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/",
+                            "items": {
+                              "description": "An ACMEChallengeSolver describes how to solve ACME challenges for the issuer it is part of. A selector may be provided to use different solving strategies for different DNS names. Only one of HTTP01 or DNS01 must be provided.",
+                              "properties": {
+                                "dns01": {
+                                  "description": "Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.",
+                                  "properties": {
+                                    "acmeDNS": {
+                                      "description": "Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "accountSecretRef": {
+                                          "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "host": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "accountSecretRef",
+                                        "host"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "akamai": {
+                                      "description": "Use the Akamai DNS zone management API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "accessTokenSecretRef": {
+                                          "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "clientSecretSecretRef": {
+                                          "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "clientTokenSecretRef": {
+                                          "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "serviceConsumerDomain": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "accessTokenSecretRef",
+                                        "clientSecretSecretRef",
+                                        "clientTokenSecretRef",
+                                        "serviceConsumerDomain"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "azureDNS": {
+                                      "description": "Use the Microsoft Azure DNS API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "clientID": {
+                                          "description": "if both this and ClientSecret are left unset MSI will be used",
+                                          "type": "string"
+                                        },
+                                        "clientSecretSecretRef": {
+                                          "description": "if both this and ClientID are left unset MSI will be used",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "environment": {
+                                          "description": "name of the Azure environment (default AzurePublicCloud)",
+                                          "enum": [
+                                            "AzurePublicCloud",
+                                            "AzureChinaCloud",
+                                            "AzureGermanCloud",
+                                            "AzureUSGovernmentCloud"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "hostedZoneName": {
+                                          "description": "name of the DNS zone that should be used",
+                                          "type": "string"
+                                        },
+                                        "managedIdentity": {
+                                          "description": "managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID",
+                                          "properties": {
+                                            "clientID": {
+                                              "description": "client ID of the managed identity, can not be used at the same time as resourceID",
+                                              "type": "string"
+                                            },
+                                            "resourceID": {
+                                              "description": "resource ID of the managed identity, can not be used at the same time as clientID",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "resourceGroupName": {
+                                          "description": "resource group the DNS zone is located in",
+                                          "type": "string"
+                                        },
+                                        "subscriptionID": {
+                                          "description": "ID of the Azure subscription",
+                                          "type": "string"
+                                        },
+                                        "tenantID": {
+                                          "description": "when specifying ClientID and ClientSecret then this field is also needed",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "resourceGroupName",
+                                        "subscriptionID"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "cloudDNS": {
+                                      "description": "Use the Google Cloud DNS API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "hostedZoneName": {
+                                          "description": "HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.",
+                                          "type": "string"
+                                        },
+                                        "project": {
+                                          "type": "string"
+                                        },
+                                        "serviceAccountSecretRef": {
+                                          "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [
+                                        "project"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "cloudflare": {
+                                      "description": "Use the Cloudflare API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "apiKeySecretRef": {
+                                          "description": "API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "apiTokenSecretRef": {
+                                          "description": "API token used to authenticate with Cloudflare.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "email": {
+                                          "description": "Email of the account, only required when using API key based authentication.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "cnameStrategy": {
+                                      "description": "CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.",
+                                      "enum": [
+                                        "None",
+                                        "Follow"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "digitalocean": {
+                                      "description": "Use the DigitalOcean DNS API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "tokenSecretRef": {
+                                          "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [
+                                        "tokenSecretRef"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "rfc2136": {
+                                      "description": "Use RFC2136 (\"Dynamic Updates in the Domain Name System\") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "nameserver": {
+                                          "description": "The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.",
+                                          "type": "string"
+                                        },
+                                        "tsigAlgorithm": {
+                                          "description": "The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.",
+                                          "type": "string"
+                                        },
+                                        "tsigKeyName": {
+                                          "description": "The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.",
+                                          "type": "string"
+                                        },
+                                        "tsigSecretSecretRef": {
+                                          "description": "The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [
+                                        "nameserver"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "route53": {
+                                      "description": "Use the AWS Route53 API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "accessKeyID": {
+                                          "description": "The AccessKeyID is used for authentication. Cannot be set when SecretAccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                                          "type": "string"
+                                        },
+                                        "accessKeyIDSecretRef": {
+                                          "description": "The SecretAccessKey is used for authentication. If set, pull the AWS access key ID from a key within a Kubernetes Secret. Cannot be set when AccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "hostedZoneID": {
+                                          "description": "If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.",
+                                          "type": "string"
+                                        },
+                                        "region": {
+                                          "description": "Always set the region when using AccessKeyID and SecretAccessKey",
+                                          "type": "string"
+                                        },
+                                        "role": {
+                                          "description": "Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata",
+                                          "type": "string"
+                                        },
+                                        "secretAccessKeySecretRef": {
+                                          "description": "The SecretAccessKey is used for authentication. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [
+                                        "region"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "webhook": {
+                                      "description": "Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "config": {
+                                          "description": "Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.",
+                                          "x-kubernetes-preserve-unknown-fields": true
+                                        },
+                                        "groupName": {
+                                          "description": "The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.",
+                                          "type": "string"
+                                        },
+                                        "solverName": {
+                                          "description": "The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "groupName",
+                                        "solverName"
+                                      ],
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "http01": {
+                                  "description": "Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.",
+                                  "properties": {
+                                    "gatewayHTTPRoute": {
+                                      "description": "The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.",
+                                      "properties": {
+                                        "labels": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "description": "Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.",
+                                          "type": "object"
+                                        },
+                                        "parentRefs": {
+                                          "description": "When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways",
+                                          "items": {
+                                            "description": "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object.",
+                                            "properties": {
+                                              "group": {
+                                                "default": "gateway.networking.k8s.io",
+                                                "description": "Group is the group of the referent. \n Support: Core",
+                                                "maxLength": 253,
+                                                "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "default": "Gateway",
+                                                "description": "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)",
+                                                "maxLength": 63,
+                                                "minLength": 1,
+                                                "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "Name is the name of the referent. \n Support: Core",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "description": "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core",
+                                                "maxLength": 63,
+                                                "minLength": 1,
+                                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                                "type": "string"
+                                              },
+                                              "sectionName": {
+                                                "description": "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "serviceType": {
+                                          "description": "Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "ingress": {
+                                      "description": "The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.",
+                                      "properties": {
+                                        "class": {
+                                          "description": "The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.",
+                                          "type": "string"
+                                        },
+                                        "ingressTemplate": {
+                                          "description": "Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.",
+                                          "properties": {
+                                            "metadata": {
+                                              "description": "ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.",
+                                              "properties": {
+                                                "annotations": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": "Annotations that should be added to the created ACME HTTP01 solver ingress.",
+                                                  "type": "object"
+                                                },
+                                                "labels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": "Labels that should be added to the created ACME HTTP01 solver ingress.",
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "description": "The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.",
+                                          "type": "string"
+                                        },
+                                        "podTemplate": {
+                                          "description": "Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.",
+                                          "properties": {
+                                            "metadata": {
+                                              "description": "ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.",
+                                              "properties": {
+                                                "annotations": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": "Annotations that should be added to the create ACME HTTP01 solver pods.",
+                                                  "type": "object"
+                                                },
+                                                "labels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": "Labels that should be added to the created ACME HTTP01 solver pods.",
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "spec": {
+                                              "description": "PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.",
+                                              "properties": {
+                                                "affinity": {
+                                                  "description": "If specified, the pod's scheduling constraints",
+                                                  "properties": {
+                                                    "nodeAffinity": {
+                                                      "description": "Describes node affinity scheduling rules for the pod.",
+                                                      "properties": {
+                                                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                                                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                                          "items": {
+                                                            "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                                            "properties": {
+                                                              "preference": {
+                                                                "description": "A node selector term, associated with the corresponding weight.",
+                                                                "properties": {
+                                                                  "matchExpressions": {
+                                                                    "description": "A list of node selector requirements by node's labels.",
+                                                                    "items": {
+                                                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "The label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "matchFields": {
+                                                                    "description": "A list of node selector requirements by node's fields.",
+                                                                    "items": {
+                                                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "The label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "weight": {
+                                                                "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                                                "format": "int32",
+                                                                "type": "integer"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "preference",
+                                                              "weight"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                          "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                                          "properties": {
+                                                            "nodeSelectorTerms": {
+                                                              "description": "Required. A list of node selector terms. The terms are ORed.",
+                                                              "items": {
+                                                                "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                                                "properties": {
+                                                                  "matchExpressions": {
+                                                                    "description": "A list of node selector requirements by node's labels.",
+                                                                    "items": {
+                                                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "The label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "matchFields": {
+                                                                    "description": "A list of node selector requirements by node's fields.",
+                                                                    "items": {
+                                                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "The label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "type": "array"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "nodeSelectorTerms"
+                                                          ],
+                                                          "type": "object"
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "podAffinity": {
+                                                      "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                                                      "properties": {
+                                                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                                                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                                          "items": {
+                                                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                                            "properties": {
+                                                              "podAffinityTerm": {
+                                                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                                "properties": {
+                                                                  "labelSelector": {
+                                                                    "description": "A label query over a set of resources, in this case pods.",
+                                                                    "properties": {
+                                                                      "matchExpressions": {
+                                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                        "items": {
+                                                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                          "properties": {
+                                                                            "key": {
+                                                                              "description": "key is the label key that the selector applies to.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            }
+                                                                          },
+                                                                          "required": [
+                                                                            "key",
+                                                                            "operator"
+                                                                          ],
+                                                                          "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                      },
+                                                                      "matchLabels": {
+                                                                        "additionalProperties": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                        "type": "object"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  "namespaceSelector": {
+                                                                    "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                                    "properties": {
+                                                                      "matchExpressions": {
+                                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                        "items": {
+                                                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                          "properties": {
+                                                                            "key": {
+                                                                              "description": "key is the label key that the selector applies to.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            }
+                                                                          },
+                                                                          "required": [
+                                                                            "key",
+                                                                            "operator"
+                                                                          ],
+                                                                          "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                      },
+                                                                      "matchLabels": {
+                                                                        "additionalProperties": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                        "type": "object"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  "namespaces": {
+                                                                    "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "topologyKey": {
+                                                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "topologyKey"
+                                                                ],
+                                                                "type": "object"
+                                                              },
+                                                              "weight": {
+                                                                "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                                                "format": "int32",
+                                                                "type": "integer"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "podAffinityTerm",
+                                                              "weight"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                          "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                                          "items": {
+                                                            "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \u003ctopologyKey\u003e matches that of any node on which a pod of the set of pods is running",
+                                                            "properties": {
+                                                              "labelSelector": {
+                                                                "description": "A label query over a set of resources, in this case pods.",
+                                                                "properties": {
+                                                                  "matchExpressions": {
+                                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                    "items": {
+                                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "key is the label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "matchLabels": {
+                                                                    "additionalProperties": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                    "type": "object"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "namespaceSelector": {
+                                                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                                "properties": {
+                                                                  "matchExpressions": {
+                                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                    "items": {
+                                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "key is the label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "matchLabels": {
+                                                                    "additionalProperties": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                    "type": "object"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "namespaces": {
+                                                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                                "items": {
+                                                                  "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              "topologyKey": {
+                                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "topologyKey"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "podAntiAffinity": {
+                                                      "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                                                      "properties": {
+                                                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                                                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                                          "items": {
+                                                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                                            "properties": {
+                                                              "podAffinityTerm": {
+                                                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                                "properties": {
+                                                                  "labelSelector": {
+                                                                    "description": "A label query over a set of resources, in this case pods.",
+                                                                    "properties": {
+                                                                      "matchExpressions": {
+                                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                        "items": {
+                                                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                          "properties": {
+                                                                            "key": {
+                                                                              "description": "key is the label key that the selector applies to.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            }
+                                                                          },
+                                                                          "required": [
+                                                                            "key",
+                                                                            "operator"
+                                                                          ],
+                                                                          "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                      },
+                                                                      "matchLabels": {
+                                                                        "additionalProperties": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                        "type": "object"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  "namespaceSelector": {
+                                                                    "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                                    "properties": {
+                                                                      "matchExpressions": {
+                                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                        "items": {
+                                                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                          "properties": {
+                                                                            "key": {
+                                                                              "description": "key is the label key that the selector applies to.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            }
+                                                                          },
+                                                                          "required": [
+                                                                            "key",
+                                                                            "operator"
+                                                                          ],
+                                                                          "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                      },
+                                                                      "matchLabels": {
+                                                                        "additionalProperties": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                        "type": "object"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  "namespaces": {
+                                                                    "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "topologyKey": {
+                                                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "topologyKey"
+                                                                ],
+                                                                "type": "object"
+                                                              },
+                                                              "weight": {
+                                                                "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                                                "format": "int32",
+                                                                "type": "integer"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "podAffinityTerm",
+                                                              "weight"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                          "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                                          "items": {
+                                                            "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \u003ctopologyKey\u003e matches that of any node on which a pod of the set of pods is running",
+                                                            "properties": {
+                                                              "labelSelector": {
+                                                                "description": "A label query over a set of resources, in this case pods.",
+                                                                "properties": {
+                                                                  "matchExpressions": {
+                                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                    "items": {
+                                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "key is the label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "matchLabels": {
+                                                                    "additionalProperties": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                    "type": "object"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "namespaceSelector": {
+                                                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                                "properties": {
+                                                                  "matchExpressions": {
+                                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                    "items": {
+                                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "key is the label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "matchLabels": {
+                                                                    "additionalProperties": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                    "type": "object"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "namespaces": {
+                                                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                                "items": {
+                                                                  "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              "topologyKey": {
+                                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "topologyKey"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "nodeSelector": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+                                                  "type": "object"
+                                                },
+                                                "priorityClassName": {
+                                                  "description": "If specified, the pod's priorityClassName.",
+                                                  "type": "string"
+                                                },
+                                                "serviceAccountName": {
+                                                  "description": "If specified, the pod's service account",
+                                                  "type": "string"
+                                                },
+                                                "tolerations": {
+                                                  "description": "If specified, the pod's tolerations.",
+                                                  "items": {
+                                                    "description": "The pod this Toleration is attached to tolerates any taint that matches the triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
+                                                    "properties": {
+                                                      "effect": {
+                                                        "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                                        "type": "string"
+                                                      },
+                                                      "key": {
+                                                        "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                                        "type": "string"
+                                                      },
+                                                      "tolerationSeconds": {
+                                                        "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                                        "format": "int64",
+                                                        "type": "integer"
+                                                      },
+                                                      "value": {
+                                                        "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "serviceType": {
+                                          "description": "Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "selector": {
+                                  "description": "Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.",
+                                  "properties": {
+                                    "dnsNames": {
+                                      "description": "List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "dnsZones": {
+                                      "description": "List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "A label selector that is used to refine the set of certificate's that this challenge solver will apply to.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "privateKeySecretRef",
+                          "server"
+                        ],
+                        "type": "object"
+                      },
+                      "ca": {
+                        "description": "CA configures this issuer to sign certificates using a signing CA keypair stored in a Secret resource. This is used to build internal PKIs that are managed by cert-manager.",
+                        "properties": {
+                          "crlDistributionPoints": {
+                            "description": "The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set, certificates will be issued without distribution points set.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "ocspServers": {
+                            "description": "The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be \"http://ocsp.int-x3.letsencrypt.org\".",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "secretName": {
+                            "description": "SecretName is the name of the secret used to sign Certificates issued by this Issuer.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "secretName"
+                        ],
+                        "type": "object"
+                      },
+                      "selfSigned": {
+                        "description": "SelfSigned configures this issuer to 'self sign' certificates using the private key used to create the CertificateRequest object.",
+                        "properties": {
+                          "crlDistributionPoints": {
+                            "description": "The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set certificate will be issued without CDP. Values are strings.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "vault": {
+                        "description": "Vault configures this issuer to sign certificates using a HashiCorp Vault PKI backend.",
+                        "properties": {
+                          "auth": {
+                            "description": "Auth configures how cert-manager authenticates with the Vault server.",
+                            "properties": {
+                              "appRole": {
+                                "description": "AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.",
+                                "properties": {
+                                  "path": {
+                                    "description": "Path where the App Role authentication backend is mounted in Vault, e.g: \"approle\"",
+                                    "type": "string"
+                                  },
+                                  "roleId": {
+                                    "description": "RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.",
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "description": "Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "path",
+                                  "roleId",
+                                  "secretRef"
+                                ],
+                                "type": "object"
+                              },
+                              "kubernetes": {
+                                "description": "Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.",
+                                "properties": {
+                                  "mountPath": {
+                                    "description": "The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value \"/v1/auth/kubernetes\" will be used.",
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "description": "A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.",
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "description": "The required Secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. Use of 'ambient credentials' is not supported.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "role",
+                                  "secretRef"
+                                ],
+                                "type": "object"
+                              },
+                              "tokenSecretRef": {
+                                "description": "TokenSecretRef authenticates with Vault by presenting a token.",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "caBundle": {
+                            "description": "PEM-encoded CA bundle (base64-encoded) used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.",
+                            "format": "byte",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: \"ns1\" More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "Path is the mount path of the Vault PKI backend's `sign` endpoint, e.g: \"my_pki_mount/sign/my-role-name\".",
+                            "type": "string"
+                          },
+                          "server": {
+                            "description": "Server is the connection address for the Vault server, e.g: \"https://vault.example.com:8200\".",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "auth",
+                          "path",
+                          "server"
+                        ],
+                        "type": "object"
+                      },
+                      "venafi": {
+                        "description": "Venafi configures this issuer to sign certificates using a Venafi TPP or Venafi Cloud policy zone.",
+                        "properties": {
+                          "cloud": {
+                            "description": "Cloud specifies the Venafi cloud configuration settings. Only one of TPP or Cloud may be specified.",
+                            "properties": {
+                              "apiTokenSecretRef": {
+                                "description": "APITokenSecretRef is a secret key selector for the Venafi Cloud API token.",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "url": {
+                                "description": "URL is the base URL for Venafi Cloud. Defaults to \"https://api.venafi.cloud/v1\".",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "apiTokenSecretRef"
+                            ],
+                            "type": "object"
+                          },
+                          "tpp": {
+                            "description": "TPP specifies Trust Protection Platform configuration settings. Only one of TPP or Cloud may be specified.",
+                            "properties": {
+                              "caBundle": {
+                                "description": "CABundle is a PEM encoded TLS certificate to use to verify connections to the TPP instance. If specified, system roots will not be used and the issuing CA for the TPP instance must be verifiable using the provided root. If not specified, the connection will be verified using the cert-manager system root certificates.",
+                                "format": "byte",
+                                "type": "string"
+                              },
+                              "credentialsRef": {
+                                "description": "CredentialsRef is a reference to a Secret containing the username and password for the TPP server. The secret must contain two keys, 'username' and 'password'.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "url": {
+                                "description": "URL is the base URL for the vedsdk endpoint of the Venafi TPP instance, for example: \"https://tpp.example.com/vedsdk\".",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "credentialsRef",
+                              "url"
+                            ],
+                            "type": "object"
+                          },
+                          "zone": {
+                            "description": "Zone is the Venafi Policy Zone to use for this issuer. All requests made to the Venafi platform will be restricted by the named zone policy. This field is required.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "zone"
+                        ],
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "status": {
+                    "description": "Status of the Issuer. This is set and managed automatically.",
+                    "properties": {
+                      "acme": {
+                        "description": "ACME specific status options. This field should only be set if the Issuer is configured to use an ACME server to issue certificates.",
+                        "properties": {
+                          "lastRegisteredEmail": {
+                            "description": "LastRegisteredEmail is the email associated with the latest registered ACME account, in order to track changes made to registered account associated with the  Issuer",
+                            "type": "string"
+                          },
+                          "uri": {
+                            "description": "URI is the unique account identifier, which can also be used to retrieve account details from the CA",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "conditions": {
+                        "description": "List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready`.",
+                        "items": {
+                          "description": "IssuerCondition contains condition information for an Issuer.",
+                          "properties": {
+                            "lastTransitionTime": {
+                              "description": "LastTransitionTime is the timestamp corresponding to the last status change of this condition.",
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "message": {
+                              "description": "Message is a human readable description of the details of the last transition, complementing reason.",
+                              "type": "string"
+                            },
+                            "observedGeneration": {
+                              "description": "If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "reason": {
+                              "description": "Reason is a brief machine readable explanation for the condition's last transition.",
+                              "type": "string"
+                            },
+                            "status": {
+                              "description": "Status of the condition, one of (`True`, `False`, `Unknown`).",
+                              "enum": [
+                                "True",
+                                "False",
+                                "Unknown"
+                              ],
+                              "type": "string"
+                            },
+                            "type": {
+                              "description": "Type of the condition, known values are (`Ready`).",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "status",
+                            "type"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "type"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "spec"
+                ],
+                "type": "object"
+              }
+            },
+            "served": true,
+            "storage": true,
+            "subresources": {
+              "status": {}
+            }
+          }
+        ]
+      },
+      "status": {
+        "acceptedNames": {
+          "categories": [
+            "cert-manager"
+          ],
+          "kind": "Issuer",
+          "listKind": "IssuerList",
+          "plural": "issuers",
+          "singular": "issuer"
+        },
+        "conditions": [
+          {
+            "lastTransitionTime": "2022-11-11T15:53:16Z",
+            "message": "no conflicts found",
+            "reason": "NoConflicts",
+            "status": "True",
+            "type": "NamesAccepted"
+          },
+          {
+            "lastTransitionTime": "2022-11-11T15:53:16Z",
+            "message": "the initial names have been accepted",
+            "reason": "InitialNamesAccepted",
+            "status": "True",
+            "type": "Established"
+          },
+          {
+            "lastTransitionTime": "2022-11-17T16:07:19Z",
+            "message": "removed all instances",
+            "reason": "InstanceDeletionCompleted",
+            "status": "False",
+            "type": "Terminating"
+          }
+        ],
+        "storedVersions": [
+          "v1"
+        ]
+      }
+    },
+    {
+      "apiVersion": "apiextensions.k8s.io/v1",
+      "kind": "CustomResourceDefinition",
+      "metadata": {
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apiextensions.k8s.io/v1\",\"kind\":\"CustomResourceDefinition\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"cert-manager\",\"app.kubernetes.io/instance\":\"cert-manager\",\"app.kubernetes.io/name\":\"cert-manager\",\"app.kubernetes.io/version\":\"v1.9.2-beta.0\"},\"name\":\"orders.acme.cert-manager.io\"},\"spec\":{\"group\":\"acme.cert-manager.io\",\"names\":{\"categories\":[\"cert-manager\",\"cert-manager-acme\"],\"kind\":\"Order\",\"listKind\":\"OrderList\",\"plural\":\"orders\",\"singular\":\"order\"},\"scope\":\"Namespaced\",\"versions\":[{\"additionalPrinterColumns\":[{\"jsonPath\":\".status.state\",\"name\":\"State\",\"type\":\"string\"},{\"jsonPath\":\".spec.issuerRef.name\",\"name\":\"Issuer\",\"priority\":1,\"type\":\"string\"},{\"jsonPath\":\".status.reason\",\"name\":\"Reason\",\"priority\":1,\"type\":\"string\"},{\"description\":\"CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\",\"jsonPath\":\".metadata.creationTimestamp\",\"name\":\"Age\",\"type\":\"date\"}],\"name\":\"v1\",\"schema\":{\"openAPIV3Schema\":{\"description\":\"Order is a type to represent an Order with an ACME server\",\"properties\":{\"apiVersion\":{\"description\":\"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources\",\"type\":\"string\"},\"kind\":{\"description\":\"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds\",\"type\":\"string\"},\"metadata\":{\"type\":\"object\"},\"spec\":{\"properties\":{\"commonName\":{\"description\":\"CommonName is the common name as specified on the DER encoded CSR. If specified, this value must also be present in `dnsNames` or `ipAddresses`. This field must match the corresponding field on the DER encoded CSR.\",\"type\":\"string\"},\"dnsNames\":{\"description\":\"DNSNames is a list of DNS names that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"duration\":{\"description\":\"Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.\",\"type\":\"string\"},\"ipAddresses\":{\"description\":\"IPAddresses is a list of IP addresses that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.\",\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"issuerRef\":{\"description\":\"IssuerRef references a properly configured ACME-type Issuer which should be used to create this Order. If the Issuer does not exist, processing will be retried. If the Issuer is not an 'ACME' Issuer, an error will be returned and the Order will be marked as failed.\",\"properties\":{\"group\":{\"description\":\"Group of the resource being referred to.\",\"type\":\"string\"},\"kind\":{\"description\":\"Kind of the resource being referred to.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to.\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"request\":{\"description\":\"Certificate signing request bytes in DER encoding. This will be used when finalizing the order. This field must be set on the order.\",\"format\":\"byte\",\"type\":\"string\"}},\"required\":[\"issuerRef\",\"request\"],\"type\":\"object\"},\"status\":{\"properties\":{\"authorizations\":{\"description\":\"Authorizations contains data returned from the ACME server on what authorizations must be completed in order to validate the DNS names specified on the Order.\",\"items\":{\"description\":\"ACMEAuthorization contains data returned from the ACME server on an authorization that must be completed in order validate a DNS name on an ACME Order resource.\",\"properties\":{\"challenges\":{\"description\":\"Challenges specifies the challenge types offered by the ACME server. One of these challenge types will be selected when validating the DNS name and an appropriate Challenge resource will be created to perform the ACME challenge process.\",\"items\":{\"description\":\"Challenge specifies a challenge offered by the ACME server for an Order. An appropriate Challenge resource can be created to perform the ACME challenge process.\",\"properties\":{\"token\":{\"description\":\"Token is the token that must be presented for this challenge. This is used to compute the 'key' that must also be presented.\",\"type\":\"string\"},\"type\":{\"description\":\"Type is the type of challenge being offered, e.g. 'http-01', 'dns-01', 'tls-sni-01', etc. This is the raw value retrieved from the ACME server. Only 'http-01' and 'dns-01' are supported by cert-manager, other values will be ignored.\",\"type\":\"string\"},\"url\":{\"description\":\"URL is the URL of this challenge. It can be used to retrieve additional metadata about the Challenge from the ACME server.\",\"type\":\"string\"}},\"required\":[\"token\",\"type\",\"url\"],\"type\":\"object\"},\"type\":\"array\"},\"identifier\":{\"description\":\"Identifier is the DNS name to be validated as part of this authorization\",\"type\":\"string\"},\"initialState\":{\"description\":\"InitialState is the initial state of the ACME authorization when first fetched from the ACME server. If an Authorization is already 'valid', the Order controller will not create a Challenge resource for the authorization. This will occur when working with an ACME server that enables 'authz reuse' (such as Let's Encrypt's production endpoint). If not set and 'identifier' is set, the state is assumed to be pending and a Challenge will be created.\",\"enum\":[\"valid\",\"ready\",\"pending\",\"processing\",\"invalid\",\"expired\",\"errored\"],\"type\":\"string\"},\"url\":{\"description\":\"URL is the URL of the Authorization that must be completed\",\"type\":\"string\"},\"wildcard\":{\"description\":\"Wildcard will be true if this authorization is for a wildcard DNS name. If this is true, the identifier will be the *non-wildcard* version of the DNS name. For example, if '*.example.com' is the DNS name being validated, this field will be 'true' and the 'identifier' field will be 'example.com'.\",\"type\":\"boolean\"}},\"required\":[\"url\"],\"type\":\"object\"},\"type\":\"array\"},\"certificate\":{\"description\":\"Certificate is a copy of the PEM encoded certificate for this Order. This field will be populated after the order has been successfully finalized with the ACME server, and the order has transitioned to the 'valid' state.\",\"format\":\"byte\",\"type\":\"string\"},\"failureTime\":{\"description\":\"FailureTime stores the time that this order failed. This is used to influence garbage collection and back-off.\",\"format\":\"date-time\",\"type\":\"string\"},\"finalizeURL\":{\"description\":\"FinalizeURL of the Order. This is used to obtain certificates for this order once it has been completed.\",\"type\":\"string\"},\"reason\":{\"description\":\"Reason optionally provides more information about a why the order is in the current state.\",\"type\":\"string\"},\"state\":{\"description\":\"State contains the current state of this Order resource. States 'success' and 'expired' are 'final'\",\"enum\":[\"valid\",\"ready\",\"pending\",\"processing\",\"invalid\",\"expired\",\"errored\"],\"type\":\"string\"},\"url\":{\"description\":\"URL of the Order. This will initially be empty when the resource is first created. The Order controller will populate this field when the Order is first processed. This field will be immutable after it is initially set.\",\"type\":\"string\"}},\"type\":\"object\"}},\"required\":[\"metadata\",\"spec\"],\"type\":\"object\"}},\"served\":true,\"storage\":true,\"subresources\":{\"status\":{}}}]}}\n"
+        },
+        "creationTimestamp": "2022-11-17T16:09:59Z",
+        "generation": 1,
+        "labels": {
+          "app": "cert-manager",
+          "app.kubernetes.io/instance": "cert-manager",
+          "app.kubernetes.io/name": "cert-manager",
+          "app.kubernetes.io/version": "v1.9.2-beta.0"
+        },
+        "name": "orders.acme.cert-manager.io",
+        "resourceVersion": "148282",
+        "uid": "6d45b082-8ef0-4b5a-96bd-67e02dafec91"
+      },
+      "spec": {
+        "conversion": {
+          "strategy": "None"
+        },
+        "group": "acme.cert-manager.io",
+        "names": {
+          "categories": [
+            "cert-manager",
+            "cert-manager-acme"
+          ],
+          "kind": "Order",
+          "listKind": "OrderList",
+          "plural": "orders",
+          "singular": "order"
+        },
+        "scope": "Namespaced",
+        "versions": [
+          {
+            "additionalPrinterColumns": [
+              {
+                "jsonPath": ".status.state",
+                "name": "State",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".spec.issuerRef.name",
+                "name": "Issuer",
+                "priority": 1,
+                "type": "string"
+              },
+              {
+                "jsonPath": ".status.reason",
+                "name": "Reason",
+                "priority": 1,
+                "type": "string"
+              },
+              {
+                "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.",
+                "jsonPath": ".metadata.creationTimestamp",
+                "name": "Age",
+                "type": "date"
+              }
+            ],
+            "name": "v1",
+            "schema": {
+              "openAPIV3Schema": {
+                "description": "Order is a type to represent an Order with an ACME server",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "type": "object"
+                  },
+                  "spec": {
+                    "properties": {
+                      "commonName": {
+                        "description": "CommonName is the common name as specified on the DER encoded CSR. If specified, this value must also be present in `dnsNames` or `ipAddresses`. This field must match the corresponding field on the DER encoded CSR.",
+                        "type": "string"
+                      },
+                      "dnsNames": {
+                        "description": "DNSNames is a list of DNS names that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "duration": {
+                        "description": "Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.",
+                        "type": "string"
+                      },
+                      "ipAddresses": {
+                        "description": "IPAddresses is a list of IP addresses that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "issuerRef": {
+                        "description": "IssuerRef references a properly configured ACME-type Issuer which should be used to create this Order. If the Issuer does not exist, processing will be retried. If the Issuer is not an 'ACME' Issuer, an error will be returned and the Order will be marked as failed.",
+                        "properties": {
+                          "group": {
+                            "description": "Group of the resource being referred to.",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "Kind of the resource being referred to.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the resource being referred to.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object"
+                      },
+                      "request": {
+                        "description": "Certificate signing request bytes in DER encoding. This will be used when finalizing the order. This field must be set on the order.",
+                        "format": "byte",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "issuerRef",
+                      "request"
+                    ],
+                    "type": "object"
+                  },
+                  "status": {
+                    "properties": {
+                      "authorizations": {
+                        "description": "Authorizations contains data returned from the ACME server on what authorizations must be completed in order to validate the DNS names specified on the Order.",
+                        "items": {
+                          "description": "ACMEAuthorization contains data returned from the ACME server on an authorization that must be completed in order validate a DNS name on an ACME Order resource.",
+                          "properties": {
+                            "challenges": {
+                              "description": "Challenges specifies the challenge types offered by the ACME server. One of these challenge types will be selected when validating the DNS name and an appropriate Challenge resource will be created to perform the ACME challenge process.",
+                              "items": {
+                                "description": "Challenge specifies a challenge offered by the ACME server for an Order. An appropriate Challenge resource can be created to perform the ACME challenge process.",
+                                "properties": {
+                                  "token": {
+                                    "description": "Token is the token that must be presented for this challenge. This is used to compute the 'key' that must also be presented.",
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "description": "Type is the type of challenge being offered, e.g. 'http-01', 'dns-01', 'tls-sni-01', etc. This is the raw value retrieved from the ACME server. Only 'http-01' and 'dns-01' are supported by cert-manager, other values will be ignored.",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "description": "URL is the URL of this challenge. It can be used to retrieve additional metadata about the Challenge from the ACME server.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "token",
+                                  "type",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "identifier": {
+                              "description": "Identifier is the DNS name to be validated as part of this authorization",
+                              "type": "string"
+                            },
+                            "initialState": {
+                              "description": "InitialState is the initial state of the ACME authorization when first fetched from the ACME server. If an Authorization is already 'valid', the Order controller will not create a Challenge resource for the authorization. This will occur when working with an ACME server that enables 'authz reuse' (such as Let's Encrypt's production endpoint). If not set and 'identifier' is set, the state is assumed to be pending and a Challenge will be created.",
+                              "enum": [
+                                "valid",
+                                "ready",
+                                "pending",
+                                "processing",
+                                "invalid",
+                                "expired",
+                                "errored"
+                              ],
+                              "type": "string"
+                            },
+                            "url": {
+                              "description": "URL is the URL of the Authorization that must be completed",
+                              "type": "string"
+                            },
+                            "wildcard": {
+                              "description": "Wildcard will be true if this authorization is for a wildcard DNS name. If this is true, the identifier will be the *non-wildcard* version of the DNS name. For example, if '*.example.com' is the DNS name being validated, this field will be 'true' and the 'identifier' field will be 'example.com'.",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "url"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "certificate": {
+                        "description": "Certificate is a copy of the PEM encoded certificate for this Order. This field will be populated after the order has been successfully finalized with the ACME server, and the order has transitioned to the 'valid' state.",
+                        "format": "byte",
+                        "type": "string"
+                      },
+                      "failureTime": {
+                        "description": "FailureTime stores the time that this order failed. This is used to influence garbage collection and back-off.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "finalizeURL": {
+                        "description": "FinalizeURL of the Order. This is used to obtain certificates for this order once it has been completed.",
+                        "type": "string"
+                      },
+                      "reason": {
+                        "description": "Reason optionally provides more information about a why the order is in the current state.",
+                        "type": "string"
+                      },
+                      "state": {
+                        "description": "State contains the current state of this Order resource. States 'success' and 'expired' are 'final'",
+                        "enum": [
+                          "valid",
+                          "ready",
+                          "pending",
+                          "processing",
+                          "invalid",
+                          "expired",
+                          "errored"
+                        ],
+                        "type": "string"
+                      },
+                      "url": {
+                        "description": "URL of the Order. This will initially be empty when the resource is first created. The Order controller will populate this field when the Order is first processed. This field will be immutable after it is initially set.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "metadata",
+                  "spec"
+                ],
+                "type": "object"
+              }
+            },
+            "served": true,
+            "storage": true,
+            "subresources": {
+              "status": {}
+            }
+          }
+        ]
+      },
+      "status": {
+        "acceptedNames": {
+          "categories": [
+            "cert-manager",
+            "cert-manager-acme"
+          ],
+          "kind": "Order",
+          "listKind": "OrderList",
+          "plural": "orders",
+          "singular": "order"
+        },
+        "conditions": [
+          {
+            "lastTransitionTime": "2022-11-17T16:09:59Z",
+            "message": "no conflicts found",
+            "reason": "NoConflicts",
+            "status": "True",
+            "type": "NamesAccepted"
+          },
+          {
+            "lastTransitionTime": "2022-11-17T16:09:59Z",
+            "message": "the initial names have been accepted",
+            "reason": "InitialNamesAccepted",
+            "status": "True",
+            "type": "Established"
+          }
+        ],
+        "storedVersions": [
+          "v1"
+        ]
+      }
+    }
+  ],
+  "kind": "List",
+  "metadata": {
+    "resourceVersion": "",
+    "selfLink": ""
+  }
+}

--- a/internal/kubernetes/backup/fixtures/crd-list.json
+++ b/internal/kubernetes/backup/fixtures/crd-list.json
@@ -1,0 +1,9940 @@
+{
+  "apiVersion": "v1",
+  "items": [
+    {
+      "apiVersion": "apiextensions.k8s.io/v1",
+      "kind": "CustomResourceDefinition",
+      "metadata": {
+        "annotations": {
+          "controller-gen.kubebuilder.io/version": "v0.4.1",
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apiextensions.k8s.io/v1\",\"kind\":\"CustomResourceDefinition\",\"metadata\":{\"annotations\":{\"controller-gen.kubebuilder.io/version\":\"v0.4.1\"},\"creationTimestamp\":null,\"name\":\"awspcaissuers.awspca.cert-manager.io\"},\"spec\":{\"group\":\"awspca.cert-manager.io\",\"names\":{\"kind\":\"AWSPCAIssuer\",\"listKind\":\"AWSPCAIssuerList\",\"plural\":\"awspcaissuers\",\"singular\":\"awspcaissuer\"},\"scope\":\"Namespaced\",\"versions\":[{\"name\":\"v1beta1\",\"schema\":{\"openAPIV3Schema\":{\"description\":\"AWSPCAIssuer is the Schema for the awspcaissuers API\",\"properties\":{\"apiVersion\":{\"description\":\"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources\",\"type\":\"string\"},\"kind\":{\"description\":\"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds\",\"type\":\"string\"},\"metadata\":{\"type\":\"object\"},\"spec\":{\"description\":\"AWSPCAIssuerSpec defines the desired state of AWSPCAIssuer\",\"properties\":{\"arn\":{\"description\":\"Specifies the ARN of the PCA resource\",\"type\":\"string\"},\"region\":{\"description\":\"Should contain the AWS region if it cannot be inferred\",\"type\":\"string\"},\"secretRef\":{\"description\":\"Needs to be specified if you want to authorize with AWS using an access and secret key\",\"properties\":{\"name\":{\"description\":\"Name is unique within a namespace to reference a secret resource.\",\"type\":\"string\"},\"namespace\":{\"description\":\"Namespace defines the space within which the secret name must be unique.\",\"type\":\"string\"}},\"type\":\"object\"}},\"type\":\"object\"},\"status\":{\"description\":\"AWSPCAIssuerStatus defines the observed state of AWSPCAIssuer\",\"properties\":{\"conditions\":{\"items\":{\"description\":\"Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \\\"Available\\\", \\\"Progressing\\\", and \\\"Degraded\\\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\\\"conditions,omitempty\\\" patchStrategy:\\\"merge\\\" patchMergeKey:\\\"type\\\" protobuf:\\\"bytes,1,rep,name=conditions\\\"` \\n     // other fields }\",\"properties\":{\"lastTransitionTime\":{\"description\":\"lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.\",\"format\":\"date-time\",\"type\":\"string\"},\"message\":{\"description\":\"message is a human readable message indicating details about the transition. This may be an empty string.\",\"maxLength\":32768,\"type\":\"string\"},\"observedGeneration\":{\"description\":\"observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.\",\"format\":\"int64\",\"minimum\":0,\"type\":\"integer\"},\"reason\":{\"description\":\"reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.\",\"maxLength\":1024,\"minLength\":1,\"pattern\":\"^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$\",\"type\":\"string\"},\"status\":{\"description\":\"status of the condition, one of True, False, Unknown.\",\"enum\":[\"True\",\"False\",\"Unknown\"],\"type\":\"string\"},\"type\":{\"description\":\"type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)\",\"maxLength\":316,\"pattern\":\"^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$\",\"type\":\"string\"}},\"required\":[\"lastTransitionTime\",\"message\",\"reason\",\"status\",\"type\"],\"type\":\"object\"},\"type\":\"array\"}},\"type\":\"object\"}},\"type\":\"object\"}},\"served\":true,\"storage\":true,\"subresources\":{\"status\":{}}}]},\"status\":{\"acceptedNames\":{\"kind\":\"\",\"plural\":\"\"},\"conditions\":[],\"storedVersions\":[]}}\n"
+        },
+        "creationTimestamp": "2022-11-04T16:27:37Z",
+        "generation": 1,
+        "name": "awspcaissuers.awspca.cert-manager.io",
+        "resourceVersion": "183863",
+        "uid": "786ad3c6-642e-4272-bda1-1797801572a5"
+      },
+      "spec": {
+        "conversion": {
+          "strategy": "None"
+        },
+        "group": "awspca.cert-manager.io",
+        "names": {
+          "kind": "AWSPCAIssuer",
+          "listKind": "AWSPCAIssuerList",
+          "plural": "awspcaissuers",
+          "singular": "awspcaissuer"
+        },
+        "scope": "Namespaced",
+        "versions": [
+          {
+            "name": "v1beta1",
+            "schema": {
+              "openAPIV3Schema": {
+                "description": "AWSPCAIssuer is the Schema for the awspcaissuers API",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "type": "object"
+                  },
+                  "spec": {
+                    "description": "AWSPCAIssuerSpec defines the desired state of AWSPCAIssuer",
+                    "properties": {
+                      "arn": {
+                        "description": "Specifies the ARN of the PCA resource",
+                        "type": "string"
+                      },
+                      "region": {
+                        "description": "Should contain the AWS region if it cannot be inferred",
+                        "type": "string"
+                      },
+                      "secretRef": {
+                        "description": "Needs to be specified if you want to authorize with AWS using an access and secret key",
+                        "properties": {
+                          "name": {
+                            "description": "Name is unique within a namespace to reference a secret resource.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace defines the space within which the secret name must be unique.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "status": {
+                    "description": "AWSPCAIssuerStatus defines the observed state of AWSPCAIssuer",
+                    "properties": {
+                      "conditions": {
+                        "items": {
+                          "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }",
+                          "properties": {
+                            "lastTransitionTime": {
+                              "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "message": {
+                              "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                              "maxLength": 32768,
+                              "type": "string"
+                            },
+                            "observedGeneration": {
+                              "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                              "format": "int64",
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "reason": {
+                              "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                              "maxLength": 1024,
+                              "minLength": 1,
+                              "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                              "type": "string"
+                            },
+                            "status": {
+                              "description": "status of the condition, one of True, False, Unknown.",
+                              "enum": [
+                                "True",
+                                "False",
+                                "Unknown"
+                              ],
+                              "type": "string"
+                            },
+                            "type": {
+                              "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                              "maxLength": 316,
+                              "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "lastTransitionTime",
+                            "message",
+                            "reason",
+                            "status",
+                            "type"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "served": true,
+            "storage": true,
+            "subresources": {
+              "status": {}
+            }
+          }
+        ]
+      },
+      "status": {
+        "acceptedNames": {
+          "kind": "AWSPCAIssuer",
+          "listKind": "AWSPCAIssuerList",
+          "plural": "awspcaissuers",
+          "singular": "awspcaissuer"
+        },
+        "conditions": [
+          {
+            "lastTransitionTime": "2022-11-04T16:27:37Z",
+            "message": "no conflicts found",
+            "reason": "NoConflicts",
+            "status": "True",
+            "type": "NamesAccepted"
+          },
+          {
+            "lastTransitionTime": "2022-11-04T16:27:37Z",
+            "message": "the initial names have been accepted",
+            "reason": "InitialNamesAccepted",
+            "status": "True",
+            "type": "Established"
+          }
+        ],
+        "storedVersions": [
+          "v1beta1"
+        ]
+      }
+    },
+    {
+      "apiVersion": "apiextensions.k8s.io/v1",
+      "kind": "CustomResourceDefinition",
+      "metadata": {
+        "annotations": {
+          "controller-gen.kubebuilder.io/version": "v0.9.2",
+          "operator.jetstack.io/component": "approver-policy",
+          "operator.jetstack.io/component-version": "v0.4.0"
+        },
+        "creationTimestamp": "2022-11-03T14:15:13Z",
+        "finalizers": [
+          "operator.jetstack.io/crd-controller"
+        ],
+        "generation": 1,
+        "name": "certificaterequestpolicies.policy.cert-manager.io",
+        "ownerReferences": [
+          {
+            "apiVersion": "operator.jetstack.io/v1alpha1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Installation",
+            "name": "installation",
+            "uid": "648c8b6d-3c85-4faa-9497-1eedc3873baf"
+          }
+        ],
+        "resourceVersion": "71319",
+        "uid": "07d7692f-71da-48a2-833b-82d4a3878544"
+      },
+      "spec": {
+        "conversion": {
+          "strategy": "None"
+        },
+        "group": "policy.cert-manager.io",
+        "names": {
+          "categories": [
+            "cert-manager"
+          ],
+          "kind": "CertificateRequestPolicy",
+          "listKind": "CertificateRequestPolicyList",
+          "plural": "certificaterequestpolicies",
+          "shortNames": [
+            "crp"
+          ],
+          "singular": "certificaterequestpolicy"
+        },
+        "scope": "Cluster",
+        "versions": [
+          {
+            "additionalPrinterColumns": [
+              {
+                "description": "CertificateRequestPolicy is ready for evaluation",
+                "jsonPath": ".status.conditions[?(@.type == \"Ready\")].status",
+                "name": "Ready",
+                "type": "string"
+              },
+              {
+                "description": "Timestamp CertificateRequestPolicy was created",
+                "jsonPath": ".metadata.creationTimestamp",
+                "name": "Age",
+                "type": "date"
+              }
+            ],
+            "name": "v1alpha1",
+            "schema": {
+              "openAPIV3Schema": {
+                "description": "CertificateRequestPolicy is an object for describing a \"policy profile\" that makes decisions on whether applicable CertificateRequests should be approved or denied.",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "type": "object"
+                  },
+                  "spec": {
+                    "description": "CertificateRequestPolicySpec defines the desired state of CertificateRequestPolicy.",
+                    "properties": {
+                      "allowed": {
+                        "description": "Allowed is the set of attributes that are \"allowed\" by this policy. A CertificateRequest will only be considered permissible for this policy if the CertificateRequest has the same or less as what is allowed.  Empty or `nil` allowed fields mean CertificateRequests are not allowed to have that field present to be permissible.",
+                        "properties": {
+                          "commonName": {
+                            "description": "CommonName defines the X.509 Common Name that is permissible.",
+                            "properties": {
+                              "required": {
+                                "description": "Required marks this field as being a required value on the request. May only be set to true if Value is also defined.",
+                                "type": "boolean"
+                              },
+                              "value": {
+                                "description": "Value defines the value that is permissible to be present on the request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids the value from being requested. An empty string is equivalent to `nil`, however an empty string pared with Required as `true` is an impossible condition that always denies. Value may not be `nil` if Required is `true`.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "dnsNames": {
+                            "description": "DNSNames defines the X.509 DNS SANs that may be requested for. Accepts wildcards \"*\".",
+                            "properties": {
+                              "required": {
+                                "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                "type": "boolean"
+                              },
+                              "values": {
+                                "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "emailAddresses": {
+                            "description": "EmailAddresses defines the X.509 Email SANs that may be requested for.",
+                            "properties": {
+                              "required": {
+                                "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                "type": "boolean"
+                              },
+                              "values": {
+                                "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "ipAddresses": {
+                            "description": "IPAddresses defines the X.509 IP SANs that may be requested for.",
+                            "properties": {
+                              "required": {
+                                "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                "type": "boolean"
+                              },
+                              "values": {
+                                "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "isCA": {
+                            "description": "IsCA defines whether it is permissible for a CertificateRequest to have the `spec.IsCA` field set to `true`. An omitted field, value of `nil` or `false`, forbids the `spec.IsCA` field from bring `true`. A value of `true` permits CertificateRequests setting the `spec.IsCA` field to `true`.",
+                            "type": "boolean"
+                          },
+                          "subject": {
+                            "description": "Subject defines the X.509 subject that is permissible. An omitted field or value of `nil` forbids any Subject being requested.",
+                            "properties": {
+                              "countries": {
+                                "description": "Countries define the X.509 Subject Countries that may be requested for.",
+                                "properties": {
+                                  "required": {
+                                    "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                    "type": "boolean"
+                                  },
+                                  "values": {
+                                    "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "localities": {
+                                "description": "Localities defines the X.509 Subject Localities that may be requested for.",
+                                "properties": {
+                                  "required": {
+                                    "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                    "type": "boolean"
+                                  },
+                                  "values": {
+                                    "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "organizationalUnits": {
+                                "description": "OrganizationalUnits defines the X.509 Subject Organizational Units that may be requested for.",
+                                "properties": {
+                                  "required": {
+                                    "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                    "type": "boolean"
+                                  },
+                                  "values": {
+                                    "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "organizations": {
+                                "description": "Organizations define the X.509 Subject Organizations that may be requested for.",
+                                "properties": {
+                                  "required": {
+                                    "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                    "type": "boolean"
+                                  },
+                                  "values": {
+                                    "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "postalCodes": {
+                                "description": "PostalCodes defines the X.509 Subject Postal Codes that may be requested for.",
+                                "properties": {
+                                  "required": {
+                                    "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                    "type": "boolean"
+                                  },
+                                  "values": {
+                                    "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "provinces": {
+                                "description": "Provinces defines the X.509 Subject Provinces that may be requested for.",
+                                "properties": {
+                                  "required": {
+                                    "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                    "type": "boolean"
+                                  },
+                                  "values": {
+                                    "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "serialNumber": {
+                                "description": "SerialNumber defines the X.509 Subject Serial Number that may be requested for.",
+                                "properties": {
+                                  "required": {
+                                    "description": "Required marks this field as being a required value on the request. May only be set to true if Value is also defined.",
+                                    "type": "boolean"
+                                  },
+                                  "value": {
+                                    "description": "Value defines the value that is permissible to be present on the request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids the value from being requested. An empty string is equivalent to `nil`, however an empty string pared with Required as `true` is an impossible condition that always denies. Value may not be `nil` if Required is `true`.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "streetAddresses": {
+                                "description": "StreetAddresses defines the X.509 Subject Street Addresses that may be requested for.",
+                                "properties": {
+                                  "required": {
+                                    "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                    "type": "boolean"
+                                  },
+                                  "values": {
+                                    "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "uris": {
+                            "description": "URIs defines the X.509 URI SANs that may be requested for.",
+                            "properties": {
+                              "required": {
+                                "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                "type": "boolean"
+                              },
+                              "values": {
+                                "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "usages": {
+                            "description": "Usages defines the list of permissible key usages that may appear on the CertificateRequest `spec.keyUsages` field. An omitted field or value of `nil` forbids any Usages being requested. An empty slice `[]` is equivalent to `nil`.",
+                            "items": {
+                              "description": "KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12 Valid KeyUsage values are as follows: \"signing\", \"digital signature\", \"content commitment\", \"key encipherment\", \"key agreement\", \"data encipherment\", \"cert sign\", \"crl sign\", \"encipher only\", \"decipher only\", \"any\", \"server auth\", \"client auth\", \"code signing\", \"email protection\", \"s/mime\", \"ipsec end system\", \"ipsec tunnel\", \"ipsec user\", \"timestamping\", \"ocsp signing\", \"microsoft sgc\", \"netscape sgc\"",
+                              "enum": [
+                                "signing",
+                                "digital signature",
+                                "content commitment",
+                                "key encipherment",
+                                "key agreement",
+                                "data encipherment",
+                                "cert sign",
+                                "crl sign",
+                                "encipher only",
+                                "decipher only",
+                                "any",
+                                "server auth",
+                                "client auth",
+                                "code signing",
+                                "email protection",
+                                "s/mime",
+                                "ipsec end system",
+                                "ipsec tunnel",
+                                "ipsec user",
+                                "timestamping",
+                                "ocsp signing",
+                                "microsoft sgc",
+                                "netscape sgc"
+                              ],
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "constraints": {
+                        "description": "Constraints is the set of attributes that _must_ be satisfied by the CertificateRequest for the request to be permissible by the policy. Empty or `nil` constraint fields mean CertificateRequests satisfy that field with any value of their corresponding attribute.",
+                        "properties": {
+                          "maxDuration": {
+                            "description": "MaxDuration defines the maximum duration a certificate may be requested for. Values are inclusive (i.e. a max value of `1h` will accept a duration of `1h`). MaxDuration and MinDuration may be the same value. An omitted field or value of `nil` permits any maximum duration. If MaxDuration is defined, a duration _must_ be requested on the CertificateRequest.",
+                            "type": "string"
+                          },
+                          "minDuration": {
+                            "description": "MinDuration defines the minimum duration a certificate may be requested for. Values are inclusive (i.e. a min value of `1h` will accept a duration of `1h`). MinDuration and MaxDuration may be the same value. An omitted field or value of `nil` permits any minimum duration. If MinDuration is defined, a duration _must_ be requested on the CertificateRequest.",
+                            "type": "string"
+                          },
+                          "privateKey": {
+                            "description": "PrivateKey defines the shape of permissible private keys that may be used for the request with this policy. An omitted field or value of `nil` permits the use of any private key by the requestor.",
+                            "properties": {
+                              "algorithm": {
+                                "description": "Algorithm defines the allowed crypto algorithm that is used by the requestor for their private key in their request. An omitted field or value of `nil` permits any Algorithm.",
+                                "enum": [
+                                  "RSA",
+                                  "ECDSA",
+                                  "Ed25519"
+                                ],
+                                "type": "string"
+                              },
+                              "maxSize": {
+                                "description": "MaxSize defines the maximum key size a requestor may use for their private key. Values are inclusive (i.e. a min value of `2048` will accept a size of `2048`). MaxSize and MinSize may be the same value. An omitted field or value of `nil` permits any maximum size.",
+                                "type": "integer"
+                              },
+                              "minSize": {
+                                "description": "MinSize defines the minimum key size a requestor may use for their private key. Values are inclusive (i.e. a min value of `2048` will accept a size of `2048`). MinSize and MaxSize may be the same value. An omitted field or value of `nil` permits any minimum size.",
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "plugins": {
+                        "additionalProperties": {
+                          "description": "CertificateRequestPolicyPluginData is configuration needed by the plugin approver to evaluate a CertificateRequest on this policy.",
+                          "properties": {
+                            "values": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Values define a set of well-known, to the plugin, key value pairs that are required for the plugin to successfully evaluate a request based on this policy.",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "description": "Plugins define a set of plugins and their configuration that should be executed when this policy is evaluated against a CertificateRequest. A plugin must already be built within approver-policy for it to be available.",
+                        "type": "object"
+                      },
+                      "selector": {
+                        "description": "Selector is used for selecting over which CertificateRequests this CertificateRequestPolicy is appropriate for and so will used for its evaluation.",
+                        "properties": {
+                          "issuerRef": {
+                            "description": "IssuerRef is used to match this CertificateRequestPolicy against processed CertificateRequests. This policy will only be evaluated against a CertificateRequest whose `spec.issuerRef` field matches `spec.selector.issuerRef`. CertificateRequests will not be processed on unmatched `issuerRef`, regardless of whether the requestor is bound by RBAC. Accepts wildcards \"*\". Nil values are equivalent to \"*\", \n The following value will match _all_ `issuerRefs`: ``` issuerRef: {} ``` \n Required field.",
+                            "properties": {
+                              "group": {
+                                "description": "Group is the wildcard selector to match the `spec.issuerRef.group` field on requests. Accepts wildcards \"*\". An omitted field or value of `nil` matches all.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind is the wildcard selector to match the `spec.issuerRef.kind` field on requests. Accepts wildcards \"*\". An omitted field or value of `nil` matches all.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the wildcard selector to match the `spec.issuerRef.name` field on requests. Accepts wildcards \"*\". An omitted field or value of `nil` matches all.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "required": [
+                          "issuerRef"
+                        ],
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "selector"
+                    ],
+                    "type": "object"
+                  },
+                  "status": {
+                    "description": "CertificateRequestPolicyStatus defines the observed state of the CertificateRequestPolicy.",
+                    "properties": {
+                      "conditions": {
+                        "description": "List of status conditions to indicate the status of the CertificateRequestPolicy. Known condition types are `Ready`.",
+                        "items": {
+                          "description": "CertificateRequestPolicyCondition contains condition information for a CertificateRequestPolicyStatus.",
+                          "properties": {
+                            "lastTransitionTime": {
+                              "description": "LastTransitionTime is the timestamp corresponding to the last status change of this condition.",
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "message": {
+                              "description": "Message is a human readable description of the details of the last transition, complementing reason.",
+                              "type": "string"
+                            },
+                            "observedGeneration": {
+                              "description": "If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the CertificateRequestPolicy.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "reason": {
+                              "description": "Reason is a brief machine readable explanation for the condition's last transition.",
+                              "type": "string"
+                            },
+                            "status": {
+                              "description": "Status of the condition, one of ('True', 'False', 'Unknown').",
+                              "type": "string"
+                            },
+                            "type": {
+                              "description": "Type of the condition, known values are (`Ready`).",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "status",
+                            "type"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "served": true,
+            "storage": true,
+            "subresources": {
+              "status": {}
+            }
+          }
+        ]
+      },
+      "status": {
+        "acceptedNames": {
+          "categories": [
+            "cert-manager"
+          ],
+          "kind": "CertificateRequestPolicy",
+          "listKind": "CertificateRequestPolicyList",
+          "plural": "certificaterequestpolicies",
+          "shortNames": [
+            "crp"
+          ],
+          "singular": "certificaterequestpolicy"
+        },
+        "conditions": [
+          {
+            "lastTransitionTime": "2022-11-03T14:15:13Z",
+            "message": "no conflicts found",
+            "reason": "NoConflicts",
+            "status": "True",
+            "type": "NamesAccepted"
+          },
+          {
+            "lastTransitionTime": "2022-11-03T14:15:13Z",
+            "message": "the initial names have been accepted",
+            "reason": "InitialNamesAccepted",
+            "status": "True",
+            "type": "Established"
+          }
+        ],
+        "storedVersions": [
+          "v1alpha1"
+        ]
+      }
+    },
+    {
+      "apiVersion": "apiextensions.k8s.io/v1",
+      "kind": "CustomResourceDefinition",
+      "metadata": {
+        "annotations": {
+          "operator.jetstack.io/component": "cert-manager",
+          "operator.jetstack.io/component-version": "v1.9.1"
+        },
+        "creationTimestamp": "2022-11-03T14:15:18Z",
+        "generation": 1,
+        "labels": {
+          "app": "cert-manager",
+          "app.kubernetes.io/instance": "cert-manager",
+          "app.kubernetes.io/name": "cert-manager",
+          "app.kubernetes.io/version": "v1.9.1"
+        },
+        "name": "certificaterequests.cert-manager.io",
+        "ownerReferences": [
+          {
+            "apiVersion": "operator.jetstack.io/v1alpha1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Installation",
+            "name": "installation",
+            "uid": "648c8b6d-3c85-4faa-9497-1eedc3873baf"
+          }
+        ],
+        "resourceVersion": "71247",
+        "uid": "795d9265-abb6-4f91-9d17-497ae1b341e1"
+      },
+      "spec": {
+        "conversion": {
+          "strategy": "None"
+        },
+        "group": "cert-manager.io",
+        "names": {
+          "categories": [
+            "cert-manager"
+          ],
+          "kind": "CertificateRequest",
+          "listKind": "CertificateRequestList",
+          "plural": "certificaterequests",
+          "shortNames": [
+            "cr",
+            "crs"
+          ],
+          "singular": "certificaterequest"
+        },
+        "scope": "Namespaced",
+        "versions": [
+          {
+            "additionalPrinterColumns": [
+              {
+                "jsonPath": ".status.conditions[?(@.type==\"Approved\")].status",
+                "name": "Approved",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".status.conditions[?(@.type==\"Denied\")].status",
+                "name": "Denied",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".status.conditions[?(@.type==\"Ready\")].status",
+                "name": "Ready",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".spec.issuerRef.name",
+                "name": "Issuer",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".spec.username",
+                "name": "Requestor",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".status.conditions[?(@.type==\"Ready\")].message",
+                "name": "Status",
+                "priority": 1,
+                "type": "string"
+              },
+              {
+                "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.",
+                "jsonPath": ".metadata.creationTimestamp",
+                "name": "Age",
+                "type": "date"
+              }
+            ],
+            "name": "v1",
+            "schema": {
+              "openAPIV3Schema": {
+                "description": "A CertificateRequest is used to request a signed certificate from one of the configured issuers. \n All fields within the CertificateRequest's `spec` are immutable after creation. A CertificateRequest will either succeed or fail, as denoted by its `status.state` field. \n A CertificateRequest is a one-shot resource, meaning it represents a single point in time request for a certificate and cannot be re-used.",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "type": "object"
+                  },
+                  "spec": {
+                    "description": "Desired state of the CertificateRequest resource.",
+                    "properties": {
+                      "duration": {
+                        "description": "The requested 'duration' (i.e. lifetime) of the Certificate. This option may be ignored/overridden by some issuer types.",
+                        "type": "string"
+                      },
+                      "extra": {
+                        "additionalProperties": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "description": "Extra contains extra attributes of the user that created the CertificateRequest. Populated by the cert-manager webhook on creation and immutable.",
+                        "type": "object"
+                      },
+                      "groups": {
+                        "description": "Groups contains group membership of the user that created the CertificateRequest. Populated by the cert-manager webhook on creation and immutable.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "isCA": {
+                        "description": "IsCA will request to mark the certificate as valid for certificate signing when submitting to the issuer. This will automatically add the `cert sign` usage to the list of `usages`.",
+                        "type": "boolean"
+                      },
+                      "issuerRef": {
+                        "description": "IssuerRef is a reference to the issuer for this CertificateRequest.  If the `kind` field is not set, or set to `Issuer`, an Issuer resource with the given name in the same namespace as the CertificateRequest will be used.  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the provided name will be used. The `name` field in this stanza is required at all times. The group field refers to the API group of the issuer which defaults to `cert-manager.io` if empty.",
+                        "properties": {
+                          "group": {
+                            "description": "Group of the resource being referred to.",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "Kind of the resource being referred to.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the resource being referred to.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object"
+                      },
+                      "request": {
+                        "description": "The PEM-encoded x509 certificate signing request to be submitted to the CA for signing.",
+                        "format": "byte",
+                        "type": "string"
+                      },
+                      "uid": {
+                        "description": "UID contains the uid of the user that created the CertificateRequest. Populated by the cert-manager webhook on creation and immutable.",
+                        "type": "string"
+                      },
+                      "usages": {
+                        "description": "Usages is the set of x509 usages that are requested for the certificate. If usages are set they SHOULD be encoded inside the CSR spec Defaults to `digital signature` and `key encipherment` if not specified.",
+                        "items": {
+                          "description": "KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12 Valid KeyUsage values are as follows: \"signing\", \"digital signature\", \"content commitment\", \"key encipherment\", \"key agreement\", \"data encipherment\", \"cert sign\", \"crl sign\", \"encipher only\", \"decipher only\", \"any\", \"server auth\", \"client auth\", \"code signing\", \"email protection\", \"s/mime\", \"ipsec end system\", \"ipsec tunnel\", \"ipsec user\", \"timestamping\", \"ocsp signing\", \"microsoft sgc\", \"netscape sgc\"",
+                          "enum": [
+                            "signing",
+                            "digital signature",
+                            "content commitment",
+                            "key encipherment",
+                            "key agreement",
+                            "data encipherment",
+                            "cert sign",
+                            "crl sign",
+                            "encipher only",
+                            "decipher only",
+                            "any",
+                            "server auth",
+                            "client auth",
+                            "code signing",
+                            "email protection",
+                            "s/mime",
+                            "ipsec end system",
+                            "ipsec tunnel",
+                            "ipsec user",
+                            "timestamping",
+                            "ocsp signing",
+                            "microsoft sgc",
+                            "netscape sgc"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "username": {
+                        "description": "Username contains the name of the user that created the CertificateRequest. Populated by the cert-manager webhook on creation and immutable.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "issuerRef",
+                      "request"
+                    ],
+                    "type": "object"
+                  },
+                  "status": {
+                    "description": "Status of the CertificateRequest. This is set and managed automatically.",
+                    "properties": {
+                      "ca": {
+                        "description": "The PEM encoded x509 certificate of the signer, also known as the CA (Certificate Authority). This is set on a best-effort basis by different issuers. If not set, the CA is assumed to be unknown/not available.",
+                        "format": "byte",
+                        "type": "string"
+                      },
+                      "certificate": {
+                        "description": "The PEM encoded x509 certificate resulting from the certificate signing request. If not set, the CertificateRequest has either not been completed or has failed. More information on failure can be found by checking the `conditions` field.",
+                        "format": "byte",
+                        "type": "string"
+                      },
+                      "conditions": {
+                        "description": "List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready` and `InvalidRequest`.",
+                        "items": {
+                          "description": "CertificateRequestCondition contains condition information for a CertificateRequest.",
+                          "properties": {
+                            "lastTransitionTime": {
+                              "description": "LastTransitionTime is the timestamp corresponding to the last status change of this condition.",
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "message": {
+                              "description": "Message is a human readable description of the details of the last transition, complementing reason.",
+                              "type": "string"
+                            },
+                            "reason": {
+                              "description": "Reason is a brief machine readable explanation for the condition's last transition.",
+                              "type": "string"
+                            },
+                            "status": {
+                              "description": "Status of the condition, one of (`True`, `False`, `Unknown`).",
+                              "enum": [
+                                "True",
+                                "False",
+                                "Unknown"
+                              ],
+                              "type": "string"
+                            },
+                            "type": {
+                              "description": "Type of the condition, known values are (`Ready`, `InvalidRequest`, `Approved`, `Denied`).",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "status",
+                            "type"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "type"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "failureTime": {
+                        "description": "FailureTime stores the time that this CertificateRequest failed. This is used to influence garbage collection and back-off.",
+                        "format": "date-time",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "spec"
+                ],
+                "type": "object"
+              }
+            },
+            "served": true,
+            "storage": true,
+            "subresources": {
+              "status": {}
+            }
+          }
+        ]
+      },
+      "status": {
+        "acceptedNames": {
+          "categories": [
+            "cert-manager"
+          ],
+          "kind": "CertificateRequest",
+          "listKind": "CertificateRequestList",
+          "plural": "certificaterequests",
+          "shortNames": [
+            "cr",
+            "crs"
+          ],
+          "singular": "certificaterequest"
+        },
+        "conditions": [
+          {
+            "lastTransitionTime": "2022-11-03T14:15:18Z",
+            "message": "no conflicts found",
+            "reason": "NoConflicts",
+            "status": "True",
+            "type": "NamesAccepted"
+          },
+          {
+            "lastTransitionTime": "2022-11-03T14:15:18Z",
+            "message": "the initial names have been accepted",
+            "reason": "InitialNamesAccepted",
+            "status": "True",
+            "type": "Established"
+          }
+        ],
+        "storedVersions": [
+          "v1"
+        ]
+      }
+    },
+    {
+      "apiVersion": "apiextensions.k8s.io/v1",
+      "kind": "CustomResourceDefinition",
+      "metadata": {
+        "annotations": {
+          "operator.jetstack.io/component": "cert-manager",
+          "operator.jetstack.io/component-version": "v1.9.1"
+        },
+        "creationTimestamp": "2022-11-03T14:15:18Z",
+        "generation": 1,
+        "labels": {
+          "app": "cert-manager",
+          "app.kubernetes.io/instance": "cert-manager",
+          "app.kubernetes.io/name": "cert-manager",
+          "app.kubernetes.io/version": "v1.9.1"
+        },
+        "name": "certificates.cert-manager.io",
+        "ownerReferences": [
+          {
+            "apiVersion": "operator.jetstack.io/v1alpha1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Installation",
+            "name": "installation",
+            "uid": "648c8b6d-3c85-4faa-9497-1eedc3873baf"
+          }
+        ],
+        "resourceVersion": "71254",
+        "uid": "462f5d86-39cc-40d7-845f-1b41006cfdf9"
+      },
+      "spec": {
+        "conversion": {
+          "strategy": "None"
+        },
+        "group": "cert-manager.io",
+        "names": {
+          "categories": [
+            "cert-manager"
+          ],
+          "kind": "Certificate",
+          "listKind": "CertificateList",
+          "plural": "certificates",
+          "shortNames": [
+            "cert",
+            "certs"
+          ],
+          "singular": "certificate"
+        },
+        "scope": "Namespaced",
+        "versions": [
+          {
+            "additionalPrinterColumns": [
+              {
+                "jsonPath": ".status.conditions[?(@.type==\"Ready\")].status",
+                "name": "Ready",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".spec.secretName",
+                "name": "Secret",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".spec.issuerRef.name",
+                "name": "Issuer",
+                "priority": 1,
+                "type": "string"
+              },
+              {
+                "jsonPath": ".status.conditions[?(@.type==\"Ready\")].message",
+                "name": "Status",
+                "priority": 1,
+                "type": "string"
+              },
+              {
+                "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.",
+                "jsonPath": ".metadata.creationTimestamp",
+                "name": "Age",
+                "type": "date"
+              }
+            ],
+            "name": "v1",
+            "schema": {
+              "openAPIV3Schema": {
+                "description": "A Certificate resource should be created to ensure an up to date and signed x509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`. \n The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`).",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "type": "object"
+                  },
+                  "spec": {
+                    "description": "Desired state of the Certificate resource.",
+                    "properties": {
+                      "additionalOutputFormats": {
+                        "description": "AdditionalOutputFormats defines extra output formats of the private key and signed certificate chain to be written to this Certificate's target Secret. This is an Alpha Feature and is only enabled with the `--feature-gates=AdditionalCertificateOutputFormats=true` option on both the controller and webhook components.",
+                        "items": {
+                          "description": "CertificateAdditionalOutputFormat defines an additional output format of a Certificate resource. These contain supplementary data formats of the signed certificate chain and paired private key.",
+                          "properties": {
+                            "type": {
+                              "description": "Type is the name of the format type that should be written to the Certificate's target Secret.",
+                              "enum": [
+                                "DER",
+                                "CombinedPEM"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "commonName": {
+                        "description": "CommonName is a common name to be used on the Certificate. The CommonName should have a length of 64 characters or fewer to avoid generating invalid CSRs. This value is ignored by TLS clients when any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4",
+                        "type": "string"
+                      },
+                      "dnsNames": {
+                        "description": "DNSNames is a list of DNS subjectAltNames to be set on the Certificate.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "duration": {
+                        "description": "The requested 'duration' (i.e. lifetime) of the Certificate. This option may be ignored/overridden by some issuer types. If unset this defaults to 90 days. Certificate will be renewed either 2/3 through its duration or `renewBefore` period before its expiry, whichever is later. Minimum accepted duration is 1 hour. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration",
+                        "type": "string"
+                      },
+                      "emailAddresses": {
+                        "description": "EmailAddresses is a list of email subjectAltNames to be set on the Certificate.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "encodeUsagesInRequest": {
+                        "description": "EncodeUsagesInRequest controls whether key usages should be present in the CertificateRequest",
+                        "type": "boolean"
+                      },
+                      "ipAddresses": {
+                        "description": "IPAddresses is a list of IP address subjectAltNames to be set on the Certificate.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "isCA": {
+                        "description": "IsCA will mark this Certificate as valid for certificate signing. This will automatically add the `cert sign` usage to the list of `usages`.",
+                        "type": "boolean"
+                      },
+                      "issuerRef": {
+                        "description": "IssuerRef is a reference to the issuer for this certificate. If the `kind` field is not set, or set to `Issuer`, an Issuer resource with the given name in the same namespace as the Certificate will be used. If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the provided name will be used. The `name` field in this stanza is required at all times.",
+                        "properties": {
+                          "group": {
+                            "description": "Group of the resource being referred to.",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "Kind of the resource being referred to.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the resource being referred to.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object"
+                      },
+                      "keystores": {
+                        "description": "Keystores configures additional keystore output formats stored in the `secretName` Secret resource.",
+                        "properties": {
+                          "jks": {
+                            "description": "JKS configures options for storing a JKS keystore in the `spec.secretName` Secret resource.",
+                            "properties": {
+                              "create": {
+                                "description": "Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.jks` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority",
+                                "type": "boolean"
+                              },
+                              "passwordSecretRef": {
+                                "description": "PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the JKS keystore.",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "required": [
+                              "create",
+                              "passwordSecretRef"
+                            ],
+                            "type": "object"
+                          },
+                          "pkcs12": {
+                            "description": "PKCS12 configures options for storing a PKCS12 keystore in the `spec.secretName` Secret resource.",
+                            "properties": {
+                              "create": {
+                                "description": "Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.p12` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority",
+                                "type": "boolean"
+                              },
+                              "passwordSecretRef": {
+                                "description": "PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the PKCS12 keystore.",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "required": [
+                              "create",
+                              "passwordSecretRef"
+                            ],
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "literalSubject": {
+                        "description": "LiteralSubject is an LDAP formatted string that represents the [X.509 Subject field](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6). Use this *instead* of the Subject field if you need to ensure the correct ordering of the RDN sequence, such as when issuing certs for LDAP authentication. See https://github.com/cert-manager/cert-manager/issues/3203, https://github.com/cert-manager/cert-manager/issues/4424. This field is alpha level and is only supported by cert-manager installations where LiteralCertificateSubject feature gate is enabled on both cert-manager controller and webhook.",
+                        "type": "string"
+                      },
+                      "privateKey": {
+                        "description": "Options to control private keys used for the Certificate.",
+                        "properties": {
+                          "algorithm": {
+                            "description": "Algorithm is the private key algorithm of the corresponding private key for this certificate. If provided, allowed values are either `RSA`,`Ed25519` or `ECDSA` If `algorithm` is specified and `size` is not provided, key size of 256 will be used for `ECDSA` key algorithm and key size of 2048 will be used for `RSA` key algorithm. key size is ignored when using the `Ed25519` key algorithm.",
+                            "enum": [
+                              "RSA",
+                              "ECDSA",
+                              "Ed25519"
+                            ],
+                            "type": "string"
+                          },
+                          "encoding": {
+                            "description": "The private key cryptography standards (PKCS) encoding for this certificate's private key to be encoded in. If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1 and PKCS#8, respectively. Defaults to `PKCS1` if not specified.",
+                            "enum": [
+                              "PKCS1",
+                              "PKCS8"
+                            ],
+                            "type": "string"
+                          },
+                          "rotationPolicy": {
+                            "description": "RotationPolicy controls how private keys should be regenerated when a re-issuance is being processed. If set to Never, a private key will only be generated if one does not already exist in the target `spec.secretName`. If one does exists but it does not have the correct algorithm or size, a warning will be raised to await user intervention. If set to Always, a private key matching the specified requirements will be generated whenever a re-issuance occurs. Default is 'Never' for backward compatibility.",
+                            "enum": [
+                              "Never",
+                              "Always"
+                            ],
+                            "type": "string"
+                          },
+                          "size": {
+                            "description": "Size is the key bit size of the corresponding private key for this certificate. If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`, and will default to `2048` if not specified. If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`, and will default to `256` if not specified. If `algorithm` is set to `Ed25519`, Size is ignored. No other values are allowed.",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "renewBefore": {
+                        "description": "How long before the currently issued certificate's expiry cert-manager should renew the certificate. The default is 2/3 of the issued certificate's duration. Minimum accepted value is 5 minutes. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration",
+                        "type": "string"
+                      },
+                      "revisionHistoryLimit": {
+                        "description": "revisionHistoryLimit is the maximum number of CertificateRequest revisions that are maintained in the Certificate's history. Each revision represents a single `CertificateRequest` created by this Certificate, either when it was created, renewed, or Spec was changed. Revisions will be removed by oldest first if the number of revisions exceeds this number. If set, revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`), revisions will not be garbage collected. Default value is `nil`.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "secretName": {
+                        "description": "SecretName is the name of the secret resource that will be automatically created and managed by this Certificate resource. It will be populated with a private key and certificate, signed by the denoted issuer.",
+                        "type": "string"
+                      },
+                      "secretTemplate": {
+                        "description": "SecretTemplate defines annotations and labels to be copied to the Certificate's Secret. Labels and annotations on the Secret will be changed as they appear on the SecretTemplate when added or removed. SecretTemplate annotations are added in conjunction with, and cannot overwrite, the base set of annotations cert-manager sets on the Certificate's Secret.",
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Annotations is a key value map to be copied to the target Kubernetes Secret.",
+                            "type": "object"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Labels is a key value map to be copied to the target Kubernetes Secret.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "subject": {
+                        "description": "Full X509 name specification (https://golang.org/pkg/crypto/x509/pkix/#Name).",
+                        "properties": {
+                          "countries": {
+                            "description": "Countries to be used on the Certificate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "localities": {
+                            "description": "Cities to be used on the Certificate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "organizationalUnits": {
+                            "description": "Organizational Units to be used on the Certificate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "organizations": {
+                            "description": "Organizations to be used on the Certificate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "postalCodes": {
+                            "description": "Postal codes to be used on the Certificate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "provinces": {
+                            "description": "State/Provinces to be used on the Certificate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "serialNumber": {
+                            "description": "Serial number to be used on the Certificate.",
+                            "type": "string"
+                          },
+                          "streetAddresses": {
+                            "description": "Street addresses to be used on the Certificate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "uris": {
+                        "description": "URIs is a list of URI subjectAltNames to be set on the Certificate.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "usages": {
+                        "description": "Usages is the set of x509 usages that are requested for the certificate. Defaults to `digital signature` and `key encipherment` if not specified.",
+                        "items": {
+                          "description": "KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12 Valid KeyUsage values are as follows: \"signing\", \"digital signature\", \"content commitment\", \"key encipherment\", \"key agreement\", \"data encipherment\", \"cert sign\", \"crl sign\", \"encipher only\", \"decipher only\", \"any\", \"server auth\", \"client auth\", \"code signing\", \"email protection\", \"s/mime\", \"ipsec end system\", \"ipsec tunnel\", \"ipsec user\", \"timestamping\", \"ocsp signing\", \"microsoft sgc\", \"netscape sgc\"",
+                          "enum": [
+                            "signing",
+                            "digital signature",
+                            "content commitment",
+                            "key encipherment",
+                            "key agreement",
+                            "data encipherment",
+                            "cert sign",
+                            "crl sign",
+                            "encipher only",
+                            "decipher only",
+                            "any",
+                            "server auth",
+                            "client auth",
+                            "code signing",
+                            "email protection",
+                            "s/mime",
+                            "ipsec end system",
+                            "ipsec tunnel",
+                            "ipsec user",
+                            "timestamping",
+                            "ocsp signing",
+                            "microsoft sgc",
+                            "netscape sgc"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "issuerRef",
+                      "secretName"
+                    ],
+                    "type": "object"
+                  },
+                  "status": {
+                    "description": "Status of the Certificate. This is set and managed automatically.",
+                    "properties": {
+                      "conditions": {
+                        "description": "List of status conditions to indicate the status of certificates. Known condition types are `Ready` and `Issuing`.",
+                        "items": {
+                          "description": "CertificateCondition contains condition information for an Certificate.",
+                          "properties": {
+                            "lastTransitionTime": {
+                              "description": "LastTransitionTime is the timestamp corresponding to the last status change of this condition.",
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "message": {
+                              "description": "Message is a human readable description of the details of the last transition, complementing reason.",
+                              "type": "string"
+                            },
+                            "observedGeneration": {
+                              "description": "If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Certificate.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "reason": {
+                              "description": "Reason is a brief machine readable explanation for the condition's last transition.",
+                              "type": "string"
+                            },
+                            "status": {
+                              "description": "Status of the condition, one of (`True`, `False`, `Unknown`).",
+                              "enum": [
+                                "True",
+                                "False",
+                                "Unknown"
+                              ],
+                              "type": "string"
+                            },
+                            "type": {
+                              "description": "Type of the condition, known values are (`Ready`, `Issuing`).",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "status",
+                            "type"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "type"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "failedIssuanceAttempts": {
+                        "description": "The number of continuous failed issuance attempts up till now. This field gets removed (if set) on a successful issuance and gets set to 1 if unset and an issuance has failed. If an issuance has failed, the delay till the next issuance will be calculated using formula time.Hour * 2 ^ (failedIssuanceAttempts - 1).",
+                        "type": "integer"
+                      },
+                      "lastFailureTime": {
+                        "description": "LastFailureTime is the time as recorded by the Certificate controller of the most recent failure to complete a CertificateRequest for this Certificate resource. If set, cert-manager will not re-request another Certificate until 1 hour has elapsed from this time.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "nextPrivateKeySecretName": {
+                        "description": "The name of the Secret resource containing the private key to be used for the next certificate iteration. The keymanager controller will automatically set this field if the `Issuing` condition is set to `True`. It will automatically unset this field when the Issuing condition is not set or False.",
+                        "type": "string"
+                      },
+                      "notAfter": {
+                        "description": "The expiration time of the certificate stored in the secret named by this resource in `spec.secretName`.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "notBefore": {
+                        "description": "The time after which the certificate stored in the secret named by this resource in spec.secretName is valid.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "renewalTime": {
+                        "description": "RenewalTime is the time at which the certificate will be next renewed. If not set, no upcoming renewal is scheduled.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "revision": {
+                        "description": "The current 'revision' of the certificate as issued. \n When a CertificateRequest resource is created, it will have the `cert-manager.io/certificate-revision` set to one greater than the current value of this field. \n Upon issuance, this field will be set to the value of the annotation on the CertificateRequest resource used to issue the certificate. \n Persisting the value on the CertificateRequest resource allows the certificates controller to know whether a request is part of an old issuance or if it is part of the ongoing revision's issuance by checking if the revision value in the annotation is greater than this field.",
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "spec"
+                ],
+                "type": "object"
+              }
+            },
+            "served": true,
+            "storage": true,
+            "subresources": {
+              "status": {}
+            }
+          }
+        ]
+      },
+      "status": {
+        "acceptedNames": {
+          "categories": [
+            "cert-manager"
+          ],
+          "kind": "Certificate",
+          "listKind": "CertificateList",
+          "plural": "certificates",
+          "shortNames": [
+            "cert",
+            "certs"
+          ],
+          "singular": "certificate"
+        },
+        "conditions": [
+          {
+            "lastTransitionTime": "2022-11-03T14:15:18Z",
+            "message": "no conflicts found",
+            "reason": "NoConflicts",
+            "status": "True",
+            "type": "NamesAccepted"
+          },
+          {
+            "lastTransitionTime": "2022-11-03T14:15:18Z",
+            "message": "the initial names have been accepted",
+            "reason": "InitialNamesAccepted",
+            "status": "True",
+            "type": "Established"
+          }
+        ],
+        "storedVersions": [
+          "v1"
+        ]
+      }
+    },
+    {
+      "apiVersion": "apiextensions.k8s.io/v1",
+      "kind": "CustomResourceDefinition",
+      "metadata": {
+        "annotations": {
+          "operator.jetstack.io/component": "cert-manager",
+          "operator.jetstack.io/component-version": "v1.9.1"
+        },
+        "creationTimestamp": "2022-11-03T14:15:18Z",
+        "generation": 1,
+        "labels": {
+          "app": "cert-manager",
+          "app.kubernetes.io/instance": "cert-manager",
+          "app.kubernetes.io/name": "cert-manager",
+          "app.kubernetes.io/version": "v1.9.1"
+        },
+        "name": "challenges.acme.cert-manager.io",
+        "ownerReferences": [
+          {
+            "apiVersion": "operator.jetstack.io/v1alpha1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Installation",
+            "name": "installation",
+            "uid": "648c8b6d-3c85-4faa-9497-1eedc3873baf"
+          }
+        ],
+        "resourceVersion": "71261",
+        "uid": "a229da1c-5728-4020-bdca-7bbe733288b9"
+      },
+      "spec": {
+        "conversion": {
+          "strategy": "None"
+        },
+        "group": "acme.cert-manager.io",
+        "names": {
+          "categories": [
+            "cert-manager",
+            "cert-manager-acme"
+          ],
+          "kind": "Challenge",
+          "listKind": "ChallengeList",
+          "plural": "challenges",
+          "singular": "challenge"
+        },
+        "scope": "Namespaced",
+        "versions": [
+          {
+            "additionalPrinterColumns": [
+              {
+                "jsonPath": ".status.state",
+                "name": "State",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".spec.dnsName",
+                "name": "Domain",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".status.reason",
+                "name": "Reason",
+                "priority": 1,
+                "type": "string"
+              },
+              {
+                "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.",
+                "jsonPath": ".metadata.creationTimestamp",
+                "name": "Age",
+                "type": "date"
+              }
+            ],
+            "name": "v1",
+            "schema": {
+              "openAPIV3Schema": {
+                "description": "Challenge is a type to represent a Challenge request with an ACME server",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "type": "object"
+                  },
+                  "spec": {
+                    "properties": {
+                      "authorizationURL": {
+                        "description": "The URL to the ACME Authorization resource that this challenge is a part of.",
+                        "type": "string"
+                      },
+                      "dnsName": {
+                        "description": "dnsName is the identifier that this challenge is for, e.g. example.com. If the requested DNSName is a 'wildcard', this field MUST be set to the non-wildcard domain, e.g. for `*.example.com`, it must be `example.com`.",
+                        "type": "string"
+                      },
+                      "issuerRef": {
+                        "description": "References a properly configured ACME-type Issuer which should be used to create this Challenge. If the Issuer does not exist, processing will be retried. If the Issuer is not an 'ACME' Issuer, an error will be returned and the Challenge will be marked as failed.",
+                        "properties": {
+                          "group": {
+                            "description": "Group of the resource being referred to.",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "Kind of the resource being referred to.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the resource being referred to.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object"
+                      },
+                      "key": {
+                        "description": "The ACME challenge key for this challenge For HTTP01 challenges, this is the value that must be responded with to complete the HTTP01 challenge in the format: `\u003cprivate key JWK thumbprint\u003e.\u003ckey from acme server for challenge\u003e`. For DNS01 challenges, this is the base64 encoded SHA256 sum of the `\u003cprivate key JWK thumbprint\u003e.\u003ckey from acme server for challenge\u003e` text that must be set as the TXT record content.",
+                        "type": "string"
+                      },
+                      "solver": {
+                        "description": "Contains the domain solving configuration that should be used to solve this challenge resource.",
+                        "properties": {
+                          "dns01": {
+                            "description": "Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.",
+                            "properties": {
+                              "acmeDNS": {
+                                "description": "Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.",
+                                "properties": {
+                                  "accountSecretRef": {
+                                    "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "host": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "accountSecretRef",
+                                  "host"
+                                ],
+                                "type": "object"
+                              },
+                              "akamai": {
+                                "description": "Use the Akamai DNS zone management API to manage DNS01 challenge records.",
+                                "properties": {
+                                  "accessTokenSecretRef": {
+                                    "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "clientSecretSecretRef": {
+                                    "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "clientTokenSecretRef": {
+                                    "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "serviceConsumerDomain": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "accessTokenSecretRef",
+                                  "clientSecretSecretRef",
+                                  "clientTokenSecretRef",
+                                  "serviceConsumerDomain"
+                                ],
+                                "type": "object"
+                              },
+                              "azureDNS": {
+                                "description": "Use the Microsoft Azure DNS API to manage DNS01 challenge records.",
+                                "properties": {
+                                  "clientID": {
+                                    "description": "if both this and ClientSecret are left unset MSI will be used",
+                                    "type": "string"
+                                  },
+                                  "clientSecretSecretRef": {
+                                    "description": "if both this and ClientID are left unset MSI will be used",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "environment": {
+                                    "description": "name of the Azure environment (default AzurePublicCloud)",
+                                    "enum": [
+                                      "AzurePublicCloud",
+                                      "AzureChinaCloud",
+                                      "AzureGermanCloud",
+                                      "AzureUSGovernmentCloud"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "hostedZoneName": {
+                                    "description": "name of the DNS zone that should be used",
+                                    "type": "string"
+                                  },
+                                  "managedIdentity": {
+                                    "description": "managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID",
+                                    "properties": {
+                                      "clientID": {
+                                        "description": "client ID of the managed identity, can not be used at the same time as resourceID",
+                                        "type": "string"
+                                      },
+                                      "resourceID": {
+                                        "description": "resource ID of the managed identity, can not be used at the same time as clientID",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "resourceGroupName": {
+                                    "description": "resource group the DNS zone is located in",
+                                    "type": "string"
+                                  },
+                                  "subscriptionID": {
+                                    "description": "ID of the Azure subscription",
+                                    "type": "string"
+                                  },
+                                  "tenantID": {
+                                    "description": "when specifying ClientID and ClientSecret then this field is also needed",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "resourceGroupName",
+                                  "subscriptionID"
+                                ],
+                                "type": "object"
+                              },
+                              "cloudDNS": {
+                                "description": "Use the Google Cloud DNS API to manage DNS01 challenge records.",
+                                "properties": {
+                                  "hostedZoneName": {
+                                    "description": "HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.",
+                                    "type": "string"
+                                  },
+                                  "project": {
+                                    "type": "string"
+                                  },
+                                  "serviceAccountSecretRef": {
+                                    "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "project"
+                                ],
+                                "type": "object"
+                              },
+                              "cloudflare": {
+                                "description": "Use the Cloudflare API to manage DNS01 challenge records.",
+                                "properties": {
+                                  "apiKeySecretRef": {
+                                    "description": "API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "apiTokenSecretRef": {
+                                    "description": "API token used to authenticate with Cloudflare.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "email": {
+                                    "description": "Email of the account, only required when using API key based authentication.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "cnameStrategy": {
+                                "description": "CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.",
+                                "enum": [
+                                  "None",
+                                  "Follow"
+                                ],
+                                "type": "string"
+                              },
+                              "digitalocean": {
+                                "description": "Use the DigitalOcean DNS API to manage DNS01 challenge records.",
+                                "properties": {
+                                  "tokenSecretRef": {
+                                    "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "tokenSecretRef"
+                                ],
+                                "type": "object"
+                              },
+                              "rfc2136": {
+                                "description": "Use RFC2136 (\"Dynamic Updates in the Domain Name System\") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.",
+                                "properties": {
+                                  "nameserver": {
+                                    "description": "The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.",
+                                    "type": "string"
+                                  },
+                                  "tsigAlgorithm": {
+                                    "description": "The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.",
+                                    "type": "string"
+                                  },
+                                  "tsigKeyName": {
+                                    "description": "The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.",
+                                    "type": "string"
+                                  },
+                                  "tsigSecretSecretRef": {
+                                    "description": "The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "nameserver"
+                                ],
+                                "type": "object"
+                              },
+                              "route53": {
+                                "description": "Use the AWS Route53 API to manage DNS01 challenge records.",
+                                "properties": {
+                                  "accessKeyID": {
+                                    "description": "The AccessKeyID is used for authentication. Cannot be set when SecretAccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                                    "type": "string"
+                                  },
+                                  "accessKeyIDSecretRef": {
+                                    "description": "The SecretAccessKey is used for authentication. If set, pull the AWS access key ID from a key within a Kubernetes Secret. Cannot be set when AccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "hostedZoneID": {
+                                    "description": "If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.",
+                                    "type": "string"
+                                  },
+                                  "region": {
+                                    "description": "Always set the region when using AccessKeyID and SecretAccessKey",
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "description": "Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata",
+                                    "type": "string"
+                                  },
+                                  "secretAccessKeySecretRef": {
+                                    "description": "The SecretAccessKey is used for authentication. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "region"
+                                ],
+                                "type": "object"
+                              },
+                              "webhook": {
+                                "description": "Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.",
+                                "properties": {
+                                  "config": {
+                                    "description": "Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "groupName": {
+                                    "description": "The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.",
+                                    "type": "string"
+                                  },
+                                  "solverName": {
+                                    "description": "The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "groupName",
+                                  "solverName"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "http01": {
+                            "description": "Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.",
+                            "properties": {
+                              "gatewayHTTPRoute": {
+                                "description": "The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.",
+                                "properties": {
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.",
+                                    "type": "object"
+                                  },
+                                  "parentRefs": {
+                                    "description": "When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways",
+                                    "items": {
+                                      "description": "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object.",
+                                      "properties": {
+                                        "group": {
+                                          "default": "gateway.networking.k8s.io",
+                                          "description": "Group is the group of the referent. \n Support: Core",
+                                          "maxLength": 253,
+                                          "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                          "type": "string"
+                                        },
+                                        "kind": {
+                                          "default": "Gateway",
+                                          "description": "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)",
+                                          "maxLength": 63,
+                                          "minLength": 1,
+                                          "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name is the name of the referent. \n Support: Core",
+                                          "maxLength": 253,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "description": "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core",
+                                          "maxLength": 63,
+                                          "minLength": 1,
+                                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                          "type": "string"
+                                        },
+                                        "sectionName": {
+                                          "description": "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core",
+                                          "maxLength": 253,
+                                          "minLength": 1,
+                                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "serviceType": {
+                                    "description": "Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "ingress": {
+                                "description": "The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.",
+                                "properties": {
+                                  "class": {
+                                    "description": "The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.",
+                                    "type": "string"
+                                  },
+                                  "ingressTemplate": {
+                                    "description": "Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.",
+                                    "properties": {
+                                      "metadata": {
+                                        "description": "ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.",
+                                        "properties": {
+                                          "annotations": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "Annotations that should be added to the created ACME HTTP01 solver ingress.",
+                                            "type": "object"
+                                          },
+                                          "labels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "Labels that should be added to the created ACME HTTP01 solver ingress.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "name": {
+                                    "description": "The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.",
+                                    "type": "string"
+                                  },
+                                  "podTemplate": {
+                                    "description": "Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.",
+                                    "properties": {
+                                      "metadata": {
+                                        "description": "ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.",
+                                        "properties": {
+                                          "annotations": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "Annotations that should be added to the create ACME HTTP01 solver pods.",
+                                            "type": "object"
+                                          },
+                                          "labels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "Labels that should be added to the created ACME HTTP01 solver pods.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "spec": {
+                                        "description": "PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.",
+                                        "properties": {
+                                          "affinity": {
+                                            "description": "If specified, the pod's scheduling constraints",
+                                            "properties": {
+                                              "nodeAffinity": {
+                                                "description": "Describes node affinity scheduling rules for the pod.",
+                                                "properties": {
+                                                  "preferredDuringSchedulingIgnoredDuringExecution": {
+                                                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                                    "items": {
+                                                      "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                                      "properties": {
+                                                        "preference": {
+                                                          "description": "A node selector term, associated with the corresponding weight.",
+                                                          "properties": {
+                                                            "matchExpressions": {
+                                                              "description": "A list of node selector requirements by node's labels.",
+                                                              "items": {
+                                                                "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                "properties": {
+                                                                  "key": {
+                                                                    "description": "The label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "operator": {
+                                                                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "values": {
+                                                                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "key",
+                                                                  "operator"
+                                                                ],
+                                                                "type": "object"
+                                                              },
+                                                              "type": "array"
+                                                            },
+                                                            "matchFields": {
+                                                              "description": "A list of node selector requirements by node's fields.",
+                                                              "items": {
+                                                                "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                "properties": {
+                                                                  "key": {
+                                                                    "description": "The label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "operator": {
+                                                                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "values": {
+                                                                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "key",
+                                                                  "operator"
+                                                                ],
+                                                                "type": "object"
+                                                              },
+                                                              "type": "array"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "weight": {
+                                                          "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                                          "format": "int32",
+                                                          "type": "integer"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "preference",
+                                                        "weight"
+                                                      ],
+                                                      "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                    "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                                    "properties": {
+                                                      "nodeSelectorTerms": {
+                                                        "description": "Required. A list of node selector terms. The terms are ORed.",
+                                                        "items": {
+                                                          "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                                          "properties": {
+                                                            "matchExpressions": {
+                                                              "description": "A list of node selector requirements by node's labels.",
+                                                              "items": {
+                                                                "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                "properties": {
+                                                                  "key": {
+                                                                    "description": "The label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "operator": {
+                                                                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "values": {
+                                                                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "key",
+                                                                  "operator"
+                                                                ],
+                                                                "type": "object"
+                                                              },
+                                                              "type": "array"
+                                                            },
+                                                            "matchFields": {
+                                                              "description": "A list of node selector requirements by node's fields.",
+                                                              "items": {
+                                                                "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                "properties": {
+                                                                  "key": {
+                                                                    "description": "The label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "operator": {
+                                                                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "values": {
+                                                                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "key",
+                                                                  "operator"
+                                                                ],
+                                                                "type": "object"
+                                                              },
+                                                              "type": "array"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "nodeSelectorTerms"
+                                                    ],
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "podAffinity": {
+                                                "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                                                "properties": {
+                                                  "preferredDuringSchedulingIgnoredDuringExecution": {
+                                                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                                    "items": {
+                                                      "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                                      "properties": {
+                                                        "podAffinityTerm": {
+                                                          "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                          "properties": {
+                                                            "labelSelector": {
+                                                              "description": "A label query over a set of resources, in this case pods.",
+                                                              "properties": {
+                                                                "matchExpressions": {
+                                                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                  "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                    "properties": {
+                                                                      "key": {
+                                                                        "description": "key is the label key that the selector applies to.",
+                                                                        "type": "string"
+                                                                      },
+                                                                      "operator": {
+                                                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                        "type": "string"
+                                                                      },
+                                                                      "values": {
+                                                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                        "items": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "type": "array"
+                                                                      }
+                                                                    },
+                                                                    "required": [
+                                                                      "key",
+                                                                      "operator"
+                                                                    ],
+                                                                    "type": "object"
+                                                                  },
+                                                                  "type": "array"
+                                                                },
+                                                                "matchLabels": {
+                                                                  "additionalProperties": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                  "type": "object"
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            "namespaceSelector": {
+                                                              "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                              "properties": {
+                                                                "matchExpressions": {
+                                                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                  "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                    "properties": {
+                                                                      "key": {
+                                                                        "description": "key is the label key that the selector applies to.",
+                                                                        "type": "string"
+                                                                      },
+                                                                      "operator": {
+                                                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                        "type": "string"
+                                                                      },
+                                                                      "values": {
+                                                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                        "items": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "type": "array"
+                                                                      }
+                                                                    },
+                                                                    "required": [
+                                                                      "key",
+                                                                      "operator"
+                                                                    ],
+                                                                    "type": "object"
+                                                                  },
+                                                                  "type": "array"
+                                                                },
+                                                                "matchLabels": {
+                                                                  "additionalProperties": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                  "type": "object"
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            "namespaces": {
+                                                              "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                              "items": {
+                                                                "type": "string"
+                                                              },
+                                                              "type": "array"
+                                                            },
+                                                            "topologyKey": {
+                                                              "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "topologyKey"
+                                                          ],
+                                                          "type": "object"
+                                                        },
+                                                        "weight": {
+                                                          "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                                          "format": "int32",
+                                                          "type": "integer"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "podAffinityTerm",
+                                                        "weight"
+                                                      ],
+                                                      "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                    "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                                    "items": {
+                                                      "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \u003ctopologyKey\u003e matches that of any node on which a pod of the set of pods is running",
+                                                      "properties": {
+                                                        "labelSelector": {
+                                                          "description": "A label query over a set of resources, in this case pods.",
+                                                          "properties": {
+                                                            "matchExpressions": {
+                                                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                              "items": {
+                                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                "properties": {
+                                                                  "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "key",
+                                                                  "operator"
+                                                                ],
+                                                                "type": "object"
+                                                              },
+                                                              "type": "array"
+                                                            },
+                                                            "matchLabels": {
+                                                              "additionalProperties": {
+                                                                "type": "string"
+                                                              },
+                                                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                              "type": "object"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "namespaceSelector": {
+                                                          "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                          "properties": {
+                                                            "matchExpressions": {
+                                                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                              "items": {
+                                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                "properties": {
+                                                                  "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "key",
+                                                                  "operator"
+                                                                ],
+                                                                "type": "object"
+                                                              },
+                                                              "type": "array"
+                                                            },
+                                                            "matchLabels": {
+                                                              "additionalProperties": {
+                                                                "type": "string"
+                                                              },
+                                                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                              "type": "object"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "namespaces": {
+                                                          "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "topologyKey": {
+                                                          "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "topologyKey"
+                                                      ],
+                                                      "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "podAntiAffinity": {
+                                                "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                                                "properties": {
+                                                  "preferredDuringSchedulingIgnoredDuringExecution": {
+                                                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                                    "items": {
+                                                      "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                                      "properties": {
+                                                        "podAffinityTerm": {
+                                                          "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                          "properties": {
+                                                            "labelSelector": {
+                                                              "description": "A label query over a set of resources, in this case pods.",
+                                                              "properties": {
+                                                                "matchExpressions": {
+                                                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                  "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                    "properties": {
+                                                                      "key": {
+                                                                        "description": "key is the label key that the selector applies to.",
+                                                                        "type": "string"
+                                                                      },
+                                                                      "operator": {
+                                                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                        "type": "string"
+                                                                      },
+                                                                      "values": {
+                                                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                        "items": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "type": "array"
+                                                                      }
+                                                                    },
+                                                                    "required": [
+                                                                      "key",
+                                                                      "operator"
+                                                                    ],
+                                                                    "type": "object"
+                                                                  },
+                                                                  "type": "array"
+                                                                },
+                                                                "matchLabels": {
+                                                                  "additionalProperties": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                  "type": "object"
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            "namespaceSelector": {
+                                                              "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                              "properties": {
+                                                                "matchExpressions": {
+                                                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                  "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                    "properties": {
+                                                                      "key": {
+                                                                        "description": "key is the label key that the selector applies to.",
+                                                                        "type": "string"
+                                                                      },
+                                                                      "operator": {
+                                                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                        "type": "string"
+                                                                      },
+                                                                      "values": {
+                                                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                        "items": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "type": "array"
+                                                                      }
+                                                                    },
+                                                                    "required": [
+                                                                      "key",
+                                                                      "operator"
+                                                                    ],
+                                                                    "type": "object"
+                                                                  },
+                                                                  "type": "array"
+                                                                },
+                                                                "matchLabels": {
+                                                                  "additionalProperties": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                  "type": "object"
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            "namespaces": {
+                                                              "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                              "items": {
+                                                                "type": "string"
+                                                              },
+                                                              "type": "array"
+                                                            },
+                                                            "topologyKey": {
+                                                              "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "topologyKey"
+                                                          ],
+                                                          "type": "object"
+                                                        },
+                                                        "weight": {
+                                                          "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                                          "format": "int32",
+                                                          "type": "integer"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "podAffinityTerm",
+                                                        "weight"
+                                                      ],
+                                                      "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                    "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                                    "items": {
+                                                      "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \u003ctopologyKey\u003e matches that of any node on which a pod of the set of pods is running",
+                                                      "properties": {
+                                                        "labelSelector": {
+                                                          "description": "A label query over a set of resources, in this case pods.",
+                                                          "properties": {
+                                                            "matchExpressions": {
+                                                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                              "items": {
+                                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                "properties": {
+                                                                  "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "key",
+                                                                  "operator"
+                                                                ],
+                                                                "type": "object"
+                                                              },
+                                                              "type": "array"
+                                                            },
+                                                            "matchLabels": {
+                                                              "additionalProperties": {
+                                                                "type": "string"
+                                                              },
+                                                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                              "type": "object"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "namespaceSelector": {
+                                                          "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                          "properties": {
+                                                            "matchExpressions": {
+                                                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                              "items": {
+                                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                "properties": {
+                                                                  "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                  },
+                                                                  "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "key",
+                                                                  "operator"
+                                                                ],
+                                                                "type": "object"
+                                                              },
+                                                              "type": "array"
+                                                            },
+                                                            "matchLabels": {
+                                                              "additionalProperties": {
+                                                                "type": "string"
+                                                              },
+                                                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                              "type": "object"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "namespaces": {
+                                                          "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "topologyKey": {
+                                                          "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "topologyKey"
+                                                      ],
+                                                      "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "nodeSelector": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+                                            "type": "object"
+                                          },
+                                          "priorityClassName": {
+                                            "description": "If specified, the pod's priorityClassName.",
+                                            "type": "string"
+                                          },
+                                          "serviceAccountName": {
+                                            "description": "If specified, the pod's service account",
+                                            "type": "string"
+                                          },
+                                          "tolerations": {
+                                            "description": "If specified, the pod's tolerations.",
+                                            "items": {
+                                              "description": "The pod this Toleration is attached to tolerates any taint that matches the triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
+                                              "properties": {
+                                                "effect": {
+                                                  "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                                  "type": "string"
+                                                },
+                                                "key": {
+                                                  "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                                  "type": "string"
+                                                },
+                                                "tolerationSeconds": {
+                                                  "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                                  "format": "int64",
+                                                  "type": "integer"
+                                                },
+                                                "value": {
+                                                  "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "serviceType": {
+                                    "description": "Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "selector": {
+                            "description": "Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.",
+                            "properties": {
+                              "dnsNames": {
+                                "description": "List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "dnsZones": {
+                                "description": "List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "A label selector that is used to refine the set of certificate's that this challenge solver will apply to.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "token": {
+                        "description": "The ACME challenge token for this challenge. This is the raw value returned from the ACME server.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "The type of ACME challenge this resource represents. One of \"HTTP-01\" or \"DNS-01\".",
+                        "enum": [
+                          "HTTP-01",
+                          "DNS-01"
+                        ],
+                        "type": "string"
+                      },
+                      "url": {
+                        "description": "The URL of the ACME Challenge resource for this challenge. This can be used to lookup details about the status of this challenge.",
+                        "type": "string"
+                      },
+                      "wildcard": {
+                        "description": "wildcard will be true if this challenge is for a wildcard identifier, for example '*.example.com'.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "authorizationURL",
+                      "dnsName",
+                      "issuerRef",
+                      "key",
+                      "solver",
+                      "token",
+                      "type",
+                      "url"
+                    ],
+                    "type": "object"
+                  },
+                  "status": {
+                    "properties": {
+                      "presented": {
+                        "description": "presented will be set to true if the challenge values for this challenge are currently 'presented'. This *does not* imply the self check is passing. Only that the values have been 'submitted' for the appropriate challenge mechanism (i.e. the DNS01 TXT record has been presented, or the HTTP01 configuration has been configured).",
+                        "type": "boolean"
+                      },
+                      "processing": {
+                        "description": "Used to denote whether this challenge should be processed or not. This field will only be set to true by the 'scheduling' component. It will only be set to false by the 'challenges' controller, after the challenge has reached a final state or timed out. If this field is set to false, the challenge controller will not take any more action.",
+                        "type": "boolean"
+                      },
+                      "reason": {
+                        "description": "Contains human readable information on why the Challenge is in the current state.",
+                        "type": "string"
+                      },
+                      "state": {
+                        "description": "Contains the current 'state' of the challenge. If not set, the state of the challenge is unknown.",
+                        "enum": [
+                          "valid",
+                          "ready",
+                          "pending",
+                          "processing",
+                          "invalid",
+                          "expired",
+                          "errored"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "metadata",
+                  "spec"
+                ],
+                "type": "object"
+              }
+            },
+            "served": true,
+            "storage": true,
+            "subresources": {
+              "status": {}
+            }
+          }
+        ]
+      },
+      "status": {
+        "acceptedNames": {
+          "categories": [
+            "cert-manager",
+            "cert-manager-acme"
+          ],
+          "kind": "Challenge",
+          "listKind": "ChallengeList",
+          "plural": "challenges",
+          "singular": "challenge"
+        },
+        "conditions": [
+          {
+            "lastTransitionTime": "2022-11-03T14:15:18Z",
+            "message": "no conflicts found",
+            "reason": "NoConflicts",
+            "status": "True",
+            "type": "NamesAccepted"
+          },
+          {
+            "lastTransitionTime": "2022-11-03T14:15:18Z",
+            "message": "the initial names have been accepted",
+            "reason": "InitialNamesAccepted",
+            "status": "True",
+            "type": "Established"
+          }
+        ],
+        "storedVersions": [
+          "v1"
+        ]
+      }
+    },
+    {
+      "apiVersion": "apiextensions.k8s.io/v1",
+      "kind": "CustomResourceDefinition",
+      "metadata": {
+        "annotations": {
+          "operator.jetstack.io/component": "cert-manager",
+          "operator.jetstack.io/component-version": "v1.9.1"
+        },
+        "creationTimestamp": "2022-11-03T14:15:18Z",
+        "finalizers": [
+          "operator.jetstack.io/crd-controller"
+        ],
+        "generation": 1,
+        "labels": {
+          "app": "cert-manager",
+          "app.kubernetes.io/instance": "cert-manager",
+          "app.kubernetes.io/name": "cert-manager",
+          "app.kubernetes.io/version": "v1.9.1"
+        },
+        "name": "clusterissuers.cert-manager.io",
+        "ownerReferences": [
+          {
+            "apiVersion": "operator.jetstack.io/v1alpha1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Installation",
+            "name": "installation",
+            "uid": "648c8b6d-3c85-4faa-9497-1eedc3873baf"
+          }
+        ],
+        "resourceVersion": "71272",
+        "uid": "9251d016-5fbb-4ff4-a4f2-512ed303cfec"
+      },
+      "spec": {
+        "conversion": {
+          "strategy": "None"
+        },
+        "group": "cert-manager.io",
+        "names": {
+          "categories": [
+            "cert-manager"
+          ],
+          "kind": "ClusterIssuer",
+          "listKind": "ClusterIssuerList",
+          "plural": "clusterissuers",
+          "singular": "clusterissuer"
+        },
+        "scope": "Cluster",
+        "versions": [
+          {
+            "additionalPrinterColumns": [
+              {
+                "jsonPath": ".status.conditions[?(@.type==\"Ready\")].status",
+                "name": "Ready",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".status.conditions[?(@.type==\"Ready\")].message",
+                "name": "Status",
+                "priority": 1,
+                "type": "string"
+              },
+              {
+                "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.",
+                "jsonPath": ".metadata.creationTimestamp",
+                "name": "Age",
+                "type": "date"
+              }
+            ],
+            "name": "v1",
+            "schema": {
+              "openAPIV3Schema": {
+                "description": "A ClusterIssuer represents a certificate issuing authority which can be referenced as part of `issuerRef` fields. It is similar to an Issuer, however it is cluster-scoped and therefore can be referenced by resources that exist in *any* namespace, not just the same namespace as the referent.",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "type": "object"
+                  },
+                  "spec": {
+                    "description": "Desired state of the ClusterIssuer resource.",
+                    "properties": {
+                      "acme": {
+                        "description": "ACME configures this issuer to communicate with a RFC8555 (ACME) server to obtain signed x509 certificates.",
+                        "properties": {
+                          "disableAccountKeyGeneration": {
+                            "description": "Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.",
+                            "type": "boolean"
+                          },
+                          "email": {
+                            "description": "Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.",
+                            "type": "string"
+                          },
+                          "enableDurationFeature": {
+                            "description": "Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.",
+                            "type": "boolean"
+                          },
+                          "externalAccountBinding": {
+                            "description": "ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.",
+                            "properties": {
+                              "keyAlgorithm": {
+                                "description": "Deprecated: keyAlgorithm field exists for historical compatibility reasons and should not be used. The algorithm is now hardcoded to HS256 in golang/x/crypto/acme.",
+                                "enum": [
+                                  "HS256",
+                                  "HS384",
+                                  "HS512"
+                                ],
+                                "type": "string"
+                              },
+                              "keyID": {
+                                "description": "keyID is the ID of the CA key that the External Account is bound to.",
+                                "type": "string"
+                              },
+                              "keySecretRef": {
+                                "description": "keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes Secret which holds the symmetric MAC key of the External Account Binding. The `key` is the index string that is paired with the key data in the Secret and should not be confused with the key data itself, or indeed with the External Account Binding keyID above. The secret key stored in the Secret **must** be un-padded, base64 URL encoded data.",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "required": [
+                              "keyID",
+                              "keySecretRef"
+                            ],
+                            "type": "object"
+                          },
+                          "preferredChain": {
+                            "description": "PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let's Encrypt's DST crosssign you would use: \"DST Root CA X3\" or \"ISRG Root X1\" for the newer Let's Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer's CN",
+                            "maxLength": 64,
+                            "type": "string"
+                          },
+                          "privateKeySecretRef": {
+                            "description": "PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "server": {
+                            "description": "Server is the URL used to access the ACME server's 'directory' endpoint. For example, for Let's Encrypt's staging endpoint, you would use: \"https://acme-staging-v02.api.letsencrypt.org/directory\". Only ACME v2 endpoints (i.e. RFC 8555) are supported.",
+                            "type": "string"
+                          },
+                          "skipTLSVerify": {
+                            "description": "Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have their TLS certificate validated (i.e. insecure connections will be allowed). Only enable this option in development environments. The cert-manager system installed roots will be used to verify connections to the ACME server if this is false. Defaults to false.",
+                            "type": "boolean"
+                          },
+                          "solvers": {
+                            "description": "Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/",
+                            "items": {
+                              "description": "An ACMEChallengeSolver describes how to solve ACME challenges for the issuer it is part of. A selector may be provided to use different solving strategies for different DNS names. Only one of HTTP01 or DNS01 must be provided.",
+                              "properties": {
+                                "dns01": {
+                                  "description": "Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.",
+                                  "properties": {
+                                    "acmeDNS": {
+                                      "description": "Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "accountSecretRef": {
+                                          "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "host": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "accountSecretRef",
+                                        "host"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "akamai": {
+                                      "description": "Use the Akamai DNS zone management API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "accessTokenSecretRef": {
+                                          "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "clientSecretSecretRef": {
+                                          "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "clientTokenSecretRef": {
+                                          "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "serviceConsumerDomain": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "accessTokenSecretRef",
+                                        "clientSecretSecretRef",
+                                        "clientTokenSecretRef",
+                                        "serviceConsumerDomain"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "azureDNS": {
+                                      "description": "Use the Microsoft Azure DNS API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "clientID": {
+                                          "description": "if both this and ClientSecret are left unset MSI will be used",
+                                          "type": "string"
+                                        },
+                                        "clientSecretSecretRef": {
+                                          "description": "if both this and ClientID are left unset MSI will be used",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "environment": {
+                                          "description": "name of the Azure environment (default AzurePublicCloud)",
+                                          "enum": [
+                                            "AzurePublicCloud",
+                                            "AzureChinaCloud",
+                                            "AzureGermanCloud",
+                                            "AzureUSGovernmentCloud"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "hostedZoneName": {
+                                          "description": "name of the DNS zone that should be used",
+                                          "type": "string"
+                                        },
+                                        "managedIdentity": {
+                                          "description": "managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID",
+                                          "properties": {
+                                            "clientID": {
+                                              "description": "client ID of the managed identity, can not be used at the same time as resourceID",
+                                              "type": "string"
+                                            },
+                                            "resourceID": {
+                                              "description": "resource ID of the managed identity, can not be used at the same time as clientID",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "resourceGroupName": {
+                                          "description": "resource group the DNS zone is located in",
+                                          "type": "string"
+                                        },
+                                        "subscriptionID": {
+                                          "description": "ID of the Azure subscription",
+                                          "type": "string"
+                                        },
+                                        "tenantID": {
+                                          "description": "when specifying ClientID and ClientSecret then this field is also needed",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "resourceGroupName",
+                                        "subscriptionID"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "cloudDNS": {
+                                      "description": "Use the Google Cloud DNS API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "hostedZoneName": {
+                                          "description": "HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.",
+                                          "type": "string"
+                                        },
+                                        "project": {
+                                          "type": "string"
+                                        },
+                                        "serviceAccountSecretRef": {
+                                          "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [
+                                        "project"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "cloudflare": {
+                                      "description": "Use the Cloudflare API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "apiKeySecretRef": {
+                                          "description": "API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "apiTokenSecretRef": {
+                                          "description": "API token used to authenticate with Cloudflare.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "email": {
+                                          "description": "Email of the account, only required when using API key based authentication.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "cnameStrategy": {
+                                      "description": "CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.",
+                                      "enum": [
+                                        "None",
+                                        "Follow"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "digitalocean": {
+                                      "description": "Use the DigitalOcean DNS API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "tokenSecretRef": {
+                                          "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [
+                                        "tokenSecretRef"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "rfc2136": {
+                                      "description": "Use RFC2136 (\"Dynamic Updates in the Domain Name System\") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "nameserver": {
+                                          "description": "The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.",
+                                          "type": "string"
+                                        },
+                                        "tsigAlgorithm": {
+                                          "description": "The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.",
+                                          "type": "string"
+                                        },
+                                        "tsigKeyName": {
+                                          "description": "The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.",
+                                          "type": "string"
+                                        },
+                                        "tsigSecretSecretRef": {
+                                          "description": "The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [
+                                        "nameserver"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "route53": {
+                                      "description": "Use the AWS Route53 API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "accessKeyID": {
+                                          "description": "The AccessKeyID is used for authentication. Cannot be set when SecretAccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                                          "type": "string"
+                                        },
+                                        "accessKeyIDSecretRef": {
+                                          "description": "The SecretAccessKey is used for authentication. If set, pull the AWS access key ID from a key within a Kubernetes Secret. Cannot be set when AccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "hostedZoneID": {
+                                          "description": "If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.",
+                                          "type": "string"
+                                        },
+                                        "region": {
+                                          "description": "Always set the region when using AccessKeyID and SecretAccessKey",
+                                          "type": "string"
+                                        },
+                                        "role": {
+                                          "description": "Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata",
+                                          "type": "string"
+                                        },
+                                        "secretAccessKeySecretRef": {
+                                          "description": "The SecretAccessKey is used for authentication. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [
+                                        "region"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "webhook": {
+                                      "description": "Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "config": {
+                                          "description": "Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.",
+                                          "x-kubernetes-preserve-unknown-fields": true
+                                        },
+                                        "groupName": {
+                                          "description": "The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.",
+                                          "type": "string"
+                                        },
+                                        "solverName": {
+                                          "description": "The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "groupName",
+                                        "solverName"
+                                      ],
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "http01": {
+                                  "description": "Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.",
+                                  "properties": {
+                                    "gatewayHTTPRoute": {
+                                      "description": "The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.",
+                                      "properties": {
+                                        "labels": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "description": "Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.",
+                                          "type": "object"
+                                        },
+                                        "parentRefs": {
+                                          "description": "When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways",
+                                          "items": {
+                                            "description": "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object.",
+                                            "properties": {
+                                              "group": {
+                                                "default": "gateway.networking.k8s.io",
+                                                "description": "Group is the group of the referent. \n Support: Core",
+                                                "maxLength": 253,
+                                                "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "default": "Gateway",
+                                                "description": "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)",
+                                                "maxLength": 63,
+                                                "minLength": 1,
+                                                "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "Name is the name of the referent. \n Support: Core",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "description": "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core",
+                                                "maxLength": 63,
+                                                "minLength": 1,
+                                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                                "type": "string"
+                                              },
+                                              "sectionName": {
+                                                "description": "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "serviceType": {
+                                          "description": "Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "ingress": {
+                                      "description": "The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.",
+                                      "properties": {
+                                        "class": {
+                                          "description": "The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.",
+                                          "type": "string"
+                                        },
+                                        "ingressTemplate": {
+                                          "description": "Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.",
+                                          "properties": {
+                                            "metadata": {
+                                              "description": "ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.",
+                                              "properties": {
+                                                "annotations": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": "Annotations that should be added to the created ACME HTTP01 solver ingress.",
+                                                  "type": "object"
+                                                },
+                                                "labels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": "Labels that should be added to the created ACME HTTP01 solver ingress.",
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "description": "The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.",
+                                          "type": "string"
+                                        },
+                                        "podTemplate": {
+                                          "description": "Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.",
+                                          "properties": {
+                                            "metadata": {
+                                              "description": "ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.",
+                                              "properties": {
+                                                "annotations": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": "Annotations that should be added to the create ACME HTTP01 solver pods.",
+                                                  "type": "object"
+                                                },
+                                                "labels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": "Labels that should be added to the created ACME HTTP01 solver pods.",
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "spec": {
+                                              "description": "PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.",
+                                              "properties": {
+                                                "affinity": {
+                                                  "description": "If specified, the pod's scheduling constraints",
+                                                  "properties": {
+                                                    "nodeAffinity": {
+                                                      "description": "Describes node affinity scheduling rules for the pod.",
+                                                      "properties": {
+                                                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                                                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                                          "items": {
+                                                            "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                                            "properties": {
+                                                              "preference": {
+                                                                "description": "A node selector term, associated with the corresponding weight.",
+                                                                "properties": {
+                                                                  "matchExpressions": {
+                                                                    "description": "A list of node selector requirements by node's labels.",
+                                                                    "items": {
+                                                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "The label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "matchFields": {
+                                                                    "description": "A list of node selector requirements by node's fields.",
+                                                                    "items": {
+                                                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "The label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "weight": {
+                                                                "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                                                "format": "int32",
+                                                                "type": "integer"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "preference",
+                                                              "weight"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                          "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                                          "properties": {
+                                                            "nodeSelectorTerms": {
+                                                              "description": "Required. A list of node selector terms. The terms are ORed.",
+                                                              "items": {
+                                                                "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                                                "properties": {
+                                                                  "matchExpressions": {
+                                                                    "description": "A list of node selector requirements by node's labels.",
+                                                                    "items": {
+                                                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "The label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "matchFields": {
+                                                                    "description": "A list of node selector requirements by node's fields.",
+                                                                    "items": {
+                                                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "The label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "type": "array"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "nodeSelectorTerms"
+                                                          ],
+                                                          "type": "object"
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "podAffinity": {
+                                                      "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                                                      "properties": {
+                                                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                                                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                                          "items": {
+                                                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                                            "properties": {
+                                                              "podAffinityTerm": {
+                                                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                                "properties": {
+                                                                  "labelSelector": {
+                                                                    "description": "A label query over a set of resources, in this case pods.",
+                                                                    "properties": {
+                                                                      "matchExpressions": {
+                                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                        "items": {
+                                                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                          "properties": {
+                                                                            "key": {
+                                                                              "description": "key is the label key that the selector applies to.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            }
+                                                                          },
+                                                                          "required": [
+                                                                            "key",
+                                                                            "operator"
+                                                                          ],
+                                                                          "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                      },
+                                                                      "matchLabels": {
+                                                                        "additionalProperties": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                        "type": "object"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  "namespaceSelector": {
+                                                                    "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                                    "properties": {
+                                                                      "matchExpressions": {
+                                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                        "items": {
+                                                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                          "properties": {
+                                                                            "key": {
+                                                                              "description": "key is the label key that the selector applies to.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            }
+                                                                          },
+                                                                          "required": [
+                                                                            "key",
+                                                                            "operator"
+                                                                          ],
+                                                                          "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                      },
+                                                                      "matchLabels": {
+                                                                        "additionalProperties": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                        "type": "object"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  "namespaces": {
+                                                                    "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "topologyKey": {
+                                                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "topologyKey"
+                                                                ],
+                                                                "type": "object"
+                                                              },
+                                                              "weight": {
+                                                                "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                                                "format": "int32",
+                                                                "type": "integer"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "podAffinityTerm",
+                                                              "weight"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                          "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                                          "items": {
+                                                            "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \u003ctopologyKey\u003e matches that of any node on which a pod of the set of pods is running",
+                                                            "properties": {
+                                                              "labelSelector": {
+                                                                "description": "A label query over a set of resources, in this case pods.",
+                                                                "properties": {
+                                                                  "matchExpressions": {
+                                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                    "items": {
+                                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "key is the label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "matchLabels": {
+                                                                    "additionalProperties": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                    "type": "object"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "namespaceSelector": {
+                                                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                                "properties": {
+                                                                  "matchExpressions": {
+                                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                    "items": {
+                                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "key is the label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "matchLabels": {
+                                                                    "additionalProperties": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                    "type": "object"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "namespaces": {
+                                                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                                "items": {
+                                                                  "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              "topologyKey": {
+                                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "topologyKey"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "podAntiAffinity": {
+                                                      "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                                                      "properties": {
+                                                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                                                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                                          "items": {
+                                                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                                            "properties": {
+                                                              "podAffinityTerm": {
+                                                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                                "properties": {
+                                                                  "labelSelector": {
+                                                                    "description": "A label query over a set of resources, in this case pods.",
+                                                                    "properties": {
+                                                                      "matchExpressions": {
+                                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                        "items": {
+                                                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                          "properties": {
+                                                                            "key": {
+                                                                              "description": "key is the label key that the selector applies to.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            }
+                                                                          },
+                                                                          "required": [
+                                                                            "key",
+                                                                            "operator"
+                                                                          ],
+                                                                          "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                      },
+                                                                      "matchLabels": {
+                                                                        "additionalProperties": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                        "type": "object"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  "namespaceSelector": {
+                                                                    "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                                    "properties": {
+                                                                      "matchExpressions": {
+                                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                        "items": {
+                                                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                          "properties": {
+                                                                            "key": {
+                                                                              "description": "key is the label key that the selector applies to.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            }
+                                                                          },
+                                                                          "required": [
+                                                                            "key",
+                                                                            "operator"
+                                                                          ],
+                                                                          "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                      },
+                                                                      "matchLabels": {
+                                                                        "additionalProperties": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                        "type": "object"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  "namespaces": {
+                                                                    "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "topologyKey": {
+                                                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "topologyKey"
+                                                                ],
+                                                                "type": "object"
+                                                              },
+                                                              "weight": {
+                                                                "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                                                "format": "int32",
+                                                                "type": "integer"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "podAffinityTerm",
+                                                              "weight"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                          "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                                          "items": {
+                                                            "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \u003ctopologyKey\u003e matches that of any node on which a pod of the set of pods is running",
+                                                            "properties": {
+                                                              "labelSelector": {
+                                                                "description": "A label query over a set of resources, in this case pods.",
+                                                                "properties": {
+                                                                  "matchExpressions": {
+                                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                    "items": {
+                                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "key is the label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "matchLabels": {
+                                                                    "additionalProperties": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                    "type": "object"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "namespaceSelector": {
+                                                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                                "properties": {
+                                                                  "matchExpressions": {
+                                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                    "items": {
+                                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "key is the label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "matchLabels": {
+                                                                    "additionalProperties": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                    "type": "object"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "namespaces": {
+                                                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                                "items": {
+                                                                  "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              "topologyKey": {
+                                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "topologyKey"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "nodeSelector": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+                                                  "type": "object"
+                                                },
+                                                "priorityClassName": {
+                                                  "description": "If specified, the pod's priorityClassName.",
+                                                  "type": "string"
+                                                },
+                                                "serviceAccountName": {
+                                                  "description": "If specified, the pod's service account",
+                                                  "type": "string"
+                                                },
+                                                "tolerations": {
+                                                  "description": "If specified, the pod's tolerations.",
+                                                  "items": {
+                                                    "description": "The pod this Toleration is attached to tolerates any taint that matches the triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
+                                                    "properties": {
+                                                      "effect": {
+                                                        "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                                        "type": "string"
+                                                      },
+                                                      "key": {
+                                                        "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                                        "type": "string"
+                                                      },
+                                                      "tolerationSeconds": {
+                                                        "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                                        "format": "int64",
+                                                        "type": "integer"
+                                                      },
+                                                      "value": {
+                                                        "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "serviceType": {
+                                          "description": "Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "selector": {
+                                  "description": "Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.",
+                                  "properties": {
+                                    "dnsNames": {
+                                      "description": "List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "dnsZones": {
+                                      "description": "List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "A label selector that is used to refine the set of certificate's that this challenge solver will apply to.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "privateKeySecretRef",
+                          "server"
+                        ],
+                        "type": "object"
+                      },
+                      "ca": {
+                        "description": "CA configures this issuer to sign certificates using a signing CA keypair stored in a Secret resource. This is used to build internal PKIs that are managed by cert-manager.",
+                        "properties": {
+                          "crlDistributionPoints": {
+                            "description": "The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set, certificates will be issued without distribution points set.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "ocspServers": {
+                            "description": "The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be \"http://ocsp.int-x3.letsencrypt.org\".",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "secretName": {
+                            "description": "SecretName is the name of the secret used to sign Certificates issued by this Issuer.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "secretName"
+                        ],
+                        "type": "object"
+                      },
+                      "selfSigned": {
+                        "description": "SelfSigned configures this issuer to 'self sign' certificates using the private key used to create the CertificateRequest object.",
+                        "properties": {
+                          "crlDistributionPoints": {
+                            "description": "The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set certificate will be issued without CDP. Values are strings.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "vault": {
+                        "description": "Vault configures this issuer to sign certificates using a HashiCorp Vault PKI backend.",
+                        "properties": {
+                          "auth": {
+                            "description": "Auth configures how cert-manager authenticates with the Vault server.",
+                            "properties": {
+                              "appRole": {
+                                "description": "AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.",
+                                "properties": {
+                                  "path": {
+                                    "description": "Path where the App Role authentication backend is mounted in Vault, e.g: \"approle\"",
+                                    "type": "string"
+                                  },
+                                  "roleId": {
+                                    "description": "RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.",
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "description": "Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "path",
+                                  "roleId",
+                                  "secretRef"
+                                ],
+                                "type": "object"
+                              },
+                              "kubernetes": {
+                                "description": "Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.",
+                                "properties": {
+                                  "mountPath": {
+                                    "description": "The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value \"/v1/auth/kubernetes\" will be used.",
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "description": "A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.",
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "description": "The required Secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. Use of 'ambient credentials' is not supported.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "role",
+                                  "secretRef"
+                                ],
+                                "type": "object"
+                              },
+                              "tokenSecretRef": {
+                                "description": "TokenSecretRef authenticates with Vault by presenting a token.",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "caBundle": {
+                            "description": "PEM-encoded CA bundle (base64-encoded) used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.",
+                            "format": "byte",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: \"ns1\" More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "Path is the mount path of the Vault PKI backend's `sign` endpoint, e.g: \"my_pki_mount/sign/my-role-name\".",
+                            "type": "string"
+                          },
+                          "server": {
+                            "description": "Server is the connection address for the Vault server, e.g: \"https://vault.example.com:8200\".",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "auth",
+                          "path",
+                          "server"
+                        ],
+                        "type": "object"
+                      },
+                      "venafi": {
+                        "description": "Venafi configures this issuer to sign certificates using a Venafi TPP or Venafi Cloud policy zone.",
+                        "properties": {
+                          "cloud": {
+                            "description": "Cloud specifies the Venafi cloud configuration settings. Only one of TPP or Cloud may be specified.",
+                            "properties": {
+                              "apiTokenSecretRef": {
+                                "description": "APITokenSecretRef is a secret key selector for the Venafi Cloud API token.",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "url": {
+                                "description": "URL is the base URL for Venafi Cloud. Defaults to \"https://api.venafi.cloud/v1\".",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "apiTokenSecretRef"
+                            ],
+                            "type": "object"
+                          },
+                          "tpp": {
+                            "description": "TPP specifies Trust Protection Platform configuration settings. Only one of TPP or Cloud may be specified.",
+                            "properties": {
+                              "caBundle": {
+                                "description": "CABundle is a PEM encoded TLS certificate to use to verify connections to the TPP instance. If specified, system roots will not be used and the issuing CA for the TPP instance must be verifiable using the provided root. If not specified, the connection will be verified using the cert-manager system root certificates.",
+                                "format": "byte",
+                                "type": "string"
+                              },
+                              "credentialsRef": {
+                                "description": "CredentialsRef is a reference to a Secret containing the username and password for the TPP server. The secret must contain two keys, 'username' and 'password'.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "url": {
+                                "description": "URL is the base URL for the vedsdk endpoint of the Venafi TPP instance, for example: \"https://tpp.example.com/vedsdk\".",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "credentialsRef",
+                              "url"
+                            ],
+                            "type": "object"
+                          },
+                          "zone": {
+                            "description": "Zone is the Venafi Policy Zone to use for this issuer. All requests made to the Venafi platform will be restricted by the named zone policy. This field is required.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "zone"
+                        ],
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "status": {
+                    "description": "Status of the ClusterIssuer. This is set and managed automatically.",
+                    "properties": {
+                      "acme": {
+                        "description": "ACME specific status options. This field should only be set if the Issuer is configured to use an ACME server to issue certificates.",
+                        "properties": {
+                          "lastRegisteredEmail": {
+                            "description": "LastRegisteredEmail is the email associated with the latest registered ACME account, in order to track changes made to registered account associated with the  Issuer",
+                            "type": "string"
+                          },
+                          "uri": {
+                            "description": "URI is the unique account identifier, which can also be used to retrieve account details from the CA",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "conditions": {
+                        "description": "List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready`.",
+                        "items": {
+                          "description": "IssuerCondition contains condition information for an Issuer.",
+                          "properties": {
+                            "lastTransitionTime": {
+                              "description": "LastTransitionTime is the timestamp corresponding to the last status change of this condition.",
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "message": {
+                              "description": "Message is a human readable description of the details of the last transition, complementing reason.",
+                              "type": "string"
+                            },
+                            "observedGeneration": {
+                              "description": "If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "reason": {
+                              "description": "Reason is a brief machine readable explanation for the condition's last transition.",
+                              "type": "string"
+                            },
+                            "status": {
+                              "description": "Status of the condition, one of (`True`, `False`, `Unknown`).",
+                              "enum": [
+                                "True",
+                                "False",
+                                "Unknown"
+                              ],
+                              "type": "string"
+                            },
+                            "type": {
+                              "description": "Type of the condition, known values are (`Ready`).",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "status",
+                            "type"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "type"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "spec"
+                ],
+                "type": "object"
+              }
+            },
+            "served": true,
+            "storage": true,
+            "subresources": {
+              "status": {}
+            }
+          }
+        ]
+      },
+      "status": {
+        "acceptedNames": {
+          "categories": [
+            "cert-manager"
+          ],
+          "kind": "ClusterIssuer",
+          "listKind": "ClusterIssuerList",
+          "plural": "clusterissuers",
+          "singular": "clusterissuer"
+        },
+        "conditions": [
+          {
+            "lastTransitionTime": "2022-11-03T14:15:18Z",
+            "message": "no conflicts found",
+            "reason": "NoConflicts",
+            "status": "True",
+            "type": "NamesAccepted"
+          },
+          {
+            "lastTransitionTime": "2022-11-03T14:15:19Z",
+            "message": "the initial names have been accepted",
+            "reason": "InitialNamesAccepted",
+            "status": "True",
+            "type": "Established"
+          }
+        ],
+        "storedVersions": [
+          "v1"
+        ]
+      }
+    },
+    {
+      "apiVersion": "apiextensions.k8s.io/v1",
+      "kind": "CustomResourceDefinition",
+      "metadata": {
+        "annotations": {
+          "controller-gen.kubebuilder.io/version": "v0.9.2",
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apiextensions.k8s.io/v1\",\"kind\":\"CustomResourceDefinition\",\"metadata\":{\"annotations\":{\"controller-gen.kubebuilder.io/version\":\"v0.9.2\"},\"creationTimestamp\":null,\"name\":\"googlecasclusterissuers.cas-issuer.jetstack.io\"},\"spec\":{\"group\":\"cas-issuer.jetstack.io\",\"names\":{\"kind\":\"GoogleCASClusterIssuer\",\"listKind\":\"GoogleCASClusterIssuerList\",\"plural\":\"googlecasclusterissuers\",\"singular\":\"googlecasclusterissuer\"},\"scope\":\"Cluster\",\"versions\":[{\"additionalPrinterColumns\":[{\"jsonPath\":\".status.conditions[?(@.type=='Ready')].status\",\"name\":\"ready\",\"type\":\"string\"},{\"jsonPath\":\".status.conditions[?(@.type=='Ready')].reason\",\"name\":\"reason\",\"type\":\"string\"},{\"jsonPath\":\".status.conditions[?(@.type=='Ready')].message\",\"name\":\"message\",\"type\":\"string\"}],\"name\":\"v1beta1\",\"schema\":{\"openAPIV3Schema\":{\"description\":\"GoogleCASClusterIssuer is the Schema for the googlecasclusterissuers API\",\"properties\":{\"apiVersion\":{\"description\":\"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources\",\"type\":\"string\"},\"kind\":{\"description\":\"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds\",\"type\":\"string\"},\"metadata\":{\"type\":\"object\"},\"spec\":{\"description\":\"GoogleCASIssuerSpec defines the desired state of GoogleCASIssuer\",\"properties\":{\"caPoolId\":{\"description\":\"CaPoolId is the id of the CA pool to issue certificates from\",\"type\":\"string\"},\"certificateAuthorityId\":{\"description\":\"CertificateAuthorityId is specific certificate authority to use to sign. Omit in order to load balance across all CAs in the pool\",\"type\":\"string\"},\"credentials\":{\"description\":\"Credentials is a reference to a Kubernetes Secret Key that contains Google Service Account Credentials\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"location\":{\"description\":\"Location is the Google Cloud Project Location\",\"type\":\"string\"},\"project\":{\"description\":\"Project is the Google Cloud Project ID\",\"type\":\"string\"}},\"type\":\"object\"},\"status\":{\"description\":\"GoogleCASIssuerStatus defines the observed state of GoogleCASIssuer\",\"properties\":{\"conditions\":{\"items\":{\"description\":\"IssuerCondition contains condition information for a CAS Issuer.\",\"properties\":{\"lastTransitionTime\":{\"description\":\"LastTransitionTime is the timestamp corresponding to the last status change of this condition.\",\"format\":\"date-time\",\"type\":\"string\"},\"message\":{\"description\":\"Message is a human readable description of the details of the last transition, complementing reason.\",\"type\":\"string\"},\"reason\":{\"description\":\"Reason is a brief machine readable explanation for the condition's last transition.\",\"type\":\"string\"},\"status\":{\"allOf\":[{\"enum\":[\"True\",\"False\",\"Unknown\"]},{\"enum\":[\"True\",\"False\",\"Unknown\"]}],\"description\":\"Status of the condition, one of ('True', 'False', 'Unknown').\",\"type\":\"string\"},\"type\":{\"description\":\"Type of the condition, currently ('Ready').\",\"enum\":[\"Ready\"],\"type\":\"string\"}},\"required\":[\"status\",\"type\"],\"type\":\"object\"},\"type\":\"array\"}},\"type\":\"object\"}},\"type\":\"object\"}},\"served\":true,\"storage\":true,\"subresources\":{\"status\":{}}}]}}\n"
+        },
+        "creationTimestamp": "2022-11-04T16:26:38Z",
+        "generation": 1,
+        "name": "googlecasclusterissuers.cas-issuer.jetstack.io",
+        "resourceVersion": "183721",
+        "uid": "30d0b2f9-afd9-469f-bf59-8d4668f23a48"
+      },
+      "spec": {
+        "conversion": {
+          "strategy": "None"
+        },
+        "group": "cas-issuer.jetstack.io",
+        "names": {
+          "kind": "GoogleCASClusterIssuer",
+          "listKind": "GoogleCASClusterIssuerList",
+          "plural": "googlecasclusterissuers",
+          "singular": "googlecasclusterissuer"
+        },
+        "scope": "Cluster",
+        "versions": [
+          {
+            "additionalPrinterColumns": [
+              {
+                "jsonPath": ".status.conditions[?(@.type=='Ready')].status",
+                "name": "ready",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".status.conditions[?(@.type=='Ready')].reason",
+                "name": "reason",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".status.conditions[?(@.type=='Ready')].message",
+                "name": "message",
+                "type": "string"
+              }
+            ],
+            "name": "v1beta1",
+            "schema": {
+              "openAPIV3Schema": {
+                "description": "GoogleCASClusterIssuer is the Schema for the googlecasclusterissuers API",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "type": "object"
+                  },
+                  "spec": {
+                    "description": "GoogleCASIssuerSpec defines the desired state of GoogleCASIssuer",
+                    "properties": {
+                      "caPoolId": {
+                        "description": "CaPoolId is the id of the CA pool to issue certificates from",
+                        "type": "string"
+                      },
+                      "certificateAuthorityId": {
+                        "description": "CertificateAuthorityId is specific certificate authority to use to sign. Omit in order to load balance across all CAs in the pool",
+                        "type": "string"
+                      },
+                      "credentials": {
+                        "description": "Credentials is a reference to a Kubernetes Secret Key that contains Google Service Account Credentials",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object"
+                      },
+                      "location": {
+                        "description": "Location is the Google Cloud Project Location",
+                        "type": "string"
+                      },
+                      "project": {
+                        "description": "Project is the Google Cloud Project ID",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "status": {
+                    "description": "GoogleCASIssuerStatus defines the observed state of GoogleCASIssuer",
+                    "properties": {
+                      "conditions": {
+                        "items": {
+                          "description": "IssuerCondition contains condition information for a CAS Issuer.",
+                          "properties": {
+                            "lastTransitionTime": {
+                              "description": "LastTransitionTime is the timestamp corresponding to the last status change of this condition.",
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "message": {
+                              "description": "Message is a human readable description of the details of the last transition, complementing reason.",
+                              "type": "string"
+                            },
+                            "reason": {
+                              "description": "Reason is a brief machine readable explanation for the condition's last transition.",
+                              "type": "string"
+                            },
+                            "status": {
+                              "allOf": [
+                                {
+                                  "enum": [
+                                    "True",
+                                    "False",
+                                    "Unknown"
+                                  ]
+                                },
+                                {
+                                  "enum": [
+                                    "True",
+                                    "False",
+                                    "Unknown"
+                                  ]
+                                }
+                              ],
+                              "description": "Status of the condition, one of ('True', 'False', 'Unknown').",
+                              "type": "string"
+                            },
+                            "type": {
+                              "description": "Type of the condition, currently ('Ready').",
+                              "enum": [
+                                "Ready"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "status",
+                            "type"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "served": true,
+            "storage": true,
+            "subresources": {
+              "status": {}
+            }
+          }
+        ]
+      },
+      "status": {
+        "acceptedNames": {
+          "kind": "GoogleCASClusterIssuer",
+          "listKind": "GoogleCASClusterIssuerList",
+          "plural": "googlecasclusterissuers",
+          "singular": "googlecasclusterissuer"
+        },
+        "conditions": [
+          {
+            "lastTransitionTime": "2022-11-04T16:26:38Z",
+            "message": "no conflicts found",
+            "reason": "NoConflicts",
+            "status": "True",
+            "type": "NamesAccepted"
+          },
+          {
+            "lastTransitionTime": "2022-11-04T16:26:39Z",
+            "message": "the initial names have been accepted",
+            "reason": "InitialNamesAccepted",
+            "status": "True",
+            "type": "Established"
+          }
+        ],
+        "storedVersions": [
+          "v1beta1"
+        ]
+      }
+    },
+    {
+      "apiVersion": "apiextensions.k8s.io/v1",
+      "kind": "CustomResourceDefinition",
+      "metadata": {
+        "annotations": {
+          "controller-gen.kubebuilder.io/version": "v0.9.2",
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apiextensions.k8s.io/v1\",\"kind\":\"CustomResourceDefinition\",\"metadata\":{\"annotations\":{\"controller-gen.kubebuilder.io/version\":\"v0.9.2\"},\"creationTimestamp\":null,\"name\":\"googlecasissuers.cas-issuer.jetstack.io\"},\"spec\":{\"group\":\"cas-issuer.jetstack.io\",\"names\":{\"kind\":\"GoogleCASIssuer\",\"listKind\":\"GoogleCASIssuerList\",\"plural\":\"googlecasissuers\",\"singular\":\"googlecasissuer\"},\"scope\":\"Namespaced\",\"versions\":[{\"additionalPrinterColumns\":[{\"jsonPath\":\".status.conditions[?(@.type=='Ready')].status\",\"name\":\"ready\",\"type\":\"string\"},{\"jsonPath\":\".status.conditions[?(@.type=='Ready')].reason\",\"name\":\"reason\",\"type\":\"string\"},{\"jsonPath\":\".status.conditions[?(@.type=='Ready')].message\",\"name\":\"message\",\"type\":\"string\"}],\"name\":\"v1beta1\",\"schema\":{\"openAPIV3Schema\":{\"description\":\"GoogleCASIssuer is the Schema for the googlecasissuers API\",\"properties\":{\"apiVersion\":{\"description\":\"APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources\",\"type\":\"string\"},\"kind\":{\"description\":\"Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds\",\"type\":\"string\"},\"metadata\":{\"type\":\"object\"},\"spec\":{\"description\":\"GoogleCASIssuerSpec defines the desired state of GoogleCASIssuer\",\"properties\":{\"caPoolId\":{\"description\":\"CaPoolId is the id of the CA pool to issue certificates from\",\"type\":\"string\"},\"certificateAuthorityId\":{\"description\":\"CertificateAuthorityId is specific certificate authority to use to sign. Omit in order to load balance across all CAs in the pool\",\"type\":\"string\"},\"credentials\":{\"description\":\"Credentials is a reference to a Kubernetes Secret Key that contains Google Service Account Credentials\",\"properties\":{\"key\":{\"description\":\"The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"},\"location\":{\"description\":\"Location is the Google Cloud Project Location\",\"type\":\"string\"},\"project\":{\"description\":\"Project is the Google Cloud Project ID\",\"type\":\"string\"}},\"type\":\"object\"},\"status\":{\"description\":\"GoogleCASIssuerStatus defines the observed state of GoogleCASIssuer\",\"properties\":{\"conditions\":{\"items\":{\"description\":\"IssuerCondition contains condition information for a CAS Issuer.\",\"properties\":{\"lastTransitionTime\":{\"description\":\"LastTransitionTime is the timestamp corresponding to the last status change of this condition.\",\"format\":\"date-time\",\"type\":\"string\"},\"message\":{\"description\":\"Message is a human readable description of the details of the last transition, complementing reason.\",\"type\":\"string\"},\"reason\":{\"description\":\"Reason is a brief machine readable explanation for the condition's last transition.\",\"type\":\"string\"},\"status\":{\"allOf\":[{\"enum\":[\"True\",\"False\",\"Unknown\"]},{\"enum\":[\"True\",\"False\",\"Unknown\"]}],\"description\":\"Status of the condition, one of ('True', 'False', 'Unknown').\",\"type\":\"string\"},\"type\":{\"description\":\"Type of the condition, currently ('Ready').\",\"enum\":[\"Ready\"],\"type\":\"string\"}},\"required\":[\"status\",\"type\"],\"type\":\"object\"},\"type\":\"array\"}},\"type\":\"object\"}},\"type\":\"object\"}},\"served\":true,\"storage\":true,\"subresources\":{\"status\":{}}}]}}\n"
+        },
+        "creationTimestamp": "2022-11-04T16:26:25Z",
+        "generation": 1,
+        "name": "googlecasissuers.cas-issuer.jetstack.io",
+        "resourceVersion": "183692",
+        "uid": "23623c01-4c68-40bd-a49e-d8cc188237ed"
+      },
+      "spec": {
+        "conversion": {
+          "strategy": "None"
+        },
+        "group": "cas-issuer.jetstack.io",
+        "names": {
+          "kind": "GoogleCASIssuer",
+          "listKind": "GoogleCASIssuerList",
+          "plural": "googlecasissuers",
+          "singular": "googlecasissuer"
+        },
+        "scope": "Namespaced",
+        "versions": [
+          {
+            "additionalPrinterColumns": [
+              {
+                "jsonPath": ".status.conditions[?(@.type=='Ready')].status",
+                "name": "ready",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".status.conditions[?(@.type=='Ready')].reason",
+                "name": "reason",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".status.conditions[?(@.type=='Ready')].message",
+                "name": "message",
+                "type": "string"
+              }
+            ],
+            "name": "v1beta1",
+            "schema": {
+              "openAPIV3Schema": {
+                "description": "GoogleCASIssuer is the Schema for the googlecasissuers API",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "type": "object"
+                  },
+                  "spec": {
+                    "description": "GoogleCASIssuerSpec defines the desired state of GoogleCASIssuer",
+                    "properties": {
+                      "caPoolId": {
+                        "description": "CaPoolId is the id of the CA pool to issue certificates from",
+                        "type": "string"
+                      },
+                      "certificateAuthorityId": {
+                        "description": "CertificateAuthorityId is specific certificate authority to use to sign. Omit in order to load balance across all CAs in the pool",
+                        "type": "string"
+                      },
+                      "credentials": {
+                        "description": "Credentials is a reference to a Kubernetes Secret Key that contains Google Service Account Credentials",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object"
+                      },
+                      "location": {
+                        "description": "Location is the Google Cloud Project Location",
+                        "type": "string"
+                      },
+                      "project": {
+                        "description": "Project is the Google Cloud Project ID",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "status": {
+                    "description": "GoogleCASIssuerStatus defines the observed state of GoogleCASIssuer",
+                    "properties": {
+                      "conditions": {
+                        "items": {
+                          "description": "IssuerCondition contains condition information for a CAS Issuer.",
+                          "properties": {
+                            "lastTransitionTime": {
+                              "description": "LastTransitionTime is the timestamp corresponding to the last status change of this condition.",
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "message": {
+                              "description": "Message is a human readable description of the details of the last transition, complementing reason.",
+                              "type": "string"
+                            },
+                            "reason": {
+                              "description": "Reason is a brief machine readable explanation for the condition's last transition.",
+                              "type": "string"
+                            },
+                            "status": {
+                              "allOf": [
+                                {
+                                  "enum": [
+                                    "True",
+                                    "False",
+                                    "Unknown"
+                                  ]
+                                },
+                                {
+                                  "enum": [
+                                    "True",
+                                    "False",
+                                    "Unknown"
+                                  ]
+                                }
+                              ],
+                              "description": "Status of the condition, one of ('True', 'False', 'Unknown').",
+                              "type": "string"
+                            },
+                            "type": {
+                              "description": "Type of the condition, currently ('Ready').",
+                              "enum": [
+                                "Ready"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "status",
+                            "type"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "served": true,
+            "storage": true,
+            "subresources": {
+              "status": {}
+            }
+          }
+        ]
+      },
+      "status": {
+        "acceptedNames": {
+          "kind": "GoogleCASIssuer",
+          "listKind": "GoogleCASIssuerList",
+          "plural": "googlecasissuers",
+          "singular": "googlecasissuer"
+        },
+        "conditions": [
+          {
+            "lastTransitionTime": "2022-11-04T16:26:25Z",
+            "message": "no conflicts found",
+            "reason": "NoConflicts",
+            "status": "True",
+            "type": "NamesAccepted"
+          },
+          {
+            "lastTransitionTime": "2022-11-04T16:26:25Z",
+            "message": "the initial names have been accepted",
+            "reason": "InitialNamesAccepted",
+            "status": "True",
+            "type": "Established"
+          }
+        ],
+        "storedVersions": [
+          "v1beta1"
+        ]
+      }
+    },
+    {
+      "apiVersion": "apiextensions.k8s.io/v1",
+      "kind": "CustomResourceDefinition",
+      "metadata": {
+        "annotations": {
+          "controller-gen.kubebuilder.io/version": "v0.9.2"
+        },
+        "creationTimestamp": "2022-11-03T14:10:32Z",
+        "generation": 1,
+        "name": "installations.operator.jetstack.io",
+        "resourceVersion": "70732",
+        "uid": "b99a3475-9912-4396-9bba-95d23f5434de"
+      },
+      "spec": {
+        "conversion": {
+          "strategy": "None"
+        },
+        "group": "operator.jetstack.io",
+        "names": {
+          "kind": "Installation",
+          "listKind": "InstallationList",
+          "plural": "installations",
+          "singular": "installation"
+        },
+        "scope": "Cluster",
+        "versions": [
+          {
+            "additionalPrinterColumns": [
+              {
+                "description": "Installation Ready",
+                "jsonPath": ".status.conditions[?(@.type == \"Ready\")].status",
+                "name": "Ready",
+                "type": "string"
+              },
+              {
+                "description": "Timestamp Installation was created",
+                "jsonPath": ".metadata.creationTimestamp",
+                "name": "Age",
+                "type": "date"
+              }
+            ],
+            "name": "v1alpha1",
+            "schema": {
+              "openAPIV3Schema": {
+                "description": "Installation represents an installation of Jetstack Secure components and resources.",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "type": "object"
+                  },
+                  "spec": {
+                    "description": "InstallationSpec defines the desired state of Installation",
+                    "properties": {
+                      "approverPolicy": {
+                        "description": "ApproverPolicy contains configuration options for the Installation's approver-policy installation. This field or approverPolicyEnterprise must be set as approver-policy is a required component. https://platform.jetstack.io/documentation/installation/approver-policy",
+                        "properties": {
+                          "replicas": {
+                            "description": "ReplicaCount is the number of approver-policy instances to run. Defaults to 2 instances.",
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "version": {
+                            "description": "Version is the version of approver-policy to install https://github.com/cert-manager/approver-policy/releases. Default version: v0.4.0. Supported Versions: v0.4.0, v0.3.0,v0.2.0, v0.1.0.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "approverPolicyEnterprise": {
+                        "description": "ApproverPolicyEnterprise contains configuration options for the Installation's approver-policy-enterprise installation. This is mutually exclusive with the approverPolicy field. https://platform.jetstack.io/documentation/installation/approver-policy",
+                        "properties": {
+                          "imagePullSecrets": {
+                            "description": "An optional list of image pull secrets to be passed to the approver-policy-enterprise Pod. These need to be created in jetstack-secure namespace where approver-policy-enterprise will be deployed.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "replicas": {
+                            "description": "ReplicaCount is the number of approver-policy instances to run. Defaults to 2 instances.",
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "version": {
+                            "description": "Version is the version of approver-policy to install https://github.com/cert-manager/approver-policy/releases Default: v0.4.0-0 Supported Versions: v0.4.0-0",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "certDiscoveryVenafi": {
+                        "description": "CertDiscoveryVenafi contains configuration options for cert-discovery-venafi. See https://platform.jetstack.io/documentation/installation/cert-discovery-venafi to learn more about cert-discovery-venafi. If unset (default) cert-discovery-venafi will not be installed.",
+                        "properties": {
+                          "imagePullSecrets": {
+                            "description": "An optional list of image pull secrets to be passed to the cert-discovery-venafi Pod.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "replicas": {
+                            "description": "ReplicaCount is the number of cert-discovery-venafi instances to run. Defaults to 1 instance.",
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "tpp": {
+                            "description": "Venafi TPP server configuration options.",
+                            "properties": {
+                              "tokenSecretRef": {
+                                "description": "TokenSecretRef is a reference to a key in a Kubernetes Secret with the TPP access token that cert-discovery-venafi will use to authenticate. Secret must be in the same namespace as cert-discovery-venafi (by default cert-manager). Defaults to a Secret named 'access-token' with a key named 'access-token'.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is a key in a Secret",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of a Secret",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "url": {
+                                "description": "URL of the TPP server where cert-discovery-venafi should upload discovered certs.",
+                                "type": "string"
+                              },
+                              "zone": {
+                                "description": "Zone (policy folder) where cert-discovery-venafi should upload discovered certs.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "url",
+                              "zone"
+                            ],
+                            "type": "object"
+                          },
+                          "version": {
+                            "description": "Version is the version of cert-discovery-venafi to install Defaults to v0.2.0-alpha.3 Supported versions are v0.2.0-alpha.3",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "tpp"
+                        ],
+                        "type": "object"
+                      },
+                      "certManager": {
+                        "description": "CertManager contains configuration options for the Installation's cert-manager installation This field must be set as cert-manager is a required component.",
+                        "properties": {
+                          "controller": {
+                            "description": "Controller wraps the configuration options for the cert-manager controller",
+                            "properties": {
+                              "replicas": {
+                                "description": "ReplicaCount is the number of controller instances to run. Only one instance at a time will be a leader. Defaults to 2.",
+                                "minimum": 1,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "version": {
+                            "description": "Version is the version of cert-manager release to install https://github.com/cert-manager/cert-manager/releases. Default: v1.9.1 Supported Versions: v1.9.1, v1.8.0, v1.7.1, v1.7.0, v1.6.2, v1.6.1, v1.6.0",
+                            "type": "string"
+                          },
+                          "webhook": {
+                            "description": "Webhook wraps the configuration options for the cert-manager webhook deployment",
+                            "properties": {
+                              "replicas": {
+                                "description": "ReplicaCount is the number of webhook instances to run, default 2",
+                                "minimum": 1,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "csiDrivers": {
+                        "description": "CSIDrivers contains configuration for the different CSI Drivers available for installation",
+                        "properties": {
+                          "certManager": {
+                            "description": "certManager refers to the configuration of a cert-manager.io/csi-driver https://cert-manager.io/docs/projects/csi-driver/",
+                            "properties": {
+                              "version": {
+                                "description": "Version is the version of csi-driver to install https://github.com/cert-manager/csi-driver/releases Default: v0.4.0 Supported Versions: v0.4.0, v0.2.0, v0.1.0",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "certManagerSpiffe": {
+                            "description": "CertManagerSpiffe refers to the configuration of cert-manager/csi-driver-spiffe that can be used to issue SPIFFE certs for workloads https://cert-manager.io/docs/projects/csi-driver-spiffe/",
+                            "properties": {
+                              "issuerRef": {
+                                "description": "IssuerRef is a reference to the issuer that will be used to issue certs by csi-spiffe. This must correspond to an issuer configured in Installation.spec.issuers and must be either a cluster-scoped issuer or be in the same namespace as the pods that will request the certificate volumes. Defaults to a cert-manager.io ClusterIssuer named spiffe-ca.",
+                                "properties": {
+                                  "group": {
+                                    "description": "Group of the resource being referred to.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind of the resource being referred to.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the resource being referred to.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "replicas": {
+                                "description": "ReplicaCount is the number of approver (component responsible for verifying requests for SVID certs from the configured issuer) instances to run. Defaults to 2.",
+                                "minimum": 1,
+                                "type": "integer"
+                              },
+                              "version": {
+                                "description": "Version is the version of cert-manager/csi-driver-spiffe to install https://github.com/cert-manager/csi-driver-spiffe/releases Default: v0.2.0 Supported Versions: v0.2.0,v0.1.0",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "issuers": {
+                        "description": "Issuers can be used to configure cert-manager issuers that the operator will deploy. Currently only cert-manager.io Issuer and ClusterIssuer types are supported.",
+                        "items": {
+                          "properties": {
+                            "acme": {
+                              "description": "ACME configures this issuer to communicate with a RFC8555 (ACME) server to obtain signed x509 certificates. https://cert-manager.io/docs/configuration/acme/",
+                              "properties": {
+                                "disableAccountKeyGeneration": {
+                                  "description": "Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.",
+                                  "type": "boolean"
+                                },
+                                "email": {
+                                  "description": "Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.",
+                                  "type": "string"
+                                },
+                                "enableDurationFeature": {
+                                  "description": "Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.",
+                                  "type": "boolean"
+                                },
+                                "externalAccountBinding": {
+                                  "description": "ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.",
+                                  "properties": {
+                                    "keyAlgorithm": {
+                                      "description": "Deprecated: keyAlgorithm field exists for historical compatibility reasons and should not be used. The algorithm is now hardcoded to HS256 in golang/x/crypto/acme.",
+                                      "enum": [
+                                        "HS256",
+                                        "HS384",
+                                        "HS512"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "keyID": {
+                                      "description": "keyID is the ID of the CA key that the External Account is bound to.",
+                                      "type": "string"
+                                    },
+                                    "keySecretRef": {
+                                      "description": "keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes Secret which holds the symmetric MAC key of the External Account Binding. The `key` is the index string that is paired with the key data in the Secret and should not be confused with the key data itself, or indeed with the External Account Binding keyID above. The secret key stored in the Secret **must** be un-padded, base64 URL encoded data.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object"
+                                    }
+                                  },
+                                  "required": [
+                                    "keyID",
+                                    "keySecretRef"
+                                  ],
+                                  "type": "object"
+                                },
+                                "preferredChain": {
+                                  "description": "PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let's Encrypt's DST crosssign you would use: \"DST Root CA X3\" or \"ISRG Root X1\" for the newer Let's Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer's CN",
+                                  "maxLength": 64,
+                                  "type": "string"
+                                },
+                                "privateKeySecretRef": {
+                                  "description": "PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object"
+                                },
+                                "server": {
+                                  "description": "Server is the URL used to access the ACME server's 'directory' endpoint. For example, for Let's Encrypt's staging endpoint, you would use: \"https://acme-staging-v02.api.letsencrypt.org/directory\". Only ACME v2 endpoints (i.e. RFC 8555) are supported.",
+                                  "type": "string"
+                                },
+                                "skipTLSVerify": {
+                                  "description": "Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have their TLS certificate validated (i.e. insecure connections will be allowed). Only enable this option in development environments. The cert-manager system installed roots will be used to verify connections to the ACME server if this is false. Defaults to false.",
+                                  "type": "boolean"
+                                },
+                                "solvers": {
+                                  "description": "Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/",
+                                  "items": {
+                                    "description": "An ACMEChallengeSolver describes how to solve ACME challenges for the issuer it is part of. A selector may be provided to use different solving strategies for different DNS names. Only one of HTTP01 or DNS01 must be provided.",
+                                    "properties": {
+                                      "dns01": {
+                                        "description": "Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.",
+                                        "properties": {
+                                          "acmeDNS": {
+                                            "description": "Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.",
+                                            "properties": {
+                                              "accountSecretRef": {
+                                                "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              "host": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "accountSecretRef",
+                                              "host"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "akamai": {
+                                            "description": "Use the Akamai DNS zone management API to manage DNS01 challenge records.",
+                                            "properties": {
+                                              "accessTokenSecretRef": {
+                                                "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              "clientSecretSecretRef": {
+                                                "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              "clientTokenSecretRef": {
+                                                "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              "serviceConsumerDomain": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "accessTokenSecretRef",
+                                              "clientSecretSecretRef",
+                                              "clientTokenSecretRef",
+                                              "serviceConsumerDomain"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "azureDNS": {
+                                            "description": "Use the Microsoft Azure DNS API to manage DNS01 challenge records.",
+                                            "properties": {
+                                              "clientID": {
+                                                "description": "if both this and ClientSecret are left unset MSI will be used",
+                                                "type": "string"
+                                              },
+                                              "clientSecretSecretRef": {
+                                                "description": "if both this and ClientID are left unset MSI will be used",
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              "environment": {
+                                                "description": "name of the Azure environment (default AzurePublicCloud)",
+                                                "enum": [
+                                                  "AzurePublicCloud",
+                                                  "AzureChinaCloud",
+                                                  "AzureGermanCloud",
+                                                  "AzureUSGovernmentCloud"
+                                                ],
+                                                "type": "string"
+                                              },
+                                              "hostedZoneName": {
+                                                "description": "name of the DNS zone that should be used",
+                                                "type": "string"
+                                              },
+                                              "managedIdentity": {
+                                                "description": "managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID",
+                                                "properties": {
+                                                  "clientID": {
+                                                    "description": "client ID of the managed identity, can not be used at the same time as resourceID",
+                                                    "type": "string"
+                                                  },
+                                                  "resourceID": {
+                                                    "description": "resource ID of the managed identity, can not be used at the same time as clientID",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "resourceGroupName": {
+                                                "description": "resource group the DNS zone is located in",
+                                                "type": "string"
+                                              },
+                                              "subscriptionID": {
+                                                "description": "ID of the Azure subscription",
+                                                "type": "string"
+                                              },
+                                              "tenantID": {
+                                                "description": "when specifying ClientID and ClientSecret then this field is also needed",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "resourceGroupName",
+                                              "subscriptionID"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "cloudDNS": {
+                                            "description": "Use the Google Cloud DNS API to manage DNS01 challenge records.",
+                                            "properties": {
+                                              "hostedZoneName": {
+                                                "description": "HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.",
+                                                "type": "string"
+                                              },
+                                              "project": {
+                                                "type": "string"
+                                              },
+                                              "serviceAccountSecretRef": {
+                                                "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "type": "object"
+                                              }
+                                            },
+                                            "required": [
+                                              "project"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "cloudflare": {
+                                            "description": "Use the Cloudflare API to manage DNS01 challenge records.",
+                                            "properties": {
+                                              "apiKeySecretRef": {
+                                                "description": "API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.",
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              "apiTokenSecretRef": {
+                                                "description": "API token used to authenticate with Cloudflare.",
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              "email": {
+                                                "description": "Email of the account, only required when using API key based authentication.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "cnameStrategy": {
+                                            "description": "CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.",
+                                            "enum": [
+                                              "None",
+                                              "Follow"
+                                            ],
+                                            "type": "string"
+                                          },
+                                          "digitalocean": {
+                                            "description": "Use the DigitalOcean DNS API to manage DNS01 challenge records.",
+                                            "properties": {
+                                              "tokenSecretRef": {
+                                                "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "type": "object"
+                                              }
+                                            },
+                                            "required": [
+                                              "tokenSecretRef"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "rfc2136": {
+                                            "description": "Use RFC2136 (\"Dynamic Updates in the Domain Name System\") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.",
+                                            "properties": {
+                                              "nameserver": {
+                                                "description": "The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.",
+                                                "type": "string"
+                                              },
+                                              "tsigAlgorithm": {
+                                                "description": "The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.",
+                                                "type": "string"
+                                              },
+                                              "tsigKeyName": {
+                                                "description": "The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.",
+                                                "type": "string"
+                                              },
+                                              "tsigSecretSecretRef": {
+                                                "description": "The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.",
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "type": "object"
+                                              }
+                                            },
+                                            "required": [
+                                              "nameserver"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "route53": {
+                                            "description": "Use the AWS Route53 API to manage DNS01 challenge records.",
+                                            "properties": {
+                                              "accessKeyID": {
+                                                "description": "The AccessKeyID is used for authentication. Cannot be set when SecretAccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                                                "type": "string"
+                                              },
+                                              "accessKeyIDSecretRef": {
+                                                "description": "The SecretAccessKey is used for authentication. If set, pull the AWS access key ID from a key within a Kubernetes Secret. Cannot be set when AccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              "hostedZoneID": {
+                                                "description": "If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.",
+                                                "type": "string"
+                                              },
+                                              "region": {
+                                                "description": "Always set the region when using AccessKeyID and SecretAccessKey",
+                                                "type": "string"
+                                              },
+                                              "role": {
+                                                "description": "Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata",
+                                                "type": "string"
+                                              },
+                                              "secretAccessKeySecretRef": {
+                                                "description": "The SecretAccessKey is used for authentication. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "type": "object"
+                                              }
+                                            },
+                                            "required": [
+                                              "region"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "webhook": {
+                                            "description": "Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.",
+                                            "properties": {
+                                              "config": {
+                                                "description": "Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.",
+                                                "x-kubernetes-preserve-unknown-fields": true
+                                              },
+                                              "groupName": {
+                                                "description": "The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.",
+                                                "type": "string"
+                                              },
+                                              "solverName": {
+                                                "description": "The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "groupName",
+                                              "solverName"
+                                            ],
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "http01": {
+                                        "description": "Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.",
+                                        "properties": {
+                                          "gatewayHTTPRoute": {
+                                            "description": "The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.",
+                                            "properties": {
+                                              "labels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.",
+                                                "type": "object"
+                                              },
+                                              "parentRefs": {
+                                                "description": "When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways",
+                                                "items": {
+                                                  "description": "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object.",
+                                                  "properties": {
+                                                    "group": {
+                                                      "default": "gateway.networking.k8s.io",
+                                                      "description": "Group is the group of the referent. \n Support: Core",
+                                                      "maxLength": 253,
+                                                      "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                      "type": "string"
+                                                    },
+                                                    "kind": {
+                                                      "default": "Gateway",
+                                                      "description": "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)",
+                                                      "maxLength": 63,
+                                                      "minLength": 1,
+                                                      "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "description": "Name is the name of the referent. \n Support: Core",
+                                                      "maxLength": 253,
+                                                      "minLength": 1,
+                                                      "type": "string"
+                                                    },
+                                                    "namespace": {
+                                                      "description": "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core",
+                                                      "maxLength": 63,
+                                                      "minLength": 1,
+                                                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                                      "type": "string"
+                                                    },
+                                                    "sectionName": {
+                                                      "description": "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core",
+                                                      "maxLength": 253,
+                                                      "minLength": 1,
+                                                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name"
+                                                  ],
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "serviceType": {
+                                                "description": "Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "ingress": {
+                                            "description": "The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.",
+                                            "properties": {
+                                              "class": {
+                                                "description": "The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.",
+                                                "type": "string"
+                                              },
+                                              "ingressTemplate": {
+                                                "description": "Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.",
+                                                "properties": {
+                                                  "metadata": {
+                                                    "description": "ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.",
+                                                    "properties": {
+                                                      "annotations": {
+                                                        "additionalProperties": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": "Annotations that should be added to the created ACME HTTP01 solver ingress.",
+                                                        "type": "object"
+                                                      },
+                                                      "labels": {
+                                                        "additionalProperties": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": "Labels that should be added to the created ACME HTTP01 solver ingress.",
+                                                        "type": "object"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "name": {
+                                                "description": "The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.",
+                                                "type": "string"
+                                              },
+                                              "podTemplate": {
+                                                "description": "Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.",
+                                                "properties": {
+                                                  "metadata": {
+                                                    "description": "ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.",
+                                                    "properties": {
+                                                      "annotations": {
+                                                        "additionalProperties": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": "Annotations that should be added to the create ACME HTTP01 solver pods.",
+                                                        "type": "object"
+                                                      },
+                                                      "labels": {
+                                                        "additionalProperties": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": "Labels that should be added to the created ACME HTTP01 solver pods.",
+                                                        "type": "object"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "spec": {
+                                                    "description": "PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.",
+                                                    "properties": {
+                                                      "affinity": {
+                                                        "description": "If specified, the pod's scheduling constraints",
+                                                        "properties": {
+                                                          "nodeAffinity": {
+                                                            "description": "Describes node affinity scheduling rules for the pod.",
+                                                            "properties": {
+                                                              "preferredDuringSchedulingIgnoredDuringExecution": {
+                                                                "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                                                "items": {
+                                                                  "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                                                  "properties": {
+                                                                    "preference": {
+                                                                      "description": "A node selector term, associated with the corresponding weight.",
+                                                                      "properties": {
+                                                                        "matchExpressions": {
+                                                                          "description": "A list of node selector requirements by node's labels.",
+                                                                          "items": {
+                                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                            "properties": {
+                                                                              "key": {
+                                                                                "description": "The label key that the selector applies to.",
+                                                                                "type": "string"
+                                                                              },
+                                                                              "operator": {
+                                                                                "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                                "type": "string"
+                                                                              },
+                                                                              "values": {
+                                                                                "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                                "items": {
+                                                                                  "type": "string"
+                                                                                },
+                                                                                "type": "array"
+                                                                              }
+                                                                            },
+                                                                            "required": [
+                                                                              "key",
+                                                                              "operator"
+                                                                            ],
+                                                                            "type": "object"
+                                                                          },
+                                                                          "type": "array"
+                                                                        },
+                                                                        "matchFields": {
+                                                                          "description": "A list of node selector requirements by node's fields.",
+                                                                          "items": {
+                                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                            "properties": {
+                                                                              "key": {
+                                                                                "description": "The label key that the selector applies to.",
+                                                                                "type": "string"
+                                                                              },
+                                                                              "operator": {
+                                                                                "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                                "type": "string"
+                                                                              },
+                                                                              "values": {
+                                                                                "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                                "items": {
+                                                                                  "type": "string"
+                                                                                },
+                                                                                "type": "array"
+                                                                              }
+                                                                            },
+                                                                            "required": [
+                                                                              "key",
+                                                                              "operator"
+                                                                            ],
+                                                                            "type": "object"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "type": "object",
+                                                                      "x-kubernetes-map-type": "atomic"
+                                                                    },
+                                                                    "weight": {
+                                                                      "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                                                      "format": "int32",
+                                                                      "type": "integer"
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "preference",
+                                                                    "weight"
+                                                                  ],
+                                                                  "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                                "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                                                "properties": {
+                                                                  "nodeSelectorTerms": {
+                                                                    "description": "Required. A list of node selector terms. The terms are ORed.",
+                                                                    "items": {
+                                                                      "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                                                      "properties": {
+                                                                        "matchExpressions": {
+                                                                          "description": "A list of node selector requirements by node's labels.",
+                                                                          "items": {
+                                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                            "properties": {
+                                                                              "key": {
+                                                                                "description": "The label key that the selector applies to.",
+                                                                                "type": "string"
+                                                                              },
+                                                                              "operator": {
+                                                                                "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                                "type": "string"
+                                                                              },
+                                                                              "values": {
+                                                                                "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                                "items": {
+                                                                                  "type": "string"
+                                                                                },
+                                                                                "type": "array"
+                                                                              }
+                                                                            },
+                                                                            "required": [
+                                                                              "key",
+                                                                              "operator"
+                                                                            ],
+                                                                            "type": "object"
+                                                                          },
+                                                                          "type": "array"
+                                                                        },
+                                                                        "matchFields": {
+                                                                          "description": "A list of node selector requirements by node's fields.",
+                                                                          "items": {
+                                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                            "properties": {
+                                                                              "key": {
+                                                                                "description": "The label key that the selector applies to.",
+                                                                                "type": "string"
+                                                                              },
+                                                                              "operator": {
+                                                                                "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                                "type": "string"
+                                                                              },
+                                                                              "values": {
+                                                                                "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                                "items": {
+                                                                                  "type": "string"
+                                                                                },
+                                                                                "type": "array"
+                                                                              }
+                                                                            },
+                                                                            "required": [
+                                                                              "key",
+                                                                              "operator"
+                                                                            ],
+                                                                            "type": "object"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "type": "object",
+                                                                      "x-kubernetes-map-type": "atomic"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "nodeSelectorTerms"
+                                                                ],
+                                                                "type": "object",
+                                                                "x-kubernetes-map-type": "atomic"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "podAffinity": {
+                                                            "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                                                            "properties": {
+                                                              "preferredDuringSchedulingIgnoredDuringExecution": {
+                                                                "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                                                "items": {
+                                                                  "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                                                  "properties": {
+                                                                    "podAffinityTerm": {
+                                                                      "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                                      "properties": {
+                                                                        "labelSelector": {
+                                                                          "description": "A label query over a set of resources, in this case pods.",
+                                                                          "properties": {
+                                                                            "matchExpressions": {
+                                                                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                              "items": {
+                                                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                                "properties": {
+                                                                                  "key": {
+                                                                                    "description": "key is the label key that the selector applies to.",
+                                                                                    "type": "string"
+                                                                                  },
+                                                                                  "operator": {
+                                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                                    "type": "string"
+                                                                                  },
+                                                                                  "values": {
+                                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                                    "items": {
+                                                                                      "type": "string"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                  }
+                                                                                },
+                                                                                "required": [
+                                                                                  "key",
+                                                                                  "operator"
+                                                                                ],
+                                                                                "type": "object"
+                                                                              },
+                                                                              "type": "array"
+                                                                            },
+                                                                            "matchLabels": {
+                                                                              "additionalProperties": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                              "type": "object"
+                                                                            }
+                                                                          },
+                                                                          "type": "object",
+                                                                          "x-kubernetes-map-type": "atomic"
+                                                                        },
+                                                                        "namespaceSelector": {
+                                                                          "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                                          "properties": {
+                                                                            "matchExpressions": {
+                                                                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                              "items": {
+                                                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                                "properties": {
+                                                                                  "key": {
+                                                                                    "description": "key is the label key that the selector applies to.",
+                                                                                    "type": "string"
+                                                                                  },
+                                                                                  "operator": {
+                                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                                    "type": "string"
+                                                                                  },
+                                                                                  "values": {
+                                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                                    "items": {
+                                                                                      "type": "string"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                  }
+                                                                                },
+                                                                                "required": [
+                                                                                  "key",
+                                                                                  "operator"
+                                                                                ],
+                                                                                "type": "object"
+                                                                              },
+                                                                              "type": "array"
+                                                                            },
+                                                                            "matchLabels": {
+                                                                              "additionalProperties": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                              "type": "object"
+                                                                            }
+                                                                          },
+                                                                          "type": "object",
+                                                                          "x-kubernetes-map-type": "atomic"
+                                                                        },
+                                                                        "namespaces": {
+                                                                          "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        },
+                                                                        "topologyKey": {
+                                                                          "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                                          "type": "string"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "topologyKey"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "weight": {
+                                                                      "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                                                      "format": "int32",
+                                                                      "type": "integer"
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "podAffinityTerm",
+                                                                    "weight"
+                                                                  ],
+                                                                  "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                                "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                                                "items": {
+                                                                  "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \u003ctopologyKey\u003e matches that of any node on which a pod of the set of pods is running",
+                                                                  "properties": {
+                                                                    "labelSelector": {
+                                                                      "description": "A label query over a set of resources, in this case pods.",
+                                                                      "properties": {
+                                                                        "matchExpressions": {
+                                                                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                          "items": {
+                                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                            "properties": {
+                                                                              "key": {
+                                                                                "description": "key is the label key that the selector applies to.",
+                                                                                "type": "string"
+                                                                              },
+                                                                              "operator": {
+                                                                                "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                                "type": "string"
+                                                                              },
+                                                                              "values": {
+                                                                                "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                                "items": {
+                                                                                  "type": "string"
+                                                                                },
+                                                                                "type": "array"
+                                                                              }
+                                                                            },
+                                                                            "required": [
+                                                                              "key",
+                                                                              "operator"
+                                                                            ],
+                                                                            "type": "object"
+                                                                          },
+                                                                          "type": "array"
+                                                                        },
+                                                                        "matchLabels": {
+                                                                          "additionalProperties": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                          "type": "object"
+                                                                        }
+                                                                      },
+                                                                      "type": "object",
+                                                                      "x-kubernetes-map-type": "atomic"
+                                                                    },
+                                                                    "namespaceSelector": {
+                                                                      "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                                      "properties": {
+                                                                        "matchExpressions": {
+                                                                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                          "items": {
+                                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                            "properties": {
+                                                                              "key": {
+                                                                                "description": "key is the label key that the selector applies to.",
+                                                                                "type": "string"
+                                                                              },
+                                                                              "operator": {
+                                                                                "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                                "type": "string"
+                                                                              },
+                                                                              "values": {
+                                                                                "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                                "items": {
+                                                                                  "type": "string"
+                                                                                },
+                                                                                "type": "array"
+                                                                              }
+                                                                            },
+                                                                            "required": [
+                                                                              "key",
+                                                                              "operator"
+                                                                            ],
+                                                                            "type": "object"
+                                                                          },
+                                                                          "type": "array"
+                                                                        },
+                                                                        "matchLabels": {
+                                                                          "additionalProperties": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                          "type": "object"
+                                                                        }
+                                                                      },
+                                                                      "type": "object",
+                                                                      "x-kubernetes-map-type": "atomic"
+                                                                    },
+                                                                    "namespaces": {
+                                                                      "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                                      "items": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "type": "array"
+                                                                    },
+                                                                    "topologyKey": {
+                                                                      "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "topologyKey"
+                                                                  ],
+                                                                  "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "podAntiAffinity": {
+                                                            "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                                                            "properties": {
+                                                              "preferredDuringSchedulingIgnoredDuringExecution": {
+                                                                "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                                                "items": {
+                                                                  "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                                                  "properties": {
+                                                                    "podAffinityTerm": {
+                                                                      "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                                      "properties": {
+                                                                        "labelSelector": {
+                                                                          "description": "A label query over a set of resources, in this case pods.",
+                                                                          "properties": {
+                                                                            "matchExpressions": {
+                                                                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                              "items": {
+                                                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                                "properties": {
+                                                                                  "key": {
+                                                                                    "description": "key is the label key that the selector applies to.",
+                                                                                    "type": "string"
+                                                                                  },
+                                                                                  "operator": {
+                                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                                    "type": "string"
+                                                                                  },
+                                                                                  "values": {
+                                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                                    "items": {
+                                                                                      "type": "string"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                  }
+                                                                                },
+                                                                                "required": [
+                                                                                  "key",
+                                                                                  "operator"
+                                                                                ],
+                                                                                "type": "object"
+                                                                              },
+                                                                              "type": "array"
+                                                                            },
+                                                                            "matchLabels": {
+                                                                              "additionalProperties": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                              "type": "object"
+                                                                            }
+                                                                          },
+                                                                          "type": "object",
+                                                                          "x-kubernetes-map-type": "atomic"
+                                                                        },
+                                                                        "namespaceSelector": {
+                                                                          "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                                          "properties": {
+                                                                            "matchExpressions": {
+                                                                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                              "items": {
+                                                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                                "properties": {
+                                                                                  "key": {
+                                                                                    "description": "key is the label key that the selector applies to.",
+                                                                                    "type": "string"
+                                                                                  },
+                                                                                  "operator": {
+                                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                                    "type": "string"
+                                                                                  },
+                                                                                  "values": {
+                                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                                    "items": {
+                                                                                      "type": "string"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                  }
+                                                                                },
+                                                                                "required": [
+                                                                                  "key",
+                                                                                  "operator"
+                                                                                ],
+                                                                                "type": "object"
+                                                                              },
+                                                                              "type": "array"
+                                                                            },
+                                                                            "matchLabels": {
+                                                                              "additionalProperties": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                              "type": "object"
+                                                                            }
+                                                                          },
+                                                                          "type": "object",
+                                                                          "x-kubernetes-map-type": "atomic"
+                                                                        },
+                                                                        "namespaces": {
+                                                                          "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        },
+                                                                        "topologyKey": {
+                                                                          "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                                          "type": "string"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "topologyKey"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "weight": {
+                                                                      "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                                                      "format": "int32",
+                                                                      "type": "integer"
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "podAffinityTerm",
+                                                                    "weight"
+                                                                  ],
+                                                                  "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                                "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                                                "items": {
+                                                                  "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \u003ctopologyKey\u003e matches that of any node on which a pod of the set of pods is running",
+                                                                  "properties": {
+                                                                    "labelSelector": {
+                                                                      "description": "A label query over a set of resources, in this case pods.",
+                                                                      "properties": {
+                                                                        "matchExpressions": {
+                                                                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                          "items": {
+                                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                            "properties": {
+                                                                              "key": {
+                                                                                "description": "key is the label key that the selector applies to.",
+                                                                                "type": "string"
+                                                                              },
+                                                                              "operator": {
+                                                                                "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                                "type": "string"
+                                                                              },
+                                                                              "values": {
+                                                                                "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                                "items": {
+                                                                                  "type": "string"
+                                                                                },
+                                                                                "type": "array"
+                                                                              }
+                                                                            },
+                                                                            "required": [
+                                                                              "key",
+                                                                              "operator"
+                                                                            ],
+                                                                            "type": "object"
+                                                                          },
+                                                                          "type": "array"
+                                                                        },
+                                                                        "matchLabels": {
+                                                                          "additionalProperties": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                          "type": "object"
+                                                                        }
+                                                                      },
+                                                                      "type": "object",
+                                                                      "x-kubernetes-map-type": "atomic"
+                                                                    },
+                                                                    "namespaceSelector": {
+                                                                      "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                                      "properties": {
+                                                                        "matchExpressions": {
+                                                                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                          "items": {
+                                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                            "properties": {
+                                                                              "key": {
+                                                                                "description": "key is the label key that the selector applies to.",
+                                                                                "type": "string"
+                                                                              },
+                                                                              "operator": {
+                                                                                "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                                "type": "string"
+                                                                              },
+                                                                              "values": {
+                                                                                "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                                "items": {
+                                                                                  "type": "string"
+                                                                                },
+                                                                                "type": "array"
+                                                                              }
+                                                                            },
+                                                                            "required": [
+                                                                              "key",
+                                                                              "operator"
+                                                                            ],
+                                                                            "type": "object"
+                                                                          },
+                                                                          "type": "array"
+                                                                        },
+                                                                        "matchLabels": {
+                                                                          "additionalProperties": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                          "type": "object"
+                                                                        }
+                                                                      },
+                                                                      "type": "object",
+                                                                      "x-kubernetes-map-type": "atomic"
+                                                                    },
+                                                                    "namespaces": {
+                                                                      "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                                      "items": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "type": "array"
+                                                                    },
+                                                                    "topologyKey": {
+                                                                      "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "topologyKey"
+                                                                  ],
+                                                                  "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      "nodeSelector": {
+                                                        "additionalProperties": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+                                                        "type": "object"
+                                                      },
+                                                      "priorityClassName": {
+                                                        "description": "If specified, the pod's priorityClassName.",
+                                                        "type": "string"
+                                                      },
+                                                      "serviceAccountName": {
+                                                        "description": "If specified, the pod's service account",
+                                                        "type": "string"
+                                                      },
+                                                      "tolerations": {
+                                                        "description": "If specified, the pod's tolerations.",
+                                                        "items": {
+                                                          "description": "The pod this Toleration is attached to tolerates any taint that matches the triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
+                                                          "properties": {
+                                                            "effect": {
+                                                              "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                                              "type": "string"
+                                                            },
+                                                            "key": {
+                                                              "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                                              "type": "string"
+                                                            },
+                                                            "operator": {
+                                                              "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                                              "type": "string"
+                                                            },
+                                                            "tolerationSeconds": {
+                                                              "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                                              "format": "int64",
+                                                              "type": "integer"
+                                                            },
+                                                            "value": {
+                                                              "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "serviceType": {
+                                                "description": "Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "selector": {
+                                        "description": "Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.",
+                                        "properties": {
+                                          "dnsNames": {
+                                            "description": "List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "dnsZones": {
+                                            "description": "List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "A label selector that is used to refine the set of certificate's that this challenge solver will apply to.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "privateKeySecretRef",
+                                "server"
+                              ],
+                              "type": "object"
+                            },
+                            "annotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Annotations to set on the created issuer. More info: http://kubernetes.io/docs/user-guide/annotations",
+                              "type": "object"
+                            },
+                            "ca": {
+                              "description": "CA configures this issuer to sign certificates using a signing CA keypair stored in a Secret resource. This is used to build internal PKIs that are managed by cert-manager. https://cert-manager.io/docs/configuration/ca/",
+                              "properties": {
+                                "crlDistributionPoints": {
+                                  "description": "The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set, certificates will be issued without distribution points set.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "ocspServers": {
+                                  "description": "The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be \"http://ocsp.int-x3.letsencrypt.org\".",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "secretName": {
+                                  "description": "SecretName is the name of the secret used to sign Certificates issued by this Issuer.",
+                                  "type": "string"
+                                },
+                                "selfSignedCA": {
+                                  "description": "SelfSignedCA can be used to bootstrap the CA issuer with a CA cert issued by self-signed issuer. If this field is set, the operator will create a self-signed issuer and use that to issue a self-signed CA cert which will be stored in SecretName secret.",
+                                  "properties": {
+                                    "commonName": {
+                                      "description": "CommonName is a common name to be used on the Certificate. The CommonName should have a length of 64 characters or fewer to avoid generating invalid CSRs.",
+                                      "type": "string"
+                                    },
+                                    "subject": {
+                                      "description": "Full X509 name specification (https://golang.org/pkg/crypto/x509/pkix/#Name).",
+                                      "properties": {
+                                        "countries": {
+                                          "description": "Countries to be used on the Certificate.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "localities": {
+                                          "description": "Cities to be used on the Certificate.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "organizationalUnits": {
+                                          "description": "Organizational Units to be used on the Certificate.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "organizations": {
+                                          "description": "Organizations to be used on the Certificate.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "postalCodes": {
+                                          "description": "Postal codes to be used on the Certificate.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "provinces": {
+                                          "description": "State/Provinces to be used on the Certificate.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "serialNumber": {
+                                          "description": "Serial number to be used on the Certificate.",
+                                          "type": "string"
+                                        },
+                                        "streetAddresses": {
+                                          "description": "Street addresses to be used on the Certificate.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "required": [
+                                "secretName"
+                              ],
+                              "type": "object"
+                            },
+                            "clusterScope": {
+                              "description": "Whether a cluster-scoped resource should be created. In case of core cert-manager.io issuers setting this to true will result to a ClusterIssuer being created, setting this to false will result in an Issuer being created. (Default value is false).",
+                              "type": "boolean"
+                            },
+                            "labels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Labels to set on the created issuer. More info: http://kubernetes.io/docs/user-guide/labels",
+                              "type": "object"
+                            },
+                            "name": {
+                              "description": "Name is the name of the Issuer.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace for an Issuer. Cannot be set if ClusterScope is set to true. Namespace needs to already exist. Defaults to default namespace.",
+                              "type": "string"
+                            },
+                            "policy": {
+                              "description": "Policy is the configuration of the for this CertificateRequestPolicy for issuer. Currently a default 'allow-all' policy will be configured for each issuer that does not have a custom policy configured. https://github.com/cert-manager/approver-policy/tree/main",
+                              "properties": {
+                                "allowAll": {
+                                  "description": "AllowAll configures whether an allow-all policy should be created for an issuer.",
+                                  "type": "boolean"
+                                },
+                                "allowed": {
+                                  "description": "Allowed is the set of attributes that are \"allowed\" by this policy. A CertificateRequest will only be considered permissible for this policy if the CertificateRequest has the same or less as what is allowed.  Empty or `nil` allowed fields mean CertificateRequests are not allowed to have that field present to be permissible. This field corresponds to the Allowed block in CertificateRequestPolicy API https://github.com/cert-manager/approver-policy#allowed Only one of Allowed, AllowAll can be set.",
+                                  "properties": {
+                                    "commonName": {
+                                      "description": "CommonName defines the X.509 Common Name that is permissible.",
+                                      "properties": {
+                                        "required": {
+                                          "description": "Required marks this field as being a required value on the request. May only be set to true if Value is also defined.",
+                                          "type": "boolean"
+                                        },
+                                        "value": {
+                                          "description": "Value defines the value that is permissible to be present on the request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids the value from being requested. An empty string is equivalent to `nil`, however an empty string pared with Required as `true` is an impossible condition that always denies. Value may not be `nil` if Required is `true`.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "dnsNames": {
+                                      "description": "DNSNames defines the X.509 DNS SANs that may be requested for. Accepts wildcards \"*\".",
+                                      "properties": {
+                                        "required": {
+                                          "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                          "type": "boolean"
+                                        },
+                                        "values": {
+                                          "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "emailAddresses": {
+                                      "description": "EmailAddresses defines the X.509 Email SANs that may be requested for.",
+                                      "properties": {
+                                        "required": {
+                                          "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                          "type": "boolean"
+                                        },
+                                        "values": {
+                                          "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "ipAddresses": {
+                                      "description": "IPAddresses defines the X.509 IP SANs that may be requested for.",
+                                      "properties": {
+                                        "required": {
+                                          "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                          "type": "boolean"
+                                        },
+                                        "values": {
+                                          "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "isCA": {
+                                      "description": "IsCA defines whether it is permissible for a CertificateRequest to have the `spec.IsCA` field set to `true`. An omitted field, value of `nil` or `false`, forbids the `spec.IsCA` field from bring `true`. A value of `true` permits CertificateRequests setting the `spec.IsCA` field to `true`.",
+                                      "type": "boolean"
+                                    },
+                                    "subject": {
+                                      "description": "Subject defines the X.509 subject that is permissible. An omitted field or value of `nil` forbids any Subject being requested.",
+                                      "properties": {
+                                        "countries": {
+                                          "description": "Countries define the X.509 Subject Countries that may be requested for.",
+                                          "properties": {
+                                            "required": {
+                                              "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                              "type": "boolean"
+                                            },
+                                            "values": {
+                                              "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "localities": {
+                                          "description": "Localities defines the X.509 Subject Localities that may be requested for.",
+                                          "properties": {
+                                            "required": {
+                                              "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                              "type": "boolean"
+                                            },
+                                            "values": {
+                                              "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "organizationalUnits": {
+                                          "description": "OrganizationalUnits defines the X.509 Subject Organizational Units that may be requested for.",
+                                          "properties": {
+                                            "required": {
+                                              "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                              "type": "boolean"
+                                            },
+                                            "values": {
+                                              "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "organizations": {
+                                          "description": "Organizations define the X.509 Subject Organizations that may be requested for.",
+                                          "properties": {
+                                            "required": {
+                                              "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                              "type": "boolean"
+                                            },
+                                            "values": {
+                                              "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "postalCodes": {
+                                          "description": "PostalCodes defines the X.509 Subject Postal Codes that may be requested for.",
+                                          "properties": {
+                                            "required": {
+                                              "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                              "type": "boolean"
+                                            },
+                                            "values": {
+                                              "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "provinces": {
+                                          "description": "Provinces defines the X.509 Subject Provinces that may be requested for.",
+                                          "properties": {
+                                            "required": {
+                                              "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                              "type": "boolean"
+                                            },
+                                            "values": {
+                                              "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "serialNumber": {
+                                          "description": "SerialNumber defines the X.509 Subject Serial Number that may be requested for.",
+                                          "properties": {
+                                            "required": {
+                                              "description": "Required marks this field as being a required value on the request. May only be set to true if Value is also defined.",
+                                              "type": "boolean"
+                                            },
+                                            "value": {
+                                              "description": "Value defines the value that is permissible to be present on the request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids the value from being requested. An empty string is equivalent to `nil`, however an empty string pared with Required as `true` is an impossible condition that always denies. Value may not be `nil` if Required is `true`.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "streetAddresses": {
+                                          "description": "StreetAddresses defines the X.509 Subject Street Addresses that may be requested for.",
+                                          "properties": {
+                                            "required": {
+                                              "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                              "type": "boolean"
+                                            },
+                                            "values": {
+                                              "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "uris": {
+                                      "description": "URIs defines the X.509 URI SANs that may be requested for.",
+                                      "properties": {
+                                        "required": {
+                                          "description": "Required marks this field as being a required value on the request. May only be set to true if Values is also defined. Default is nil which marks the field as not required.",
+                                          "type": "boolean"
+                                        },
+                                        "values": {
+                                          "description": "Defines the values that are permissible to be present on request. Accepts wildcards \"*\". An omitted field or value of `nil` forbids any value on the related field in the request from being requested. An empty slice `[]` is equivalent to `nil`, however an empty slice pared with Required `true` is an impossible condition that always denies. Values may not be `nil` if Required is `true`.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "usages": {
+                                      "description": "Usages defines the list of permissible key usages that may appear on the CertificateRequest `spec.keyUsages` field. An omitted field or value of `nil` forbids any Usages being requested. An empty slice `[]` is equivalent to `nil`.",
+                                      "items": {
+                                        "description": "KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12 Valid KeyUsage values are as follows: \"signing\", \"digital signature\", \"content commitment\", \"key encipherment\", \"key agreement\", \"data encipherment\", \"cert sign\", \"crl sign\", \"encipher only\", \"decipher only\", \"any\", \"server auth\", \"client auth\", \"code signing\", \"email protection\", \"s/mime\", \"ipsec end system\", \"ipsec tunnel\", \"ipsec user\", \"timestamping\", \"ocsp signing\", \"microsoft sgc\", \"netscape sgc\"",
+                                        "enum": [
+                                          "signing",
+                                          "digital signature",
+                                          "content commitment",
+                                          "key encipherment",
+                                          "key agreement",
+                                          "data encipherment",
+                                          "cert sign",
+                                          "crl sign",
+                                          "encipher only",
+                                          "decipher only",
+                                          "any",
+                                          "server auth",
+                                          "client auth",
+                                          "code signing",
+                                          "email protection",
+                                          "s/mime",
+                                          "ipsec end system",
+                                          "ipsec tunnel",
+                                          "ipsec user",
+                                          "timestamping",
+                                          "ocsp signing",
+                                          "microsoft sgc",
+                                          "netscape sgc"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "constraints": {
+                                  "description": "Constraints is the set of attributes that _must_ be satisfied by the CertificateRequest for the request to be permissible by the policy. Empty or `nil` constraint fields mean CertificateRequests satisfy that field with any value of their corresponding attribute. This field corresponds to the Constraints block in CertificateRequestPolicyAPI https://github.com/cert-manager/approver-policy#constraints Only one of Constraints, AllowAll can be set.",
+                                  "properties": {
+                                    "maxDuration": {
+                                      "description": "MaxDuration defines the maximum duration a certificate may be requested for. Values are inclusive (i.e. a max value of `1h` will accept a duration of `1h`). MaxDuration and MinDuration may be the same value. An omitted field or value of `nil` permits any maximum duration. If MaxDuration is defined, a duration _must_ be requested on the CertificateRequest.",
+                                      "type": "string"
+                                    },
+                                    "minDuration": {
+                                      "description": "MinDuration defines the minimum duration a certificate may be requested for. Values are inclusive (i.e. a min value of `1h` will accept a duration of `1h`). MinDuration and MaxDuration may be the same value. An omitted field or value of `nil` permits any minimum duration. If MinDuration is defined, a duration _must_ be requested on the CertificateRequest.",
+                                      "type": "string"
+                                    },
+                                    "privateKey": {
+                                      "description": "PrivateKey defines the shape of permissible private keys that may be used for the request with this policy. An omitted field or value of `nil` permits the use of any private key by the requestor.",
+                                      "properties": {
+                                        "algorithm": {
+                                          "description": "Algorithm defines the allowed crypto algorithm that is used by the requestor for their private key in their request. An omitted field or value of `nil` permits any Algorithm.",
+                                          "enum": [
+                                            "RSA",
+                                            "ECDSA",
+                                            "Ed25519"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "maxSize": {
+                                          "description": "MaxSize defines the maximum key size a requestor may use for their private key. Values are inclusive (i.e. a min value of `2048` will accept a size of `2048`). MaxSize and MinSize may be the same value. An omitted field or value of `nil` permits any maximum size.",
+                                          "type": "integer"
+                                        },
+                                        "minSize": {
+                                          "description": "MinSize defines the minimum key size a requestor may use for their private key. Values are inclusive (i.e. a min value of `2048` will accept a size of `2048`). MinSize and MaxSize may be the same value. An omitted field or value of `nil` permits any minimum size.",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "plugins": {
+                                  "description": "Plugins defines additional, optional plugins to use with this policy.",
+                                  "properties": {
+                                    "tpp": {
+                                      "description": "TPP plugin is used to pull a policy defined in a zone in TPP server and use that to evaluate a CertificateRequest. This plugin is bundled with the approver-policy-enterprise only, so you must make sure that you have set approverPolicyEnterprise field on Installation spec.",
+                                      "properties": {
+                                        "caConfigMapRef": {
+                                          "description": "CAConfigMapRef is a reference to a key in a ConfigMap that holds the CA bundle to be used to when connecting to the TPP instance. If unset, system's CA pool will be used. The ConfigMap must be in jetstack-secure namespace.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is a key in a configmap",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name is the name of a configmap",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "credentialsSecretRef": {
+                                          "description": "CredentialsSecretRef is a reference to a key in a Secret that contains access-token to authenticate to the TPP server. The Secret must be in jetstack-secure namespace.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is a key in a Secret",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name is the name of a Secret",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "url": {
+                                          "description": "URL is the URL of the TPP server.",
+                                          "type": "string"
+                                        },
+                                        "zone": {
+                                          "description": "Zone is the zone (or policy folder) from which the policy should be retrieved.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "credentialsSecretRef",
+                                        "url",
+                                        "zone"
+                                      ],
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "subjects": {
+                                  "description": "Subjects is the configuration of which entities are allowed to use the CertificateRequestPolicy. At least one subject must be set if a policy is configured. AllowAll cannot be set at the same time as Allowed and Constraints.",
+                                  "properties": {
+                                    "certManager": {
+                                      "description": "CertManager allows to configure whether the service account of cert-manager's controller is allowed to use this CertificateRequestPolicy. Must be true for any issuer that will be referenced in Certificate resources as the entity creating CertificateRequests for Certificates is always cert-manager's controller. Setting this field to true will result in a ClusterRole and ClusterRoleBinding being created that will bind CertificateRequestPolicy to the cert-manager controller's service account.",
+                                      "type": "boolean"
+                                    },
+                                    "certManagerCSI": {
+                                      "description": "CertManagerCSI allows to configure whether the service account of cert-manager/csi-driver's(configured via Installation.spec.csiDrivers.certManager) Daemonset is allowed to use this CertificateRequestPolicy. Must be true if this issuer is going to be used to request certificates from cert-manager/csi-driver. Setting this field to true will result in a ClusterRole and ClusterRoleBinding being created that will bind CertificateRequestPolicy to the cert-manager csi-driver's service account.",
+                                      "type": "boolean"
+                                    },
+                                    "istioCSR": {
+                                      "description": "IstioCSR allows to configure whether the service account of istio-csr is allowed to use this CertificateRequestPolicy. Must be true if this issuer is going to be used with istio-csr. Setting this field to true will result in a ClusterRole and ClusterRoleBinding being created that will bind CertificateRequestPolicy to the istio-csr's service account.",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "selfSigned": {
+                              "description": "SelfSigned configures this issuer to 'self sign' certificates using the private key used to create the CertificateRequest object. https://cert-manager.io/docs/configuration/selfsigned/",
+                              "properties": {
+                                "crlDistributionPoints": {
+                                  "description": "The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set certificate will be issued without CDP. Values are strings.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "vault": {
+                              "description": "Vault configures this issuer to sign certificates using a HashiCorp Vault PKI backend. https://cert-manager.io/docs/configuration/vault/",
+                              "properties": {
+                                "auth": {
+                                  "description": "Auth configures how cert-manager authenticates with the Vault server.",
+                                  "properties": {
+                                    "appRole": {
+                                      "description": "AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.",
+                                      "properties": {
+                                        "path": {
+                                          "description": "Path where the App Role authentication backend is mounted in Vault, e.g: \"approle\"",
+                                          "type": "string"
+                                        },
+                                        "roleId": {
+                                          "description": "RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.",
+                                          "type": "string"
+                                        },
+                                        "secretRef": {
+                                          "description": "Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [
+                                        "path",
+                                        "roleId",
+                                        "secretRef"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "kubernetes": {
+                                      "description": "Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.",
+                                      "properties": {
+                                        "mountPath": {
+                                          "description": "The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value \"/v1/auth/kubernetes\" will be used.",
+                                          "type": "string"
+                                        },
+                                        "role": {
+                                          "description": "A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.",
+                                          "type": "string"
+                                        },
+                                        "secretRef": {
+                                          "description": "The required Secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. Use of 'ambient credentials' is not supported.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [
+                                        "role",
+                                        "secretRef"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "tokenSecretRef": {
+                                      "description": "TokenSecretRef authenticates with Vault by presenting a token.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "caBundle": {
+                                  "description": "PEM-encoded CA bundle (base64-encoded) used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.",
+                                  "format": "byte",
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "description": "Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: \"ns1\" More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces",
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "description": "Path is the mount path of the Vault PKI backend's `sign` endpoint, e.g: \"my_pki_mount/sign/my-role-name\".",
+                                  "type": "string"
+                                },
+                                "server": {
+                                  "description": "Server is the connection address for the Vault server, e.g: \"https://vault.example.com:8200\".",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "auth",
+                                "path",
+                                "server"
+                              ],
+                              "type": "object"
+                            },
+                            "venafi": {
+                              "description": "Venafi configures this issuer to sign certificates using a Venafi TPP or Venafi Cloud policy zone. https://cert-manager.io/docs/configuration/venafi/",
+                              "properties": {
+                                "cloud": {
+                                  "description": "Cloud specifies the Venafi cloud configuration settings. Only one of TPP or Cloud may be specified.",
+                                  "properties": {
+                                    "apiTokenSecretRef": {
+                                      "description": "APITokenSecretRef is a secret key selector for the Venafi Cloud API token.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "url": {
+                                      "description": "URL is the base URL for Venafi Cloud. Defaults to \"https://api.venafi.cloud/v1\".",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "apiTokenSecretRef"
+                                  ],
+                                  "type": "object"
+                                },
+                                "tpp": {
+                                  "description": "TPP specifies Trust Protection Platform configuration settings. Only one of TPP or Cloud may be specified.",
+                                  "properties": {
+                                    "caBundle": {
+                                      "description": "CABundle is a PEM encoded TLS certificate to use to verify connections to the TPP instance. If specified, system roots will not be used and the issuing CA for the TPP instance must be verifiable using the provided root. If not specified, the connection will be verified using the cert-manager system root certificates.",
+                                      "format": "byte",
+                                      "type": "string"
+                                    },
+                                    "credentialsRef": {
+                                      "description": "CredentialsRef is a reference to a Secret containing the username and password for the TPP server. The secret must contain two keys, 'username' and 'password'.",
+                                      "properties": {
+                                        "name": {
+                                          "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "url": {
+                                      "description": "URL is the base URL for the vedsdk endpoint of the Venafi TPP instance, for example: \"https://tpp.example.com/vedsdk\".",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "credentialsRef",
+                                    "url"
+                                  ],
+                                  "type": "object"
+                                },
+                                "zone": {
+                                  "description": "Zone is the Venafi Policy Zone to use for this issuer. All requests made to the Venafi platform will be restricted by the named zone policy. This field is required.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "zone"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "istioCSR": {
+                        "description": "IstioCSR contains configuration for istio-csr https://platform.jetstack.io/documentation/installation/istio-csr",
+                        "properties": {
+                          "issuerRef": {
+                            "description": "IssuerRef is a reference to the issuer that will be used to issue certs for istiod and workloads. This must correspond to an issuer configured in Installation.spec.issuers and must be either a cluster-scoped issuer or be in IstioNamespace. Defaults to a cert-manager.io Issuer named istio-ca.",
+                            "properties": {
+                              "group": {
+                                "description": "Group of the resource being referred to.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind of the resource being referred to.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the resource being referred to.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "istioNamespace": {
+                            "description": "The namespace in which Istio will be deployed. The namespace is used to pre-create istiod's serving certificate, verify the Issuer configured for istio-csr and configure istio-csr itself. Defaults to istio-system.",
+                            "type": "string"
+                          },
+                          "replicas": {
+                            "description": "ReplicaCount is the number of instances to run, default 2",
+                            "type": "integer"
+                          },
+                          "version": {
+                            "description": "Version is the version of istio-csr to install https://github.com/cert-manager/istio-csr/releases Default: v0.5.0 Supported Versions: v0.5.0, v0.4.0, v0.3.0, v0.2.1",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "registry": {
+                        "description": "Registry allows to configure a custom registry for all images for components managed by the operator. It is user's responsibility to ensure that the images exist in the registry.",
+                        "type": "string"
+                      },
+                      "venafiOauthHelper": {
+                        "description": "VenafiOauthHelper contains configuration options for the Installation's venafi-oauth-helper's installation if required. If unset (default) venafi-oauth-helper will not be installed. Set this field to an empty object to install venafi-oauth-helper with default options. See https://platform.jetstack.io/documentation/reference/venafi-oauth-helper/configuration to learn more about venafi-oauth-helper.",
+                        "properties": {
+                          "imagePullSecrets": {
+                            "description": "An optional list of image pull secrets to be passed to the venafi-oauth-helper Pod. These need to be created in jetstack-secure namespace where venafi-oauth-helper will be deployed.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "replicas": {
+                            "description": "ReplicaCount is the number of venafi-oauth-helper instances to run. Defaults to 2 instances.",
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "version": {
+                            "description": "Version is the version of venafi-oauth-helper to install https://github.com/jetstack/venafi-oauth-helper/releases Default: v0.3.0 Supported Versions: v0.3.0",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "certManager"
+                    ],
+                    "type": "object"
+                  },
+                  "status": {
+                    "description": "InstallationStatus defines the observed state of Installation",
+                    "properties": {
+                      "conditions": {
+                        "items": {
+                          "description": "InstallationCondition represents the structure of a 'Condition' item in the InstallationStatus",
+                          "properties": {
+                            "lastTransitionTime": {
+                              "description": "LastTransitionTime is the last time this condition transitioned from one state to another.",
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "message": {
+                              "description": "Message is a longer, human readable explanation for the condition's last transition.",
+                              "type": "string"
+                            },
+                            "observedGeneration": {
+                              "description": "ObservedGeneration is the value of .metadata.generation at the time this condition was set. This provides a way to track whether the condition is up to date in regards to the current spec. https://github.com/kubernetes/kubernetes/blob/59fdc02b13ec1412d7f4ad078c91050516024a79/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy.go#L82-L89",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "reason": {
+                              "description": "Reason is a brief, machine readable explanation for the condition's last transition.",
+                              "type": "string"
+                            },
+                            "status": {
+                              "description": "Status of the condition (`True`, `False` or `Unknown`).",
+                              "type": "string"
+                            },
+                            "type": {
+                              "description": "Type of condition. Known values are (`Ready`)",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "status",
+                            "type"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "served": true,
+            "storage": true,
+            "subresources": {
+              "status": {}
+            }
+          }
+        ]
+      },
+      "status": {
+        "acceptedNames": {
+          "kind": "Installation",
+          "listKind": "InstallationList",
+          "plural": "installations",
+          "singular": "installation"
+        },
+        "conditions": [
+          {
+            "lastTransitionTime": "2022-11-03T14:10:32Z",
+            "message": "no conflicts found",
+            "reason": "NoConflicts",
+            "status": "True",
+            "type": "NamesAccepted"
+          },
+          {
+            "lastTransitionTime": "2022-11-03T14:10:32Z",
+            "message": "the initial names have been accepted",
+            "reason": "InitialNamesAccepted",
+            "status": "True",
+            "type": "Established"
+          }
+        ],
+        "storedVersions": [
+          "v1alpha1"
+        ]
+      }
+    },
+    {
+      "apiVersion": "apiextensions.k8s.io/v1",
+      "kind": "CustomResourceDefinition",
+      "metadata": {
+        "annotations": {
+          "operator.jetstack.io/component": "cert-manager",
+          "operator.jetstack.io/component-version": "v1.9.1"
+        },
+        "creationTimestamp": "2022-11-03T14:15:19Z",
+        "finalizers": [
+          "operator.jetstack.io/crd-controller"
+        ],
+        "generation": 1,
+        "labels": {
+          "app": "cert-manager",
+          "app.kubernetes.io/instance": "cert-manager",
+          "app.kubernetes.io/name": "cert-manager",
+          "app.kubernetes.io/version": "v1.9.1"
+        },
+        "name": "issuers.cert-manager.io",
+        "ownerReferences": [
+          {
+            "apiVersion": "operator.jetstack.io/v1alpha1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Installation",
+            "name": "installation",
+            "uid": "648c8b6d-3c85-4faa-9497-1eedc3873baf"
+          }
+        ],
+        "resourceVersion": "71274",
+        "uid": "1cb6e33c-c5db-4719-8ee8-536d4fe394fd"
+      },
+      "spec": {
+        "conversion": {
+          "strategy": "None"
+        },
+        "group": "cert-manager.io",
+        "names": {
+          "categories": [
+            "cert-manager"
+          ],
+          "kind": "Issuer",
+          "listKind": "IssuerList",
+          "plural": "issuers",
+          "singular": "issuer"
+        },
+        "scope": "Namespaced",
+        "versions": [
+          {
+            "additionalPrinterColumns": [
+              {
+                "jsonPath": ".status.conditions[?(@.type==\"Ready\")].status",
+                "name": "Ready",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".status.conditions[?(@.type==\"Ready\")].message",
+                "name": "Status",
+                "priority": 1,
+                "type": "string"
+              },
+              {
+                "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.",
+                "jsonPath": ".metadata.creationTimestamp",
+                "name": "Age",
+                "type": "date"
+              }
+            ],
+            "name": "v1",
+            "schema": {
+              "openAPIV3Schema": {
+                "description": "An Issuer represents a certificate issuing authority which can be referenced as part of `issuerRef` fields. It is scoped to a single namespace and can therefore only be referenced by resources within the same namespace.",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "type": "object"
+                  },
+                  "spec": {
+                    "description": "Desired state of the Issuer resource.",
+                    "properties": {
+                      "acme": {
+                        "description": "ACME configures this issuer to communicate with a RFC8555 (ACME) server to obtain signed x509 certificates.",
+                        "properties": {
+                          "disableAccountKeyGeneration": {
+                            "description": "Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.",
+                            "type": "boolean"
+                          },
+                          "email": {
+                            "description": "Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.",
+                            "type": "string"
+                          },
+                          "enableDurationFeature": {
+                            "description": "Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.",
+                            "type": "boolean"
+                          },
+                          "externalAccountBinding": {
+                            "description": "ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.",
+                            "properties": {
+                              "keyAlgorithm": {
+                                "description": "Deprecated: keyAlgorithm field exists for historical compatibility reasons and should not be used. The algorithm is now hardcoded to HS256 in golang/x/crypto/acme.",
+                                "enum": [
+                                  "HS256",
+                                  "HS384",
+                                  "HS512"
+                                ],
+                                "type": "string"
+                              },
+                              "keyID": {
+                                "description": "keyID is the ID of the CA key that the External Account is bound to.",
+                                "type": "string"
+                              },
+                              "keySecretRef": {
+                                "description": "keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes Secret which holds the symmetric MAC key of the External Account Binding. The `key` is the index string that is paired with the key data in the Secret and should not be confused with the key data itself, or indeed with the External Account Binding keyID above. The secret key stored in the Secret **must** be un-padded, base64 URL encoded data.",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "required": [
+                              "keyID",
+                              "keySecretRef"
+                            ],
+                            "type": "object"
+                          },
+                          "preferredChain": {
+                            "description": "PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let's Encrypt's DST crosssign you would use: \"DST Root CA X3\" or \"ISRG Root X1\" for the newer Let's Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer's CN",
+                            "maxLength": 64,
+                            "type": "string"
+                          },
+                          "privateKeySecretRef": {
+                            "description": "PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "server": {
+                            "description": "Server is the URL used to access the ACME server's 'directory' endpoint. For example, for Let's Encrypt's staging endpoint, you would use: \"https://acme-staging-v02.api.letsencrypt.org/directory\". Only ACME v2 endpoints (i.e. RFC 8555) are supported.",
+                            "type": "string"
+                          },
+                          "skipTLSVerify": {
+                            "description": "Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have their TLS certificate validated (i.e. insecure connections will be allowed). Only enable this option in development environments. The cert-manager system installed roots will be used to verify connections to the ACME server if this is false. Defaults to false.",
+                            "type": "boolean"
+                          },
+                          "solvers": {
+                            "description": "Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/",
+                            "items": {
+                              "description": "An ACMEChallengeSolver describes how to solve ACME challenges for the issuer it is part of. A selector may be provided to use different solving strategies for different DNS names. Only one of HTTP01 or DNS01 must be provided.",
+                              "properties": {
+                                "dns01": {
+                                  "description": "Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.",
+                                  "properties": {
+                                    "acmeDNS": {
+                                      "description": "Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "accountSecretRef": {
+                                          "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "host": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "accountSecretRef",
+                                        "host"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "akamai": {
+                                      "description": "Use the Akamai DNS zone management API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "accessTokenSecretRef": {
+                                          "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "clientSecretSecretRef": {
+                                          "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "clientTokenSecretRef": {
+                                          "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "serviceConsumerDomain": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "accessTokenSecretRef",
+                                        "clientSecretSecretRef",
+                                        "clientTokenSecretRef",
+                                        "serviceConsumerDomain"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "azureDNS": {
+                                      "description": "Use the Microsoft Azure DNS API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "clientID": {
+                                          "description": "if both this and ClientSecret are left unset MSI will be used",
+                                          "type": "string"
+                                        },
+                                        "clientSecretSecretRef": {
+                                          "description": "if both this and ClientID are left unset MSI will be used",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "environment": {
+                                          "description": "name of the Azure environment (default AzurePublicCloud)",
+                                          "enum": [
+                                            "AzurePublicCloud",
+                                            "AzureChinaCloud",
+                                            "AzureGermanCloud",
+                                            "AzureUSGovernmentCloud"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "hostedZoneName": {
+                                          "description": "name of the DNS zone that should be used",
+                                          "type": "string"
+                                        },
+                                        "managedIdentity": {
+                                          "description": "managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID",
+                                          "properties": {
+                                            "clientID": {
+                                              "description": "client ID of the managed identity, can not be used at the same time as resourceID",
+                                              "type": "string"
+                                            },
+                                            "resourceID": {
+                                              "description": "resource ID of the managed identity, can not be used at the same time as clientID",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "resourceGroupName": {
+                                          "description": "resource group the DNS zone is located in",
+                                          "type": "string"
+                                        },
+                                        "subscriptionID": {
+                                          "description": "ID of the Azure subscription",
+                                          "type": "string"
+                                        },
+                                        "tenantID": {
+                                          "description": "when specifying ClientID and ClientSecret then this field is also needed",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "resourceGroupName",
+                                        "subscriptionID"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "cloudDNS": {
+                                      "description": "Use the Google Cloud DNS API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "hostedZoneName": {
+                                          "description": "HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.",
+                                          "type": "string"
+                                        },
+                                        "project": {
+                                          "type": "string"
+                                        },
+                                        "serviceAccountSecretRef": {
+                                          "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [
+                                        "project"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "cloudflare": {
+                                      "description": "Use the Cloudflare API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "apiKeySecretRef": {
+                                          "description": "API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "apiTokenSecretRef": {
+                                          "description": "API token used to authenticate with Cloudflare.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "email": {
+                                          "description": "Email of the account, only required when using API key based authentication.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "cnameStrategy": {
+                                      "description": "CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.",
+                                      "enum": [
+                                        "None",
+                                        "Follow"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "digitalocean": {
+                                      "description": "Use the DigitalOcean DNS API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "tokenSecretRef": {
+                                          "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [
+                                        "tokenSecretRef"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "rfc2136": {
+                                      "description": "Use RFC2136 (\"Dynamic Updates in the Domain Name System\") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "nameserver": {
+                                          "description": "The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.",
+                                          "type": "string"
+                                        },
+                                        "tsigAlgorithm": {
+                                          "description": "The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.",
+                                          "type": "string"
+                                        },
+                                        "tsigKeyName": {
+                                          "description": "The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.",
+                                          "type": "string"
+                                        },
+                                        "tsigSecretSecretRef": {
+                                          "description": "The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [
+                                        "nameserver"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "route53": {
+                                      "description": "Use the AWS Route53 API to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "accessKeyID": {
+                                          "description": "The AccessKeyID is used for authentication. Cannot be set when SecretAccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                                          "type": "string"
+                                        },
+                                        "accessKeyIDSecretRef": {
+                                          "description": "The SecretAccessKey is used for authentication. If set, pull the AWS access key ID from a key within a Kubernetes Secret. Cannot be set when AccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "hostedZoneID": {
+                                          "description": "If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.",
+                                          "type": "string"
+                                        },
+                                        "region": {
+                                          "description": "Always set the region when using AccessKeyID and SecretAccessKey",
+                                          "type": "string"
+                                        },
+                                        "role": {
+                                          "description": "Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata",
+                                          "type": "string"
+                                        },
+                                        "secretAccessKeySecretRef": {
+                                          "description": "The SecretAccessKey is used for authentication. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                                          "properties": {
+                                            "key": {
+                                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [
+                                        "region"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "webhook": {
+                                      "description": "Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.",
+                                      "properties": {
+                                        "config": {
+                                          "description": "Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.",
+                                          "x-kubernetes-preserve-unknown-fields": true
+                                        },
+                                        "groupName": {
+                                          "description": "The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.",
+                                          "type": "string"
+                                        },
+                                        "solverName": {
+                                          "description": "The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "groupName",
+                                        "solverName"
+                                      ],
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "http01": {
+                                  "description": "Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.",
+                                  "properties": {
+                                    "gatewayHTTPRoute": {
+                                      "description": "The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.",
+                                      "properties": {
+                                        "labels": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "description": "Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.",
+                                          "type": "object"
+                                        },
+                                        "parentRefs": {
+                                          "description": "When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways",
+                                          "items": {
+                                            "description": "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object.",
+                                            "properties": {
+                                              "group": {
+                                                "default": "gateway.networking.k8s.io",
+                                                "description": "Group is the group of the referent. \n Support: Core",
+                                                "maxLength": 253,
+                                                "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "default": "Gateway",
+                                                "description": "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)",
+                                                "maxLength": 63,
+                                                "minLength": 1,
+                                                "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "Name is the name of the referent. \n Support: Core",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "description": "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core",
+                                                "maxLength": 63,
+                                                "minLength": 1,
+                                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                                "type": "string"
+                                              },
+                                              "sectionName": {
+                                                "description": "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "serviceType": {
+                                          "description": "Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "ingress": {
+                                      "description": "The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.",
+                                      "properties": {
+                                        "class": {
+                                          "description": "The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.",
+                                          "type": "string"
+                                        },
+                                        "ingressTemplate": {
+                                          "description": "Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.",
+                                          "properties": {
+                                            "metadata": {
+                                              "description": "ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.",
+                                              "properties": {
+                                                "annotations": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": "Annotations that should be added to the created ACME HTTP01 solver ingress.",
+                                                  "type": "object"
+                                                },
+                                                "labels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": "Labels that should be added to the created ACME HTTP01 solver ingress.",
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "description": "The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.",
+                                          "type": "string"
+                                        },
+                                        "podTemplate": {
+                                          "description": "Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.",
+                                          "properties": {
+                                            "metadata": {
+                                              "description": "ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.",
+                                              "properties": {
+                                                "annotations": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": "Annotations that should be added to the create ACME HTTP01 solver pods.",
+                                                  "type": "object"
+                                                },
+                                                "labels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": "Labels that should be added to the created ACME HTTP01 solver pods.",
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "spec": {
+                                              "description": "PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.",
+                                              "properties": {
+                                                "affinity": {
+                                                  "description": "If specified, the pod's scheduling constraints",
+                                                  "properties": {
+                                                    "nodeAffinity": {
+                                                      "description": "Describes node affinity scheduling rules for the pod.",
+                                                      "properties": {
+                                                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                                                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                                          "items": {
+                                                            "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                                            "properties": {
+                                                              "preference": {
+                                                                "description": "A node selector term, associated with the corresponding weight.",
+                                                                "properties": {
+                                                                  "matchExpressions": {
+                                                                    "description": "A list of node selector requirements by node's labels.",
+                                                                    "items": {
+                                                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "The label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "matchFields": {
+                                                                    "description": "A list of node selector requirements by node's fields.",
+                                                                    "items": {
+                                                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "The label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "weight": {
+                                                                "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                                                "format": "int32",
+                                                                "type": "integer"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "preference",
+                                                              "weight"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                          "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                                          "properties": {
+                                                            "nodeSelectorTerms": {
+                                                              "description": "Required. A list of node selector terms. The terms are ORed.",
+                                                              "items": {
+                                                                "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                                                "properties": {
+                                                                  "matchExpressions": {
+                                                                    "description": "A list of node selector requirements by node's labels.",
+                                                                    "items": {
+                                                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "The label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "matchFields": {
+                                                                    "description": "A list of node selector requirements by node's fields.",
+                                                                    "items": {
+                                                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "The label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "type": "array"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "nodeSelectorTerms"
+                                                          ],
+                                                          "type": "object"
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "podAffinity": {
+                                                      "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                                                      "properties": {
+                                                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                                                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                                          "items": {
+                                                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                                            "properties": {
+                                                              "podAffinityTerm": {
+                                                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                                "properties": {
+                                                                  "labelSelector": {
+                                                                    "description": "A label query over a set of resources, in this case pods.",
+                                                                    "properties": {
+                                                                      "matchExpressions": {
+                                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                        "items": {
+                                                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                          "properties": {
+                                                                            "key": {
+                                                                              "description": "key is the label key that the selector applies to.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            }
+                                                                          },
+                                                                          "required": [
+                                                                            "key",
+                                                                            "operator"
+                                                                          ],
+                                                                          "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                      },
+                                                                      "matchLabels": {
+                                                                        "additionalProperties": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                        "type": "object"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  "namespaceSelector": {
+                                                                    "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                                    "properties": {
+                                                                      "matchExpressions": {
+                                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                        "items": {
+                                                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                          "properties": {
+                                                                            "key": {
+                                                                              "description": "key is the label key that the selector applies to.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            }
+                                                                          },
+                                                                          "required": [
+                                                                            "key",
+                                                                            "operator"
+                                                                          ],
+                                                                          "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                      },
+                                                                      "matchLabels": {
+                                                                        "additionalProperties": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                        "type": "object"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  "namespaces": {
+                                                                    "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "topologyKey": {
+                                                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "topologyKey"
+                                                                ],
+                                                                "type": "object"
+                                                              },
+                                                              "weight": {
+                                                                "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                                                "format": "int32",
+                                                                "type": "integer"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "podAffinityTerm",
+                                                              "weight"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                          "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                                          "items": {
+                                                            "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \u003ctopologyKey\u003e matches that of any node on which a pod of the set of pods is running",
+                                                            "properties": {
+                                                              "labelSelector": {
+                                                                "description": "A label query over a set of resources, in this case pods.",
+                                                                "properties": {
+                                                                  "matchExpressions": {
+                                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                    "items": {
+                                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "key is the label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "matchLabels": {
+                                                                    "additionalProperties": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                    "type": "object"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "namespaceSelector": {
+                                                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                                "properties": {
+                                                                  "matchExpressions": {
+                                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                    "items": {
+                                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "key is the label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "matchLabels": {
+                                                                    "additionalProperties": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                    "type": "object"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "namespaces": {
+                                                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                                "items": {
+                                                                  "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              "topologyKey": {
+                                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "topologyKey"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "podAntiAffinity": {
+                                                      "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                                                      "properties": {
+                                                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                                                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                                          "items": {
+                                                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                                            "properties": {
+                                                              "podAffinityTerm": {
+                                                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                                "properties": {
+                                                                  "labelSelector": {
+                                                                    "description": "A label query over a set of resources, in this case pods.",
+                                                                    "properties": {
+                                                                      "matchExpressions": {
+                                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                        "items": {
+                                                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                          "properties": {
+                                                                            "key": {
+                                                                              "description": "key is the label key that the selector applies to.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            }
+                                                                          },
+                                                                          "required": [
+                                                                            "key",
+                                                                            "operator"
+                                                                          ],
+                                                                          "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                      },
+                                                                      "matchLabels": {
+                                                                        "additionalProperties": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                        "type": "object"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  "namespaceSelector": {
+                                                                    "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                                    "properties": {
+                                                                      "matchExpressions": {
+                                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                        "items": {
+                                                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                          "properties": {
+                                                                            "key": {
+                                                                              "description": "key is the label key that the selector applies to.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                              "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            }
+                                                                          },
+                                                                          "required": [
+                                                                            "key",
+                                                                            "operator"
+                                                                          ],
+                                                                          "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                      },
+                                                                      "matchLabels": {
+                                                                        "additionalProperties": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                        "type": "object"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  "namespaces": {
+                                                                    "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "topologyKey": {
+                                                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "topologyKey"
+                                                                ],
+                                                                "type": "object"
+                                                              },
+                                                              "weight": {
+                                                                "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                                                "format": "int32",
+                                                                "type": "integer"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "podAffinityTerm",
+                                                              "weight"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                          "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                                          "items": {
+                                                            "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \u003ctopologyKey\u003e matches that of any node on which a pod of the set of pods is running",
+                                                            "properties": {
+                                                              "labelSelector": {
+                                                                "description": "A label query over a set of resources, in this case pods.",
+                                                                "properties": {
+                                                                  "matchExpressions": {
+                                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                    "items": {
+                                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "key is the label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "matchLabels": {
+                                                                    "additionalProperties": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                    "type": "object"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "namespaceSelector": {
+                                                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                                "properties": {
+                                                                  "matchExpressions": {
+                                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                    "items": {
+                                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "description": "key is the label key that the selector applies to.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                      ],
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  "matchLabels": {
+                                                                    "additionalProperties": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                    "type": "object"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "namespaces": {
+                                                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                                "items": {
+                                                                  "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              "topologyKey": {
+                                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "topologyKey"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "nodeSelector": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+                                                  "type": "object"
+                                                },
+                                                "priorityClassName": {
+                                                  "description": "If specified, the pod's priorityClassName.",
+                                                  "type": "string"
+                                                },
+                                                "serviceAccountName": {
+                                                  "description": "If specified, the pod's service account",
+                                                  "type": "string"
+                                                },
+                                                "tolerations": {
+                                                  "description": "If specified, the pod's tolerations.",
+                                                  "items": {
+                                                    "description": "The pod this Toleration is attached to tolerates any taint that matches the triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
+                                                    "properties": {
+                                                      "effect": {
+                                                        "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                                        "type": "string"
+                                                      },
+                                                      "key": {
+                                                        "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                                        "type": "string"
+                                                      },
+                                                      "tolerationSeconds": {
+                                                        "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                                        "format": "int64",
+                                                        "type": "integer"
+                                                      },
+                                                      "value": {
+                                                        "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "serviceType": {
+                                          "description": "Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "selector": {
+                                  "description": "Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.",
+                                  "properties": {
+                                    "dnsNames": {
+                                      "description": "List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "dnsZones": {
+                                      "description": "List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "A label selector that is used to refine the set of certificate's that this challenge solver will apply to.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "privateKeySecretRef",
+                          "server"
+                        ],
+                        "type": "object"
+                      },
+                      "ca": {
+                        "description": "CA configures this issuer to sign certificates using a signing CA keypair stored in a Secret resource. This is used to build internal PKIs that are managed by cert-manager.",
+                        "properties": {
+                          "crlDistributionPoints": {
+                            "description": "The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set, certificates will be issued without distribution points set.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "ocspServers": {
+                            "description": "The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be \"http://ocsp.int-x3.letsencrypt.org\".",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "secretName": {
+                            "description": "SecretName is the name of the secret used to sign Certificates issued by this Issuer.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "secretName"
+                        ],
+                        "type": "object"
+                      },
+                      "selfSigned": {
+                        "description": "SelfSigned configures this issuer to 'self sign' certificates using the private key used to create the CertificateRequest object.",
+                        "properties": {
+                          "crlDistributionPoints": {
+                            "description": "The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set certificate will be issued without CDP. Values are strings.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "vault": {
+                        "description": "Vault configures this issuer to sign certificates using a HashiCorp Vault PKI backend.",
+                        "properties": {
+                          "auth": {
+                            "description": "Auth configures how cert-manager authenticates with the Vault server.",
+                            "properties": {
+                              "appRole": {
+                                "description": "AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.",
+                                "properties": {
+                                  "path": {
+                                    "description": "Path where the App Role authentication backend is mounted in Vault, e.g: \"approle\"",
+                                    "type": "string"
+                                  },
+                                  "roleId": {
+                                    "description": "RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.",
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "description": "Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "path",
+                                  "roleId",
+                                  "secretRef"
+                                ],
+                                "type": "object"
+                              },
+                              "kubernetes": {
+                                "description": "Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.",
+                                "properties": {
+                                  "mountPath": {
+                                    "description": "The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value \"/v1/auth/kubernetes\" will be used.",
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "description": "A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.",
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "description": "The required Secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. Use of 'ambient credentials' is not supported.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "role",
+                                  "secretRef"
+                                ],
+                                "type": "object"
+                              },
+                              "tokenSecretRef": {
+                                "description": "TokenSecretRef authenticates with Vault by presenting a token.",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "caBundle": {
+                            "description": "PEM-encoded CA bundle (base64-encoded) used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.",
+                            "format": "byte",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: \"ns1\" More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "Path is the mount path of the Vault PKI backend's `sign` endpoint, e.g: \"my_pki_mount/sign/my-role-name\".",
+                            "type": "string"
+                          },
+                          "server": {
+                            "description": "Server is the connection address for the Vault server, e.g: \"https://vault.example.com:8200\".",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "auth",
+                          "path",
+                          "server"
+                        ],
+                        "type": "object"
+                      },
+                      "venafi": {
+                        "description": "Venafi configures this issuer to sign certificates using a Venafi TPP or Venafi Cloud policy zone.",
+                        "properties": {
+                          "cloud": {
+                            "description": "Cloud specifies the Venafi cloud configuration settings. Only one of TPP or Cloud may be specified.",
+                            "properties": {
+                              "apiTokenSecretRef": {
+                                "description": "APITokenSecretRef is a secret key selector for the Venafi Cloud API token.",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "url": {
+                                "description": "URL is the base URL for Venafi Cloud. Defaults to \"https://api.venafi.cloud/v1\".",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "apiTokenSecretRef"
+                            ],
+                            "type": "object"
+                          },
+                          "tpp": {
+                            "description": "TPP specifies Trust Protection Platform configuration settings. Only one of TPP or Cloud may be specified.",
+                            "properties": {
+                              "caBundle": {
+                                "description": "CABundle is a PEM encoded TLS certificate to use to verify connections to the TPP instance. If specified, system roots will not be used and the issuing CA for the TPP instance must be verifiable using the provided root. If not specified, the connection will be verified using the cert-manager system root certificates.",
+                                "format": "byte",
+                                "type": "string"
+                              },
+                              "credentialsRef": {
+                                "description": "CredentialsRef is a reference to a Secret containing the username and password for the TPP server. The secret must contain two keys, 'username' and 'password'.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "url": {
+                                "description": "URL is the base URL for the vedsdk endpoint of the Venafi TPP instance, for example: \"https://tpp.example.com/vedsdk\".",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "credentialsRef",
+                              "url"
+                            ],
+                            "type": "object"
+                          },
+                          "zone": {
+                            "description": "Zone is the Venafi Policy Zone to use for this issuer. All requests made to the Venafi platform will be restricted by the named zone policy. This field is required.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "zone"
+                        ],
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "status": {
+                    "description": "Status of the Issuer. This is set and managed automatically.",
+                    "properties": {
+                      "acme": {
+                        "description": "ACME specific status options. This field should only be set if the Issuer is configured to use an ACME server to issue certificates.",
+                        "properties": {
+                          "lastRegisteredEmail": {
+                            "description": "LastRegisteredEmail is the email associated with the latest registered ACME account, in order to track changes made to registered account associated with the  Issuer",
+                            "type": "string"
+                          },
+                          "uri": {
+                            "description": "URI is the unique account identifier, which can also be used to retrieve account details from the CA",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "conditions": {
+                        "description": "List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready`.",
+                        "items": {
+                          "description": "IssuerCondition contains condition information for an Issuer.",
+                          "properties": {
+                            "lastTransitionTime": {
+                              "description": "LastTransitionTime is the timestamp corresponding to the last status change of this condition.",
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "message": {
+                              "description": "Message is a human readable description of the details of the last transition, complementing reason.",
+                              "type": "string"
+                            },
+                            "observedGeneration": {
+                              "description": "If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "reason": {
+                              "description": "Reason is a brief machine readable explanation for the condition's last transition.",
+                              "type": "string"
+                            },
+                            "status": {
+                              "description": "Status of the condition, one of (`True`, `False`, `Unknown`).",
+                              "enum": [
+                                "True",
+                                "False",
+                                "Unknown"
+                              ],
+                              "type": "string"
+                            },
+                            "type": {
+                              "description": "Type of the condition, known values are (`Ready`).",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "status",
+                            "type"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "type"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "spec"
+                ],
+                "type": "object"
+              }
+            },
+            "served": true,
+            "storage": true,
+            "subresources": {
+              "status": {}
+            }
+          }
+        ]
+      },
+      "status": {
+        "acceptedNames": {
+          "categories": [
+            "cert-manager"
+          ],
+          "kind": "Issuer",
+          "listKind": "IssuerList",
+          "plural": "issuers",
+          "singular": "issuer"
+        },
+        "conditions": [
+          {
+            "lastTransitionTime": "2022-11-03T14:15:19Z",
+            "message": "no conflicts found",
+            "reason": "NoConflicts",
+            "status": "True",
+            "type": "NamesAccepted"
+          },
+          {
+            "lastTransitionTime": "2022-11-03T14:15:19Z",
+            "message": "the initial names have been accepted",
+            "reason": "InitialNamesAccepted",
+            "status": "True",
+            "type": "Established"
+          }
+        ],
+        "storedVersions": [
+          "v1"
+        ]
+      }
+    },
+    {
+      "apiVersion": "apiextensions.k8s.io/v1",
+      "kind": "CustomResourceDefinition",
+      "metadata": {
+        "annotations": {
+          "operator.jetstack.io/component": "cert-manager",
+          "operator.jetstack.io/component-version": "v1.9.1"
+        },
+        "creationTimestamp": "2022-11-03T14:15:19Z",
+        "generation": 1,
+        "labels": {
+          "app": "cert-manager",
+          "app.kubernetes.io/instance": "cert-manager",
+          "app.kubernetes.io/name": "cert-manager",
+          "app.kubernetes.io/version": "v1.9.1"
+        },
+        "name": "orders.acme.cert-manager.io",
+        "ownerReferences": [
+          {
+            "apiVersion": "operator.jetstack.io/v1alpha1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Installation",
+            "name": "installation",
+            "uid": "648c8b6d-3c85-4faa-9497-1eedc3873baf"
+          }
+        ],
+        "resourceVersion": "71271",
+        "uid": "1d70c9b2-1288-486f-9747-97bbcff5c979"
+      },
+      "spec": {
+        "conversion": {
+          "strategy": "None"
+        },
+        "group": "acme.cert-manager.io",
+        "names": {
+          "categories": [
+            "cert-manager",
+            "cert-manager-acme"
+          ],
+          "kind": "Order",
+          "listKind": "OrderList",
+          "plural": "orders",
+          "singular": "order"
+        },
+        "scope": "Namespaced",
+        "versions": [
+          {
+            "additionalPrinterColumns": [
+              {
+                "jsonPath": ".status.state",
+                "name": "State",
+                "type": "string"
+              },
+              {
+                "jsonPath": ".spec.issuerRef.name",
+                "name": "Issuer",
+                "priority": 1,
+                "type": "string"
+              },
+              {
+                "jsonPath": ".status.reason",
+                "name": "Reason",
+                "priority": 1,
+                "type": "string"
+              },
+              {
+                "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.",
+                "jsonPath": ".metadata.creationTimestamp",
+                "name": "Age",
+                "type": "date"
+              }
+            ],
+            "name": "v1",
+            "schema": {
+              "openAPIV3Schema": {
+                "description": "Order is a type to represent an Order with an ACME server",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "type": "object"
+                  },
+                  "spec": {
+                    "properties": {
+                      "commonName": {
+                        "description": "CommonName is the common name as specified on the DER encoded CSR. If specified, this value must also be present in `dnsNames` or `ipAddresses`. This field must match the corresponding field on the DER encoded CSR.",
+                        "type": "string"
+                      },
+                      "dnsNames": {
+                        "description": "DNSNames is a list of DNS names that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "duration": {
+                        "description": "Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.",
+                        "type": "string"
+                      },
+                      "ipAddresses": {
+                        "description": "IPAddresses is a list of IP addresses that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "issuerRef": {
+                        "description": "IssuerRef references a properly configured ACME-type Issuer which should be used to create this Order. If the Issuer does not exist, processing will be retried. If the Issuer is not an 'ACME' Issuer, an error will be returned and the Order will be marked as failed.",
+                        "properties": {
+                          "group": {
+                            "description": "Group of the resource being referred to.",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "Kind of the resource being referred to.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the resource being referred to.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object"
+                      },
+                      "request": {
+                        "description": "Certificate signing request bytes in DER encoding. This will be used when finalizing the order. This field must be set on the order.",
+                        "format": "byte",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "issuerRef",
+                      "request"
+                    ],
+                    "type": "object"
+                  },
+                  "status": {
+                    "properties": {
+                      "authorizations": {
+                        "description": "Authorizations contains data returned from the ACME server on what authorizations must be completed in order to validate the DNS names specified on the Order.",
+                        "items": {
+                          "description": "ACMEAuthorization contains data returned from the ACME server on an authorization that must be completed in order validate a DNS name on an ACME Order resource.",
+                          "properties": {
+                            "challenges": {
+                              "description": "Challenges specifies the challenge types offered by the ACME server. One of these challenge types will be selected when validating the DNS name and an appropriate Challenge resource will be created to perform the ACME challenge process.",
+                              "items": {
+                                "description": "Challenge specifies a challenge offered by the ACME server for an Order. An appropriate Challenge resource can be created to perform the ACME challenge process.",
+                                "properties": {
+                                  "token": {
+                                    "description": "Token is the token that must be presented for this challenge. This is used to compute the 'key' that must also be presented.",
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "description": "Type is the type of challenge being offered, e.g. 'http-01', 'dns-01', 'tls-sni-01', etc. This is the raw value retrieved from the ACME server. Only 'http-01' and 'dns-01' are supported by cert-manager, other values will be ignored.",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "description": "URL is the URL of this challenge. It can be used to retrieve additional metadata about the Challenge from the ACME server.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "token",
+                                  "type",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "identifier": {
+                              "description": "Identifier is the DNS name to be validated as part of this authorization",
+                              "type": "string"
+                            },
+                            "initialState": {
+                              "description": "InitialState is the initial state of the ACME authorization when first fetched from the ACME server. If an Authorization is already 'valid', the Order controller will not create a Challenge resource for the authorization. This will occur when working with an ACME server that enables 'authz reuse' (such as Let's Encrypt's production endpoint). If not set and 'identifier' is set, the state is assumed to be pending and a Challenge will be created.",
+                              "enum": [
+                                "valid",
+                                "ready",
+                                "pending",
+                                "processing",
+                                "invalid",
+                                "expired",
+                                "errored"
+                              ],
+                              "type": "string"
+                            },
+                            "url": {
+                              "description": "URL is the URL of the Authorization that must be completed",
+                              "type": "string"
+                            },
+                            "wildcard": {
+                              "description": "Wildcard will be true if this authorization is for a wildcard DNS name. If this is true, the identifier will be the *non-wildcard* version of the DNS name. For example, if '*.example.com' is the DNS name being validated, this field will be 'true' and the 'identifier' field will be 'example.com'.",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "url"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "certificate": {
+                        "description": "Certificate is a copy of the PEM encoded certificate for this Order. This field will be populated after the order has been successfully finalized with the ACME server, and the order has transitioned to the 'valid' state.",
+                        "format": "byte",
+                        "type": "string"
+                      },
+                      "failureTime": {
+                        "description": "FailureTime stores the time that this order failed. This is used to influence garbage collection and back-off.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "finalizeURL": {
+                        "description": "FinalizeURL of the Order. This is used to obtain certificates for this order once it has been completed.",
+                        "type": "string"
+                      },
+                      "reason": {
+                        "description": "Reason optionally provides more information about a why the order is in the current state.",
+                        "type": "string"
+                      },
+                      "state": {
+                        "description": "State contains the current state of this Order resource. States 'success' and 'expired' are 'final'",
+                        "enum": [
+                          "valid",
+                          "ready",
+                          "pending",
+                          "processing",
+                          "invalid",
+                          "expired",
+                          "errored"
+                        ],
+                        "type": "string"
+                      },
+                      "url": {
+                        "description": "URL of the Order. This will initially be empty when the resource is first created. The Order controller will populate this field when the Order is first processed. This field will be immutable after it is initially set.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "metadata",
+                  "spec"
+                ],
+                "type": "object"
+              }
+            },
+            "served": true,
+            "storage": true,
+            "subresources": {
+              "status": {}
+            }
+          }
+        ]
+      },
+      "status": {
+        "acceptedNames": {
+          "categories": [
+            "cert-manager",
+            "cert-manager-acme"
+          ],
+          "kind": "Order",
+          "listKind": "OrderList",
+          "plural": "orders",
+          "singular": "order"
+        },
+        "conditions": [
+          {
+            "lastTransitionTime": "2022-11-03T14:15:19Z",
+            "message": "no conflicts found",
+            "reason": "NoConflicts",
+            "status": "True",
+            "type": "NamesAccepted"
+          },
+          {
+            "lastTransitionTime": "2022-11-03T14:15:19Z",
+            "message": "the initial names have been accepted",
+            "reason": "InitialNamesAccepted",
+            "status": "True",
+            "type": "Established"
+          }
+        ],
+        "storedVersions": [
+          "v1"
+        ]
+      }
+    }
+  ],
+  "kind": "List",
+  "metadata": {
+    "resourceVersion": "",
+    "selfLink": ""
+  }
+}

--- a/internal/kubernetes/backup/fixtures/googlecasissuer-list.json
+++ b/internal/kubernetes/backup/fixtures/googlecasissuer-list.json
@@ -1,0 +1,34 @@
+{
+  "apiVersion": "v1",
+  "items": [
+    {
+      "apiVersion": "cas-issuer.jetstack.io/v1beta1",
+      "kind": "GoogleCASIssuer",
+      "metadata": {
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"cas-issuer.jetstack.io/v1beta1\",\"kind\":\"GoogleCASIssuer\",\"metadata\":{\"annotations\":{},\"name\":\"googlecasissuer-sample\",\"namespace\":\"jetstack-secure\"},\"spec\":{\"caPoolId\":\"my-pool\",\"credentials\":{\"key\":\"example\",\"name\":\"googlesa\"},\"location\":\"us-east1\",\"project\":\"example\"}}\n"
+        },
+        "creationTimestamp": "2022-11-08T14:20:47Z",
+        "generation": 1,
+        "name": "googlecasissuer-sample",
+        "namespace": "jetstack-secure",
+        "resourceVersion": "288845",
+        "uid": "7856ce8d-7f33-43d2-9035-13a2dbb465c6"
+      },
+      "spec": {
+        "caPoolId": "my-pool",
+        "credentials": {
+          "key": "example",
+          "name": "googlesa"
+        },
+        "location": "us-east1",
+        "project": "example"
+      }
+    }
+  ],
+  "kind": "List",
+  "metadata": {
+    "resourceVersion": "",
+    "selfLink": ""
+  }
+}

--- a/internal/kubernetes/backup/fixtures/issuer-list.json
+++ b/internal/kubernetes/backup/fixtures/issuer-list.json
@@ -1,0 +1,42 @@
+{
+  "apiVersion": "v1",
+  "items": [
+    {
+      "apiVersion": "cert-manager.io/v1",
+      "kind": "Issuer",
+      "metadata": {
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"cert-manager.io/v1\",\"kind\":\"Issuer\",\"metadata\":{\"annotations\":{},\"name\":\"cm-issuer-sample\",\"namespace\":\"jetstack-secure\"},\"spec\":{\"ca\":{\"secretName\":\"ca-key-pair\"}}}\n"
+        },
+        "creationTimestamp": "2022-11-08T14:20:47Z",
+        "generation": 1,
+        "name": "cm-issuer-sample",
+        "namespace": "jetstack-secure",
+        "resourceVersion": "288849",
+        "uid": "6a7e8318-22e2-4a76-81bd-7d29a748f3ee"
+      },
+      "spec": {
+        "ca": {
+          "secretName": "ca-key-pair"
+        }
+      },
+      "status": {
+        "conditions": [
+          {
+            "lastTransitionTime": "2022-11-08T14:20:47Z",
+            "message": "Error getting keypair for CA issuer: secret \"ca-key-pair\" not found",
+            "observedGeneration": 1,
+            "reason": "ErrGetKeyPair",
+            "status": "False",
+            "type": "Ready"
+          }
+        ]
+      }
+    }
+  ],
+  "kind": "List",
+  "metadata": {
+    "resourceVersion": "",
+    "selfLink": ""
+  }
+}

--- a/internal/kubernetes/clients/clients.go
+++ b/internal/kubernetes/clients/clients.go
@@ -3,19 +3,58 @@ package clients
 import (
 	"fmt"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	v1alpha1approverpolicy "github.com/cert-manager/approver-policy/pkg/apis/policy/v1alpha1"
+	v1certmanager "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	v1extensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/client-go/rest"
 )
 
 // NewCRDClient returns an instance of a generic client for querying CRDs
-func NewCRDClient(config *rest.Config) (*Generic[*apiextensionsv1.CustomResourceDefinition, *apiextensionsv1.CustomResourceDefinitionList], error) {
-	genericClient, err := NewGenericClient[*apiextensionsv1.CustomResourceDefinition, *apiextensionsv1.CustomResourceDefinitionList](
+func NewCRDClient(config *rest.Config) (*Generic[*v1extensions.CustomResourceDefinition, *v1extensions.CustomResourceDefinitionList], error) {
+	genericClient, err := NewGenericClient[*v1extensions.CustomResourceDefinition, *v1extensions.CustomResourceDefinitionList](
 		&GenericClientOptions{
 			RestConfig: config,
 			APIPath:    "/apis",
 			Group:      apiextensionsv1.GroupName,
 			Version:    apiextensionsv1.SchemeGroupVersion.Version,
 			Kind:       "customresourcedefinitions",
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error creating generic client: %w", err)
+	}
+
+	return genericClient, nil
+}
+
+// NewCertificateClient returns an instance of a generic client for querying cert-manager Certificates
+func NewCertificateClient(config *rest.Config) (*Generic[*v1certmanager.Certificate, *v1certmanager.CertificateList], error) {
+	genericClient, err := NewGenericClient[*v1certmanager.Certificate, *v1certmanager.CertificateList](
+		&GenericClientOptions{
+			RestConfig: config,
+			APIPath:    "/apis",
+			Group:      v1certmanager.SchemeGroupVersion.Group,
+			Version:    v1certmanager.SchemeGroupVersion.Version,
+			Kind:       "certificates",
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error creating generic client: %w", err)
+	}
+
+	return genericClient, nil
+}
+
+// NewCertificateRequestPolicyClient returns an instance of a generic client for
+// querying approver policy CertificateRequestPolicies
+func NewCertificateRequestPolicyClient(config *rest.Config) (*Generic[*v1alpha1approverpolicy.CertificateRequestPolicy, *v1alpha1approverpolicy.CertificateRequestPolicyList], error) {
+	genericClient, err := NewGenericClient[*v1alpha1approverpolicy.CertificateRequestPolicy, *v1alpha1approverpolicy.CertificateRequestPolicyList](
+		&GenericClientOptions{
+			RestConfig: config,
+			APIPath:    "/apis",
+			Group:      v1alpha1approverpolicy.SchemeGroupVersion.Group,
+			Version:    v1alpha1approverpolicy.SchemeGroupVersion.Version,
+			Kind:       "certificaterequestpolicies",
 		},
 	)
 	if err != nil {

--- a/internal/kubernetes/clients/clients.go
+++ b/internal/kubernetes/clients/clients.go
@@ -15,8 +15,8 @@ func NewCRDClient(config *rest.Config) (*Generic[*v1extensions.CustomResourceDef
 		&GenericClientOptions{
 			RestConfig: config,
 			APIPath:    "/apis",
-			Group:      apiextensionsv1.GroupName,
-			Version:    apiextensionsv1.SchemeGroupVersion.Version,
+			Group:      v1extensions.GroupName,
+			Version:    v1extensions.SchemeGroupVersion.Version,
 			Kind:       "customresourcedefinitions",
 		},
 	)

--- a/internal/kubernetes/clients/generic_test.go
+++ b/internal/kubernetes/clients/generic_test.go
@@ -84,18 +84,18 @@ func TestGeneric_Get_WithDropFields(t *testing.T) {
 		Host: server.URL,
 	}
 
-	client, err := NewGenericClient[*v1core.Pod, *v1core.PodList](
+	client, err := NewGenericClient[*corev1.Pod, *corev1.PodList](
 		&GenericClientOptions{
 			RestConfig: cfg,
 			APIPath:    "/api/",
-			Group:      v1core.GroupName,
-			Version:    v1core.SchemeGroupVersion.Version,
+			Group:      corev1.GroupName,
+			Version:    corev1.SchemeGroupVersion.Version,
 			Kind:       "pods",
 		},
 	)
 	require.NoError(t, err)
 
-	var result v1core.Pod
+	var result corev1.Pod
 
 	err = client.Get(ctx, &GenericRequestOptions{
 		Name:      "test-pod",
@@ -132,18 +132,18 @@ func TestGeneric_List_WithDropFields(t *testing.T) {
 		Host: server.URL,
 	}
 
-	client, err := NewGenericClient[*v1core.Pod, *v1core.PodList](
+	client, err := NewGenericClient[*corev1.Pod, *corev1.PodList](
 		&GenericClientOptions{
 			RestConfig: cfg,
 			APIPath:    "/api/",
-			Group:      v1core.GroupName,
-			Version:    v1core.SchemeGroupVersion.Version,
+			Group:      corev1.GroupName,
+			Version:    corev1.SchemeGroupVersion.Version,
 			Kind:       "pods",
 		},
 	)
 	require.NoError(t, err)
 
-	var result v1core.PodList
+	var result corev1.PodList
 
 	err = client.List(ctx, &GenericRequestOptions{
 		Namespace: "test-namespace",

--- a/internal/kubernetes/clients/generic_test.go
+++ b/internal/kubernetes/clients/generic_test.go
@@ -3,6 +3,7 @@ package clients
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -52,9 +53,109 @@ func TestGeneric_Get(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.True(t, called)
-	assert.Equal(t, result.Name, "test-pod")
-	assert.Equal(t, result.Namespace, "test-namespace")
+	assert.Equal(t, "test-pod", result.Name)
+	assert.Equal(t, "test-namespace", result.Namespace)
 	assert.Equal(t, "/api/v1/namespaces/test-namespace/pods/test-pod", requestedPath)
+}
+
+func TestGeneric_Get_WithDropFields(t *testing.T) {
+	ctx := context.Background()
+
+	var requestedPath string
+	var called bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		requestedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "test-pod",
+    "namespace": "test-namespace",
+    "annotations": {
+      "kubectl.kubernetes.io/last-applied-configuration": "data"
+    }
+  }
+}`))
+	}))
+
+	cfg := &rest.Config{
+		Host: server.URL,
+	}
+
+	client, err := NewGenericClient[*v1core.Pod, *v1core.PodList](
+		&GenericClientOptions{
+			RestConfig: cfg,
+			APIPath:    "/api/",
+			Group:      v1core.GroupName,
+			Version:    v1core.SchemeGroupVersion.Version,
+			Kind:       "pods",
+		},
+	)
+	require.NoError(t, err)
+
+	var result v1core.Pod
+
+	err = client.Get(ctx, &GenericRequestOptions{
+		Name:      "test-pod",
+		Namespace: "test-namespace",
+		DropFields: []string{
+			"/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration",
+		},
+	}, &result)
+	require.NoError(t, err)
+
+	assert.True(t, called)
+	assert.Equal(t, "test-pod", result.Name)
+	assert.Equal(t, "test-namespace", result.Namespace)
+	// Field should have been dropped
+	assert.Equal(t, map[string]string{}, result.Annotations)
+	assert.Equal(t, "/api/v1/namespaces/test-namespace/pods/test-pod", requestedPath)
+}
+
+func TestGeneric_List_WithDropFields(t *testing.T) {
+	ctx := context.Background()
+
+	var requestedPath string
+	var called bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		requestedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		data, err := os.ReadFile("fixtures/pod-list.json")
+		require.NoError(t, err)
+		w.Write(data)
+	}))
+
+	cfg := &rest.Config{
+		Host: server.URL,
+	}
+
+	client, err := NewGenericClient[*v1core.Pod, *v1core.PodList](
+		&GenericClientOptions{
+			RestConfig: cfg,
+			APIPath:    "/api/",
+			Group:      v1core.GroupName,
+			Version:    v1core.SchemeGroupVersion.Version,
+			Kind:       "pods",
+		},
+	)
+	require.NoError(t, err)
+
+	var result v1core.PodList
+
+	err = client.List(ctx, &GenericRequestOptions{
+		Namespace: "test-namespace",
+		DropFields: []string{
+			"/status",
+		},
+	}, &result)
+	require.NoError(t, err)
+
+	assert.True(t, called)
+	assert.Equal(t, "/api/v1/namespaces/test-namespace/pods", requestedPath)
+	assert.Equal(t, "", fmt.Sprintf("%s", result.Items[0].Status.Phase))
 }
 
 func TestGeneric_Get_ClusterScope(t *testing.T) {

--- a/internal/kubernetes/clients/issuers_test.go
+++ b/internal/kubernetes/clients/issuers_test.go
@@ -13,6 +13,63 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+func TestListSupportedIssuers(t *testing.T) {
+	expectedSupportedIssuers := SupportedIssuerList{
+		{
+			CRDName:  "issuers.cert-manager.io",
+			Versions: []string{"v1"},
+		},
+		{
+			CRDName:  "clusterissuers.cert-manager.io",
+			Versions: []string{"v1"},
+		},
+		{
+			CRDName:  "venafiissuers.jetstack.io",
+			Versions: []string{"v1alpha1"},
+		},
+		{
+			CRDName:  "venaficlusterissuers.jetstack.io",
+			Versions: []string{"v1alpha1"},
+		},
+		{
+			CRDName:  "awspcaissuers.awspca.cert-manager.io",
+			Versions: []string{"v1beta1"},
+		},
+		{
+			CRDName:  "awspcaclusterissuers.awspca.cert-manager.io",
+			Versions: []string{"v1beta1"},
+		},
+		{
+			CRDName:  "kmsissuers.cert-manager.skyscanner.net",
+			Versions: []string{"v1alpha1"},
+		},
+		{
+			CRDName:  "googlecasissuers.cas-issuer.jetstack.io",
+			Versions: []string{"v1beta1"},
+		},
+		{
+			CRDName:  "googlecasclusterissuers.cas-issuer.jetstack.io",
+			Versions: []string{"v1beta1"},
+		},
+		{
+			CRDName:  "originissuers.cert-manager.k8s.cloudflare.com",
+			Versions: []string{"v1"},
+		},
+		{
+			CRDName:  "stepissuers.certmanager.step.sm",
+			Versions: []string{"v1beta1"},
+		},
+		{
+			CRDName:  "stepclusterissuers.certmanager.step.sm",
+			Versions: []string{"v1beta1"},
+		},
+	}
+
+	result, err := ListSupportedIssuers()
+	require.NoError(t, err)
+	assert.Equal(t, expectedSupportedIssuers, result)
+}
+
 func TestAllIssuers_ListKinds(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
This implements a command to generate a cluster back up from the state in the K8S API.

Example output can be found in [internal/kubernetes/backup/fixtures/backup.yaml](https://github.com/jetstack/jsctl/blob/629b1a930c5bc9a4a36f2c53e5a70ae3c40c07a5/internal/kubernetes/backup/fixtures/backup.yaml), status and createdTime values come from the k8s yaml generation. These can be removed with a further round of redaction if we'd like.