### PR TITLE
Fix bug in global flag dependency injection

### DIFF
--- a/internal/command/clusters.go
+++ b/internal/command/clusters.go
@@ -15,11 +15,11 @@ func Clusters() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		clusters.Connect(run, kubeConfig, apiURL, useStdout),
-		clusters.List(run, apiURL),
-		clusters.Delete(run, apiURL),
-		clusters.View(run, apiURL),
-		clusters.Status(run, kubeConfig),
+		clusters.Connect(run, &kubeConfig, &apiURL, &useStdout),
+		clusters.List(run, &apiURL),
+		clusters.Delete(run, &apiURL),
+		clusters.View(run, &apiURL),
+		clusters.Status(run, &kubeConfig),
 		// TODO cleanup is currently experimental
 		// clusters.CleanUp(run, kubeConfig),
 	)

--- a/internal/command/clusters/connect.go
+++ b/internal/command/clusters/connect.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Connect returns a new cobra.Command that connects a cluster to the control plane.
-func Connect(run types.RunFunc, kubeConfigPath, apiURL string, useStdout bool) *cobra.Command {
+func Connect(run types.RunFunc, kubeConfigPath, apiURL *string, useStdout *bool) *cobra.Command {
 	const defaultRegistry = "quay.io/jetstack"
 	var registry string
 
@@ -36,7 +36,7 @@ func Connect(run types.RunFunc, kubeConfigPath, apiURL string, useStdout bool) *
 				return commandErrors.ErrNoOrganizationName
 			}
 
-			http := client.New(ctx, apiURL)
+			http := client.New(ctx, *apiURL)
 
 			serviceAccount, err := cluster.CreateServiceAccount(ctx, http, cnf.Organization, name)
 			if err != nil {
@@ -44,10 +44,10 @@ func Connect(run types.RunFunc, kubeConfigPath, apiURL string, useStdout bool) *
 			}
 
 			var applier cluster.Applier
-			if useStdout {
+			if *useStdout {
 				applier = kubernetes.NewStdOutApplier()
 			} else {
-				applier, err = kubernetes.NewKubeConfigApplier(kubeConfigPath)
+				applier, err = kubernetes.NewKubeConfigApplier(*kubeConfigPath)
 				if err != nil {
 					return err
 				}

--- a/internal/command/clusters/delete.go
+++ b/internal/command/clusters/delete.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Delete returns a new cobra.Command for deleting a cluster in the JSCP api
-func Delete(run types.RunFunc, apiURL string) *cobra.Command {
+func Delete(run types.RunFunc, apiURL *string) *cobra.Command {
 	var force bool
 
 	cmd := &cobra.Command{
@@ -30,7 +30,7 @@ func Delete(run types.RunFunc, apiURL string) *cobra.Command {
 				return errors.ErrNoOrganizationName
 			}
 
-			http := client.New(ctx, apiURL)
+			http := client.New(ctx, *apiURL)
 			name := args[0]
 			if name == "" {
 				return errors2.New("you must specify a cluster name")

--- a/internal/command/clusters/list.go
+++ b/internal/command/clusters/list.go
@@ -17,7 +17,7 @@ import (
 )
 
 // List returns a new cobra.Command for listing clusters in the JSCP api
-func List(run types.RunFunc, apiURL string) *cobra.Command {
+func List(run types.RunFunc, apiURL *string) *cobra.Command {
 	var jsonOut bool
 
 	cmd := &cobra.Command{
@@ -30,7 +30,7 @@ func List(run types.RunFunc, apiURL string) *cobra.Command {
 				return errors.ErrNoOrganizationName
 			}
 
-			http := client.New(ctx, apiURL)
+			http := client.New(ctx, *apiURL)
 
 			clusters, err := cluster.List(ctx, http, cnf.Organization)
 			if err != nil {

--- a/internal/command/clusters/status.go
+++ b/internal/command/clusters/status.go
@@ -14,14 +14,14 @@ import (
 )
 
 // Status returns a new command that shows the status of a cluster resources
-func Status(run types.RunFunc, kubeConfigPath string) *cobra.Command {
+func Status(run types.RunFunc, kubeConfigPath *string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "status",
 		Short: "Prints information about the state in the currently configured cluster in kubeconfig",
 		Long:  "The information printed by this command can be used to determine the state of a cluster prior to installing Jetstack Secure.",
 		Args:  cobra.ExactValidArgs(0),
 		Run: run(func(ctx context.Context, args []string) error {
-			kubeCfg, err := kubernetes.NewConfig(kubeConfigPath)
+			kubeCfg, err := kubernetes.NewConfig(*kubeConfigPath)
 			if err != nil {
 				return err
 			}

--- a/internal/command/clusters/view.go
+++ b/internal/command/clusters/view.go
@@ -16,7 +16,7 @@ import (
 )
 
 // View returns a new cobra.Command for viewing a cluster in the JSCP api
-func View(run types.RunFunc, apiURL string) *cobra.Command {
+func View(run types.RunFunc, apiURL *string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "view [name]",
 		Short: "Opens a browser window to the cluster's dashboard",
@@ -27,7 +27,7 @@ func View(run types.RunFunc, apiURL string) *cobra.Command {
 				return errors.ErrNoOrganizationName
 			}
 
-			http := client.New(ctx, apiURL)
+			http := client.New(ctx, *apiURL)
 			name := args[0]
 			if name == "" {
 				return errors2.New("you must specify a cluster name")


### PR DESCRIPTION
These values are set after they're passed down to the dependent commands. This pr fixes the issue by passing pointers.

This bug can be seen in main by running clusters connect --stdout

Signed-off-by: Charlie Egan <charlieegan3@users.noreply.github.com>