### PR TITLE
Implement a simple pre-uninstall check command

### DIFF
--- a/docs/reference/jsctl_clusters.md
+++ b/docs/reference/jsctl_clusters.md
@@ -24,5 +24,6 @@ Subcommands for cluster management
 * [jsctl clusters delete](jsctl_clusters_delete.md)	 - Deletes a cluster from the organization
 * [jsctl clusters list](jsctl_clusters_list.md)	 - Lists all clusters connected to the control plane for the organization
 * [jsctl clusters status](jsctl_clusters_status.md)	 - Prints information about the state in the currently configured cluster in kubeconfig
+* [jsctl clusters uninstall](jsctl_clusters_uninstall.md)	 - Contains commands to check a cluster before the uninstallation of Jetstack Secure software
 * [jsctl clusters view](jsctl_clusters_view.md)	 - Opens a browser window to the cluster's dashboard
 

--- a/docs/reference/jsctl_clusters.md
+++ b/docs/reference/jsctl_clusters.md
@@ -24,6 +24,5 @@ Subcommands for cluster management
 * [jsctl clusters delete](jsctl_clusters_delete.md)	 - Deletes a cluster from the organization
 * [jsctl clusters list](jsctl_clusters_list.md)	 - Lists all clusters connected to the control plane for the organization
 * [jsctl clusters status](jsctl_clusters_status.md)	 - Prints information about the state in the currently configured cluster in kubeconfig
-* [jsctl clusters uninstall](jsctl_clusters_uninstall.md)	 - Contains commands to check a cluster before the uninstallation of Jetstack Secure software
 * [jsctl clusters view](jsctl_clusters_view.md)	 - Opens a browser window to the cluster's dashboard
 

--- a/docs/reference/jsctl_clusters_uninstall.md
+++ b/docs/reference/jsctl_clusters_uninstall.md
@@ -1,0 +1,24 @@
+## jsctl clusters uninstall
+
+Contains commands to check a cluster before the uninstallation of Jetstack Secure software
+
+### Options
+
+```
+  -h, --help   help for uninstall
+```
+
+### Options inherited from parent commands
+
+```
+      --api-url string      Base URL of the control-plane API (default "https://platform.jetstack.io")
+      --config string       Location of the user's jsctl config directory (default "HOME or USERPROFILE/.jsctl")
+      --kubeconfig string   Location of the user's kubeconfig file for applying directly to the cluster (default "~/.kube/config")
+      --stdout              If provided, manifests are written to stdout rather than applied to the current cluster
+```
+
+### SEE ALSO
+
+* [jsctl clusters](jsctl_clusters.md)	 - Subcommands for cluster management
+* [jsctl clusters uninstall verify](jsctl_clusters_uninstall_verify.md)	 - Check that a cluster is ready to have Jetstack Software uninstalled
+

--- a/docs/reference/jsctl_clusters_uninstall_verify.md
+++ b/docs/reference/jsctl_clusters_uninstall_verify.md
@@ -1,0 +1,27 @@
+## jsctl clusters uninstall verify
+
+Check that a cluster is ready to have Jetstack Software uninstalled
+
+```
+jsctl clusters uninstall verify [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for verify
+```
+
+### Options inherited from parent commands
+
+```
+      --api-url string      Base URL of the control-plane API (default "https://platform.jetstack.io")
+      --config string       Location of the user's jsctl config directory (default "HOME or USERPROFILE/.jsctl")
+      --kubeconfig string   Location of the user's kubeconfig file for applying directly to the cluster (default "~/.kube/config")
+      --stdout              If provided, manifests are written to stdout rather than applied to the current cluster
+```
+
+### SEE ALSO
+
+* [jsctl clusters uninstall](jsctl_clusters_uninstall.md)	 - Contains commands to check a cluster before the uninstallation of Jetstack Secure software
+

--- a/docs/reference/jsctl_clusters_uninstall_verify.md
+++ b/docs/reference/jsctl_clusters_uninstall_verify.md
@@ -2,6 +2,15 @@
 
 Check that a cluster is ready to have Jetstack Software uninstalled
 
+### Synopsis
+
+Runs the following checks:
+* Checks secrets containing certificates are safe from garbage collection
+* Checks for any upcoming renewals
+* Checks for certificates currently being issued
+* Checks for stuck certificate requests
+
+
 ```
 jsctl clusters uninstall verify [flags]
 ```

--- a/docs/reference/jsctl_experimental_clusters_uninstall.md
+++ b/docs/reference/jsctl_experimental_clusters_uninstall.md
@@ -1,0 +1,24 @@
+## jsctl experimental clusters uninstall
+
+Contains commands to check a cluster before the uninstallation of Jetstack Secure software
+
+### Options
+
+```
+  -h, --help   help for uninstall
+```
+
+### Options inherited from parent commands
+
+```
+      --api-url string      Base URL of the control-plane API (default "https://platform.jetstack.io")
+      --config string       Location of the user's jsctl config directory (default "HOME or USERPROFILE/.jsctl")
+      --kubeconfig string   Location of the user's kubeconfig file for applying directly to the cluster (default "~/.kube/config")
+      --stdout              If provided, manifests are written to stdout rather than applied to the current cluster
+```
+
+### SEE ALSO
+
+* [jsctl experimental clusters](jsctl_experimental_clusters.md)	 - Experimental clusters commands
+* [jsctl experimental clusters uninstall verify](jsctl_experimental_clusters_uninstall_verify.md)	 - Check that a cluster is ready to have Jetstack Software uninstalled
+

--- a/docs/reference/jsctl_experimental_clusters_uninstall_verify.md
+++ b/docs/reference/jsctl_experimental_clusters_uninstall_verify.md
@@ -1,11 +1,26 @@
-## jsctl experimental clusters
+## jsctl experimental clusters uninstall verify
 
-Experimental clusters commands
+Check that a cluster is ready to have Jetstack Software uninstalled
+
+### Synopsis
+
+Runs the following checks:
+* Checks secrets containing certificates are safe from garbage collection
+* Checks for any upcoming renewals
+* Checks for certificates currently being issued
+* Checks for certificates that will expire soon
+* Checks for unready certificates
+* Checks for failing issuances
+
+
+```
+jsctl experimental clusters uninstall verify [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for clusters
+  -h, --help   help for verify
 ```
 
 ### Options inherited from parent commands
@@ -19,8 +34,5 @@ Experimental clusters commands
 
 ### SEE ALSO
 
-* [jsctl experimental](jsctl_experimental.md)	 - Experimental jsctl commands
-* [jsctl experimental clusters backup](jsctl_experimental_clusters_backup.md)	 - This command outputs the YAML data of Jetstack Secure relevant resources in the cluster
-* [jsctl experimental clusters cleanup](jsctl_experimental_clusters_cleanup.md)	 - Contains commands to prepare a cluster for the uninstallation of Jetstack Secure software
 * [jsctl experimental clusters uninstall](jsctl_experimental_clusters_uninstall.md)	 - Contains commands to check a cluster before the uninstallation of Jetstack Secure software
 

--- a/internal/command/clusters.go
+++ b/internal/command/clusters.go
@@ -20,6 +20,7 @@ func Clusters() *cobra.Command {
 		clusters.Delete(run, &apiURL),
 		clusters.View(run, &apiURL),
 		clusters.Status(run, &kubeConfig),
+		clusters.Uninstall(run, &kubeConfig),
 		// TODO these commands are currently experimental
 		// clusters.CleanUp(run, kubeConfig),
 		// clusters.Backup(run, kubeConfig),

--- a/internal/command/clusters.go
+++ b/internal/command/clusters.go
@@ -20,10 +20,10 @@ func Clusters() *cobra.Command {
 		clusters.Delete(run, &apiURL),
 		clusters.View(run, &apiURL),
 		clusters.Status(run, &kubeConfig),
-		clusters.Uninstall(run, &kubeConfig),
 		// TODO these commands are currently experimental
 		// clusters.CleanUp(run, kubeConfig),
 		// clusters.Backup(run, kubeConfig),
+		// clusters.Uninstall(run, &kubeConfig),
 	)
 
 	return cmd

--- a/internal/command/clusters/uninstall.go
+++ b/internal/command/clusters/uninstall.go
@@ -31,15 +31,20 @@ func verify(run types.RunFunc, kubeConfigPath string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "verify",
 		Short: "Check that a cluster is ready to have Jetstack Software uninstalled",
-		Args:  cobra.MatchAll(cobra.ExactArgs(0)),
+		Long: `Runs the following checks:
+* Checks secrets containing certificates are safe from garbage collection
+* Checks for any upcoming renewals
+* Checks for certificates currently being issued
+* Checks for stuck certificate requests
+`,
+		Args: cobra.MatchAll(cobra.ExactArgs(0)),
 		Run: run(func(ctx context.Context, args []string) error {
 			kubeCfg, err := kubernetes.NewConfig(kubeConfigPath)
 			if err != nil {
 				return err
 			}
 
-			// first, we need to check that secrets containing certs are safe from
-			// garbage collection
+			fmt.Fprintf(os.Stdout, "Checking certificates are safe from garbage collection...\n")
 			messagesOwnedSecrets := []string{}
 			secretsClient, err := clients.NewGenericClient[*corev1.Secret, *corev1.SecretList](
 				&clients.GenericClientOptions{
@@ -70,7 +75,7 @@ func verify(run types.RunFunc, kubeConfigPath string) *cobra.Command {
 				}
 			}
 
-			// next, check if any certificates are about to be renewed
+			fmt.Fprintf(os.Stdout, "Checking for upcoming certificate renewals...\n")
 			messagesUpcomingRenewals := []string{}
 			upcomingCerts := [][]string{}
 			certificateClient, err := clients.NewCertificateClient(kubeCfg)
@@ -109,7 +114,7 @@ func verify(run types.RunFunc, kubeConfigPath string) *cobra.Command {
 				}
 			}
 
-			// check if any certificates are currently being issued
+			fmt.Fprintf(os.Stdout, "Checking for certificates currently being issued...\n")
 			messagesIssuingCerts := []string{}
 			for _, cert := range certificates.Items {
 				issuing := false
@@ -127,7 +132,7 @@ func verify(run types.RunFunc, kubeConfigPath string) *cobra.Command {
 				}
 			}
 
-			// check for any potentially problematic certificate requests
+			fmt.Fprintf(os.Stdout, "Checking for stuck certificate requests...\n")
 			messagesCertificateRequests := []string{}
 			certificateRequestClient, err := clients.NewCertificateRequestClient(kubeCfg)
 			if err != nil {
@@ -167,9 +172,9 @@ func verify(run types.RunFunc, kubeConfigPath string) *cobra.Command {
 			messagesNextSteps := []string{}
 			if len(messagesOwnedSecrets) > 0 {
 				messagesNextSteps = append(messagesNextSteps, "Run 'jsctl experimental clusters cleanup secrets remove-certificate-owner-refs' to make sure secrets containing certificates are not garbage collected")
-				fmt.Fprintf(os.Stderr, "The following secrets contain certificates and are owned by a Certificate resource:\n")
+				fmt.Fprintf(os.Stdout, "The following secrets contain certificates and are owned by a Certificate resource:\n")
 				for _, message := range messagesOwnedSecrets {
-					fmt.Fprintf(os.Stderr, " * %s\n", message)
+					fmt.Fprintf(os.Stdout, " * %s\n", message)
 				}
 			}
 
@@ -180,34 +185,36 @@ func verify(run types.RunFunc, kubeConfigPath string) *cobra.Command {
 				}
 				messagesNextSteps = append(messagesNextSteps, fmt.Sprintf("Use cmctl to manually renew certificates: %s", strings.Join(cmctlRenewCmds, " && ")))
 
-				fmt.Fprintf(os.Stderr, "The following certificates will be renewed soon:\n")
+				fmt.Fprintf(os.Stdout, "The following certificates will be renewed soon:\n")
 				for _, message := range messagesUpcomingRenewals {
-					fmt.Fprintf(os.Stderr, " * %s\n", message)
+					fmt.Fprintf(os.Stdout, " * %s\n", message)
 				}
 			}
 
 			if len(messagesIssuingCerts) > 0 {
 				messagesNextSteps = append(messagesNextSteps, fmt.Sprintf("Wait for %d certificates to be issued", len(messagesIssuingCerts)))
-				fmt.Fprintf(os.Stderr, "The following certificates are currently being issued:\n")
+				fmt.Fprintf(os.Stdout, "The following certificates are currently being issued:\n")
 				for _, message := range messagesIssuingCerts {
-					fmt.Fprintf(os.Stderr, " * %s\n", message)
+					fmt.Fprintf(os.Stdout, " * %s\n", message)
 				}
 			}
 
 			if len(messagesCertificateRequests) > 0 {
 				messagesNextSteps = append(messagesNextSteps, fmt.Sprintf("Investigate %d pending certificate requests", len(messagesCertificateRequests)))
-				fmt.Fprintf(os.Stderr, "The following certificate requests are pending approval or issuance:\n")
+				fmt.Fprintf(os.Stdout, "The following certificate requests are pending approval or issuance:\n")
 				for _, message := range messagesCertificateRequests {
-					fmt.Fprintf(os.Stderr, " * %s\n", message)
+					fmt.Fprintf(os.Stdout, " * %s\n", message)
 				}
 			}
 
 			// print out any suggested next steps
 			if len(messagesNextSteps) > 0 {
-				fmt.Fprintf(os.Stderr, "\nSuggested next steps:\n")
+				fmt.Fprintf(os.Stdout, "\nSuggested next steps:\n")
 				for _, message := range messagesNextSteps {
-					fmt.Fprintf(os.Stderr, " * %s\n", message)
+					fmt.Fprintf(os.Stdout, " * %s\n", message)
 				}
+			} else {
+				fmt.Fprintf(os.Stdout, "\nNothing to do before uninstalling\n")
 			}
 
 			return nil

--- a/internal/command/clusters/uninstall.go
+++ b/internal/command/clusters/uninstall.go
@@ -350,7 +350,9 @@ func willExpireSoon(cert cmapi.Certificate, buffer time.Duration, nowTime time.T
 
 func isCurrentlyBeingIssued(cert cmapi.Certificate) bool {
 	for _, cond := range cert.Status.Conditions {
-		return cond.Type == cmapi.CertificateConditionIssuing && cond.Status == cmmeta.ConditionTrue
+		if cond.Type == cmapi.CertificateConditionIssuing && cond.Status == cmmeta.ConditionTrue {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/command/clusters/uninstall.go
+++ b/internal/command/clusters/uninstall.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 
@@ -78,7 +78,7 @@ func verify(run types.RunFunc, kubeConfigPath string) *cobra.Command {
 				return fmt.Errorf("error creating certificate client: %s", err)
 			}
 
-			var certificates certmanagerv1.CertificateList
+			var certificates cmapi.CertificateList
 			err = certificateClient.List(
 				ctx,
 				&clients.GenericRequestOptions{},
@@ -115,10 +115,10 @@ func verify(run types.RunFunc, kubeConfigPath string) *cobra.Command {
 				issuing := false
 				ready := false
 				for _, cond := range cert.Status.Conditions {
-					if cond.Type == certmanagerv1.CertificateConditionIssuing && cond.Status == "True" {
+					if cond.Type == cmapi.CertificateConditionIssuing && cond.Status == "True" {
 						issuing = true
 					}
-					if cond.Type == certmanagerv1.CertificateConditionReady && cond.Status == "True" {
+					if cond.Type == cmapi.CertificateConditionReady && cond.Status == "True" {
 						ready = true
 					}
 				}
@@ -133,7 +133,7 @@ func verify(run types.RunFunc, kubeConfigPath string) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("error creating certificate request client: %s", err)
 			}
-			var certificateRequests certmanagerv1.CertificateRequestList
+			var certificateRequests cmapi.CertificateRequestList
 			err = certificateRequestClient.List(
 				ctx,
 				&clients.GenericRequestOptions{},
@@ -145,13 +145,13 @@ func verify(run types.RunFunc, kubeConfigPath string) *cobra.Command {
 			for _, cr := range certificateRequests.Items {
 				ready, denied, approved := false, false, false
 				for _, cond := range cr.Status.Conditions {
-					if cond.Type == certmanagerv1.CertificateRequestConditionReady && cond.Status == "True" {
+					if cond.Type == cmapi.CertificateRequestConditionReady && cond.Status == "True" {
 						ready = true
 					}
-					if cond.Type == certmanagerv1.CertificateRequestConditionDenied && cond.Status == "True" {
+					if cond.Type == cmapi.CertificateRequestConditionDenied && cond.Status == "True" {
 						denied = true
 					}
-					if cond.Type == certmanagerv1.CertificateRequestConditionApproved && cond.Status == "True" {
+					if cond.Type == cmapi.CertificateRequestConditionApproved && cond.Status == "True" {
 						approved = true
 					}
 				}

--- a/internal/command/clusters/uninstall.go
+++ b/internal/command/clusters/uninstall.go
@@ -4,16 +4,36 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/clock"
 
 	"github.com/jetstack/jsctl/internal/command/types"
 	"github.com/jetstack/jsctl/internal/kubernetes"
 	"github.com/jetstack/jsctl/internal/kubernetes/clients"
+	"github.com/jetstack/jsctl/internal/kubernetes/status/components"
+)
+
+const (
+	hasOwnerRefInfoTemplate      = "%s/%s secret has certificate owner ref"
+	hasOwnerRefHeader            = "Secrets with Certificate owner refs were found. These Secrets will be garbage collected when Certificate CRD is uninstalled. You can run 'jsctl experimental clusters cleanup secrets remove-certificate-owner-refs' command to remove the owner references."
+	upcomingRenewalInfoTemplate  = "%s/%s certificate will be renewed soon (%s)"
+	upcomingRenewalInfoHeader    = "Some certificates will be renewed soon. You might want to ensure that uninstall is completed before any renewals kick in. Or use 'cmctl renew' command to renew the certificates now."
+	upcomingExpiriesInfoTemplate = "%s/%s certificate will expire soon (%s)"
+	upcomingExpiriesHeader       = "Some certificates will expire soon. Ensure that enough time is allocated for re-installation to prevent outages. You can use 'cmctl renew' command to manually renew certs now."
+	currentIssuancesInfoTemplate = "%s/%s certificate has issuing condition set to true"
+	currentIssuancesHeader       = "Some certificates are currently being issued. You might want to ensure that issuances complete before starting to uninstall to avoid duplicate requests for certificates."
+	unreadyInfoTemplate          = "%s/%s certificate has ready condition set to false or does not have it"
+	unreadyHeader                = "Some certificates are currently not ready. You might want to fix any issues before upgrading."
+	failedInfoTemplate           = "%s/%s certificate has failed last %d issuance attempts"
+	failedInfoHeader             = "Some certificates are currently failing issuance attempts. You might want to fix any issues before uninstalling."
+	integrationHeader            = "A cert-manager integration that creates certificate requests was found in cluster. You might want to ensure that uninstalling Jetstack Secure software will not cause downtime."
+	integrationInfoTemplate      = "%s found in cluster"
 )
 
 func Uninstall(run types.RunFunc, kubeConfigPath *string) *cobra.Command {
@@ -35,7 +55,9 @@ func verify(run types.RunFunc, kubeConfigPath string) *cobra.Command {
 * Checks secrets containing certificates are safe from garbage collection
 * Checks for any upcoming renewals
 * Checks for certificates currently being issued
-* Checks for stuck certificate requests
+* Checks for certificates that will expire soon
+* Checks for unready certificates
+* Checks for failing issuances
 `,
 		Args: cobra.MatchAll(cobra.ExactArgs(0)),
 		Run: run(func(ctx context.Context, args []string) error {
@@ -44,182 +66,274 @@ func verify(run types.RunFunc, kubeConfigPath string) *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintf(os.Stdout, "Checking certificates are safe from garbage collection...\n")
-			messagesOwnedSecrets := []string{}
-			secretsClient, err := clients.NewGenericClient[*corev1.Secret, *corev1.SecretList](
-				&clients.GenericClientOptions{
-					RestConfig: kubeCfg,
-					APIPath:    "/api/",
-					Group:      corev1.GroupName,
-					Version:    corev1.SchemeGroupVersion.Version,
-					Kind:       "secrets",
-				},
-			)
-
-			var secretsList corev1.SecretList
-			err = secretsClient.List(ctx, &clients.GenericRequestOptions{}, &secretsList)
-
-			for i := range secretsList.Items {
-				secret := &secretsList.Items[i]
-
-				hasCertificateOwnerRef := false
-				for _, ownerRef := range secret.OwnerReferences {
-					if ownerRef.Kind == "Certificate" {
-						hasCertificateOwnerRef = true
-						break
-					}
-				}
-
-				if hasCertificateOwnerRef {
-					messagesOwnedSecrets = append(messagesOwnedSecrets, fmt.Sprintf("%s/%s has certificate owner ref", secret.Namespace, secret.Name))
-				}
-			}
-
-			fmt.Fprintf(os.Stdout, "Checking for upcoming certificate renewals...\n")
-			messagesUpcomingRenewals := []string{}
-			upcomingCerts := [][]string{}
-			certificateClient, err := clients.NewCertificateClient(kubeCfg)
+			clientset, err := buildClients(kubeCfg)
 			if err != nil {
-				return fmt.Errorf("error creating certificate client: %s", err)
+				return fmt.Errorf("error building required clients: %w", err)
 			}
 
-			var certificates cmapi.CertificateList
-			err = certificateClient.List(
-				ctx,
-				&clients.GenericRequestOptions{},
-				&certificates,
-			)
+			realClock := clock.RealClock{}
+			notifications, err := findIssues(ctx, clientset, realClock)
 			if err != nil {
-				return fmt.Errorf("error listing certificates: %s", err)
-			}
-			warnBuffer, err := time.ParseDuration("1h")
-			if err != nil {
-				return fmt.Errorf("error parsing duration, this is a bug: %s", err)
-			}
-			for _, c := range certificates.Items {
-				if c.Status.RenewalTime != nil {
-					if time.Now().Add(warnBuffer).After(c.Status.RenewalTime.Time) {
-						diff := c.Status.RenewalTime.Sub(time.Now())
-						messagesUpcomingRenewals = append(
-							messagesUpcomingRenewals,
-							fmt.Sprintf(
-								"%s/%s will be renewed soon (%s)",
-								c.Namespace,
-								c.Name,
-								diff.String(),
-							),
-						)
-						upcomingCerts = append(upcomingCerts, []string{c.Namespace, c.Name})
-					}
-				}
-			}
-
-			fmt.Fprintf(os.Stdout, "Checking for certificates currently being issued...\n")
-			messagesIssuingCerts := []string{}
-			for _, cert := range certificates.Items {
-				issuing := false
-				ready := false
-				for _, cond := range cert.Status.Conditions {
-					if cond.Type == cmapi.CertificateConditionIssuing && cond.Status == "True" {
-						issuing = true
-					}
-					if cond.Type == cmapi.CertificateConditionReady && cond.Status == "True" {
-						ready = true
-					}
-				}
-				if issuing && !ready {
-					messagesIssuingCerts = append(messagesIssuingCerts, fmt.Sprintf("%s/%s", cert.Namespace, cert.Name))
-				}
-			}
-
-			fmt.Fprintf(os.Stdout, "Checking for stuck certificate requests...\n")
-			messagesCertificateRequests := []string{}
-			certificateRequestClient, err := clients.NewCertificateRequestClient(kubeCfg)
-			if err != nil {
-				return fmt.Errorf("error creating certificate request client: %s", err)
-			}
-			var certificateRequests cmapi.CertificateRequestList
-			err = certificateRequestClient.List(
-				ctx,
-				&clients.GenericRequestOptions{},
-				&certificateRequests,
-			)
-			if err != nil {
-				return fmt.Errorf("error listing certificate requests: %s", err)
-			}
-			for _, cr := range certificateRequests.Items {
-				ready, denied, approved := false, false, false
-				for _, cond := range cr.Status.Conditions {
-					if cond.Type == cmapi.CertificateRequestConditionReady && cond.Status == "True" {
-						ready = true
-					}
-					if cond.Type == cmapi.CertificateRequestConditionDenied && cond.Status == "True" {
-						denied = true
-					}
-					if cond.Type == cmapi.CertificateRequestConditionApproved && cond.Status == "True" {
-						approved = true
-					}
-				}
-				if !approved && !denied {
-					messagesCertificateRequests = append(messagesCertificateRequests, fmt.Sprintf("%s/%s is pending approval", cr.Namespace, cr.Name))
-				}
-				if approved && !ready {
-					messagesCertificateRequests = append(messagesCertificateRequests, fmt.Sprintf("%s/%s is pending issuance", cr.Namespace, cr.Name))
-				}
-			}
-
-			// display information from the data gathered
-			messagesNextSteps := []string{}
-			if len(messagesOwnedSecrets) > 0 {
-				messagesNextSteps = append(messagesNextSteps, "Run 'jsctl experimental clusters cleanup secrets remove-certificate-owner-refs' to make sure secrets containing certificates are not garbage collected")
-				fmt.Fprintf(os.Stdout, "The following secrets contain certificates and are owned by a Certificate resource:\n")
-				for _, message := range messagesOwnedSecrets {
-					fmt.Fprintf(os.Stdout, " * %s\n", message)
-				}
-			}
-
-			if len(messagesUpcomingRenewals) > 0 {
-				cmctlRenewCmds := []string{}
-				for _, cert := range upcomingCerts {
-					cmctlRenewCmds = append(cmctlRenewCmds, fmt.Sprintf("cmctl renew --namespace=%s %s", cert[0], cert[1]))
-				}
-				messagesNextSteps = append(messagesNextSteps, fmt.Sprintf("Use cmctl to manually renew certificates: %s", strings.Join(cmctlRenewCmds, " && ")))
-
-				fmt.Fprintf(os.Stdout, "The following certificates will be renewed soon:\n")
-				for _, message := range messagesUpcomingRenewals {
-					fmt.Fprintf(os.Stdout, " * %s\n", message)
-				}
-			}
-
-			if len(messagesIssuingCerts) > 0 {
-				messagesNextSteps = append(messagesNextSteps, fmt.Sprintf("Wait for %d certificates to be issued", len(messagesIssuingCerts)))
-				fmt.Fprintf(os.Stdout, "The following certificates are currently being issued:\n")
-				for _, message := range messagesIssuingCerts {
-					fmt.Fprintf(os.Stdout, " * %s\n", message)
-				}
-			}
-
-			if len(messagesCertificateRequests) > 0 {
-				messagesNextSteps = append(messagesNextSteps, fmt.Sprintf("Investigate %d pending certificate requests", len(messagesCertificateRequests)))
-				fmt.Fprintf(os.Stdout, "The following certificate requests are pending approval or issuance:\n")
-				for _, message := range messagesCertificateRequests {
-					fmt.Fprintf(os.Stdout, " * %s\n", message)
-				}
+				return fmt.Errorf("error investigating cluster state: %w", err)
 			}
 
 			// print out any suggested next steps
-			if len(messagesNextSteps) > 0 {
-				fmt.Fprintf(os.Stdout, "\nSuggested next steps:\n")
-				for _, message := range messagesNextSteps {
-					fmt.Fprintf(os.Stdout, " * %s\n", message)
+			if len(notifications) > 0 {
+				fmt.Fprintf(os.Stdout, "\nResults:\n")
+				for _, n := range notifications {
+					fmt.Fprintf(os.Stdout, "%s\n", n.header)
+					for _, ri := range n.resourceInfos {
+						fmt.Fprintf(os.Stdout, "	* %s\n", ri)
+					}
 				}
 			} else {
 				fmt.Fprintf(os.Stdout, "\nNothing to do before uninstalling\n")
 			}
-
 			return nil
 		}),
 	}
 
 	return cmd
+}
+
+func findIssues(ctx context.Context, clientset allClients, clock clock.Clock) ([]notification, error) {
+	notifications := []notification{}
+	nowTime := clock.Now()
+
+	// Check all cluster Secrets for potential issues
+	var secretsList corev1.SecretList
+	err := clientset.secrets.List(ctx, &clients.GenericRequestOptions{}, &secretsList)
+	if err != nil {
+		return nil, fmt.Errorf("error listing cluster secrets: %w", err)
+	}
+
+	fmt.Fprintf(os.Stdout, "Checking that issued certificates are safe from garbage collection...\n")
+	ownerRefsNotification := notification{}
+	for i := range secretsList.Items {
+		secret := &secretsList.Items[i]
+
+		hasCertificateOwnerRef := false
+		for _, ownerRef := range secret.OwnerReferences {
+			if ownerRef.Kind == cmapi.CertificateKind {
+				hasCertificateOwnerRef = true
+				break
+			}
+		}
+
+		if hasCertificateOwnerRef {
+			ownerRefsNotification.resourceInfos = append(ownerRefsNotification.resourceInfos, fmt.Sprintf(hasOwnerRefInfoTemplate, secret.Namespace, secret.Name))
+		}
+	}
+
+	if len(ownerRefsNotification.resourceInfos) > 0 {
+		ownerRefsNotification.header = hasOwnerRefHeader
+		notifications = append(notifications, ownerRefsNotification)
+	}
+	var certificates cmapi.CertificateList
+	err = clientset.certificates.List(
+		ctx,
+		&clients.GenericRequestOptions{},
+		&certificates,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error listing certificates: %s", err)
+	}
+
+	// Check all cluster Certificates for potential issues
+	unreadyNotification := notification{}
+	upcomingRenewalsNotification := notification{}
+	upcomingExpiriesNotification := notification{}
+	currentIssuancesNotification := notification{}
+	failedNotification := notification{}
+	renewalWarnBuffer, err := time.ParseDuration("1h")
+	if err != nil {
+		return nil, fmt.Errorf("error parsing duration, this is a bug: %s", err)
+	}
+	expiryWarnBuffer, err := time.ParseDuration("12h")
+	if err != nil {
+		return nil, fmt.Errorf("error parsing duration, this is a bug: %s", err)
+	}
+	for _, cert := range certificates.Items {
+		if isUnReady(cert) {
+			unreadyNotification.resourceInfos = append(unreadyNotification.resourceInfos, fmt.Sprintf(unreadyInfoTemplate, cert.Namespace, cert.Name))
+		}
+		if willBeRenewedSoon(cert, renewalWarnBuffer, nowTime) {
+			upcomingRenewalsNotification.resourceInfos = append(
+				upcomingRenewalsNotification.resourceInfos,
+				fmt.Sprintf(
+					upcomingRenewalInfoTemplate,
+					cert.Namespace,
+					cert.Name,
+					cert.Status.RenewalTime.Time,
+				),
+			)
+		}
+		if willExpireSoon(cert, expiryWarnBuffer, nowTime) {
+			upcomingExpiriesNotification.resourceInfos = append(
+				upcomingExpiriesNotification.resourceInfos,
+				fmt.Sprintf(
+					upcomingExpiriesInfoTemplate,
+					cert.Namespace,
+					cert.Name,
+					cert.Status.NotAfter.Time,
+				),
+			)
+		}
+		if isCurrentlyBeingIssued(cert) {
+			currentIssuancesNotification.resourceInfos = append(currentIssuancesNotification.resourceInfos, fmt.Sprintf(currentIssuancesInfoTemplate, cert.Namespace, cert.Name))
+
+		}
+		if isCurrentlyFailingIssuance(cert) {
+			failedAttempts := cert.Status.FailedIssuanceAttempts
+			failedNotification.resourceInfos = append(failedNotification.resourceInfos, fmt.Sprintf(failedInfoTemplate, cert.Namespace, cert.Name, *failedAttempts))
+		}
+	}
+	if len(unreadyNotification.resourceInfos) > 0 {
+		unreadyNotification.header = unreadyHeader
+		notifications = append(notifications, unreadyNotification)
+	}
+	if len(upcomingRenewalsNotification.resourceInfos) > 0 {
+		upcomingRenewalsNotification.header = upcomingRenewalInfoHeader
+		notifications = append(notifications, upcomingRenewalsNotification)
+	}
+	if len(upcomingExpiriesNotification.resourceInfos) > 0 {
+		upcomingExpiriesNotification.header = upcomingExpiriesHeader
+		notifications = append(notifications, upcomingExpiriesNotification)
+	}
+	if len(currentIssuancesNotification.resourceInfos) > 0 {
+		currentIssuancesNotification.header = currentIssuancesHeader
+		notifications = append(notifications, currentIssuancesNotification)
+	}
+	if len(failedNotification.resourceInfos) > 0 {
+		failedNotification.header = failedInfoHeader
+		notifications = append(notifications, failedNotification)
+	}
+
+	// Check whether cert-manager-csi-driver, cert-manager-csi-driver-spiffe and/or istio-csr are installed in cluster
+	// There aren't really any non-parameterizable values in csi-driver or
+	// istio-csr Helm charts so we use image names.
+	pods := &corev1.PodList{}
+	err = clientset.pods.List(ctx, &clients.GenericRequestOptions{}, pods)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pods: %s", err)
+	}
+	md := &components.MatchData{
+		Pods: pods.Items,
+	}
+	certManagerIntegrationsNotification := notification{}
+	s := &components.CertManagerCSIDriverSPIFFEStatus{}
+	found, err := s.Match(md)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detemine if cert-manager-csi-driver-spiffe exists: %w", err)
+	}
+	if found {
+		certManagerIntegrationsNotification.resourceInfos = append(certManagerIntegrationsNotification.resourceInfos, fmt.Sprintf(integrationInfoTemplate, "cert-manager-csi-driver-spiffe"))
+	}
+	c := &components.CertManagerCSIDriverStatus{}
+	found, err = c.Match(md)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detemine if cert-manager-csi-driver exists: %w", err)
+	}
+	if found {
+		certManagerIntegrationsNotification.resourceInfos = append(certManagerIntegrationsNotification.resourceInfos, fmt.Sprintf(integrationInfoTemplate, "cert-manager-csi-driver"))
+	}
+	i := &components.CertManagerIstioCSRStatus{}
+	found, err = i.Match(md)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detemine if istio-csr exists: %w", err)
+	}
+	if found {
+		certManagerIntegrationsNotification.resourceInfos = append(certManagerIntegrationsNotification.resourceInfos, fmt.Sprintf(integrationInfoTemplate, "cert-manager-istio-csr"))
+	}
+	if len(certManagerIntegrationsNotification.resourceInfos) > 0 {
+		certManagerIntegrationsNotification.header = integrationHeader
+		notifications = append(notifications, certManagerIntegrationsNotification)
+	}
+
+	return notifications, nil
+}
+
+// Notification holds information about a particular type of issue related to
+// uninstallation safety affecting a subset of resources in cluster
+type notification struct {
+	// header holds generic info about the issue and the suggested fix
+	header string
+	// listing of the affected resources with any additional related info
+	resourceInfos []string
+}
+
+func buildClients(kubeconfig *rest.Config) (allClients, error) {
+	secretsClient, err := clients.NewGenericClient[*corev1.Secret, *corev1.SecretList](
+		&clients.GenericClientOptions{
+			RestConfig: kubeconfig,
+			APIPath:    "/api/",
+			Group:      corev1.GroupName,
+			Version:    corev1.SchemeGroupVersion.Version,
+			Kind:       "secrets",
+		},
+	)
+	if err != nil {
+		return allClients{}, fmt.Errorf("error creating new secrets client: %w", err)
+	}
+
+	certsClient, err := clients.NewCertificateClient(kubeconfig)
+	if err != nil {
+		return allClients{}, fmt.Errorf("error creating new cert-manager.io client: %w", err)
+	}
+	podClient, err := clients.NewGenericClient[*corev1.Pod, *corev1.PodList](
+		&clients.GenericClientOptions{
+			RestConfig: kubeconfig,
+			APIPath:    "/api/",
+			Group:      corev1.GroupName,
+			Version:    corev1.SchemeGroupVersion.Version,
+			Kind:       "pods",
+		},
+	)
+	if err != nil {
+		return allClients{}, fmt.Errorf("error creating new pods client: %w", err)
+	}
+	return allClients{
+		certificates: certsClient,
+		secrets:      secretsClient,
+		pods:         podClient,
+	}, nil
+}
+
+type allClients struct {
+	secrets      clients.Generic[*corev1.Secret, *corev1.SecretList]
+	certificates clients.Generic[*cmapi.Certificate, *cmapi.CertificateList]
+	pods         clients.Generic[*corev1.Pod, *corev1.PodList]
+}
+
+func isUnReady(cert cmapi.Certificate) bool {
+	hasReady := false
+	for _, cond := range cert.Status.Conditions {
+		if cond.Type == cmapi.CertificateConditionReady {
+			hasReady = true
+			if cond.Status == cmmeta.ConditionFalse {
+				return true
+			}
+		}
+	}
+	return !hasReady
+}
+
+func willBeRenewedSoon(cert cmapi.Certificate, buffer time.Duration, nowTime time.Time) bool {
+	return cert.Status.RenewalTime != nil && nowTime.Add(buffer).After(cert.Status.RenewalTime.Time)
+}
+
+func willExpireSoon(cert cmapi.Certificate, buffer time.Duration, nowTime time.Time) bool {
+	return cert.Status.NotAfter != nil && nowTime.Add(buffer).After(cert.Status.NotAfter.Time)
+}
+
+func isCurrentlyBeingIssued(cert cmapi.Certificate) bool {
+	for _, cond := range cert.Status.Conditions {
+		return cond.Type == cmapi.CertificateConditionIssuing && cond.Status == cmmeta.ConditionTrue
+	}
+	return false
+}
+
+func isCurrentlyFailingIssuance(cert cmapi.Certificate) bool {
+	failedAttempts := cert.Status.FailedIssuanceAttempts
+	return cert.Status.FailedIssuanceAttempts != nil && *failedAttempts > 0
 }

--- a/internal/command/clusters/uninstall.go
+++ b/internal/command/clusters/uninstall.go
@@ -160,7 +160,7 @@ func findIssues(ctx context.Context, clientset allClients, clock clock.Clock) ([
 	fmt.Fprintf(os.Stdout, "	* Checking for currently failing issuances\n")
 	fmt.Fprintf(os.Stdout, "	* Checking for unready Certificates\n")
 	for _, cert := range certificates.Items {
-		if isUnReady(cert) {
+		if isUnready(cert) {
 			unreadyNotification.resourceInfos = append(unreadyNotification.resourceInfos, fmt.Sprintf(unreadyInfoTemplate, cert.Namespace, cert.Name))
 		}
 		if willBeRenewedSoon(cert, renewalWarnBuffer, nowTime) {
@@ -315,7 +315,7 @@ type allClients struct {
 	pods         clients.Generic[*corev1.Pod, *corev1.PodList]
 }
 
-func isUnReady(cert cmapi.Certificate) bool {
+func isUnready(cert cmapi.Certificate) bool {
 	hasReady := false
 	for _, cond := range cert.Status.Conditions {
 		if cond.Type == cmapi.CertificateConditionReady {

--- a/internal/command/clusters/uninstall.go
+++ b/internal/command/clusters/uninstall.go
@@ -1,0 +1,218 @@
+package clusters
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/jetstack/jsctl/internal/command/types"
+	"github.com/jetstack/jsctl/internal/kubernetes"
+	"github.com/jetstack/jsctl/internal/kubernetes/clients"
+)
+
+func Uninstall(run types.RunFunc, kubeConfigPath *string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Contains commands to check a cluster before the uninstallation of Jetstack Secure software",
+	}
+
+	cmd.AddCommand(verify(run, *kubeConfigPath))
+
+	return cmd
+}
+
+func verify(run types.RunFunc, kubeConfigPath string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "verify",
+		Short: "Check that a cluster is ready to have Jetstack Software uninstalled",
+		Args:  cobra.MatchAll(cobra.ExactArgs(0)),
+		Run: run(func(ctx context.Context, args []string) error {
+			kubeCfg, err := kubernetes.NewConfig(kubeConfigPath)
+			if err != nil {
+				return err
+			}
+
+			// first, we need to check that secrets containing certs are safe from
+			// garbage collection
+			messagesOwnedSecrets := []string{}
+			secretsClient, err := clients.NewGenericClient[*corev1.Secret, *corev1.SecretList](
+				&clients.GenericClientOptions{
+					RestConfig: kubeCfg,
+					APIPath:    "/api/",
+					Group:      corev1.GroupName,
+					Version:    corev1.SchemeGroupVersion.Version,
+					Kind:       "secrets",
+				},
+			)
+
+			var secretsList corev1.SecretList
+			err = secretsClient.List(ctx, &clients.GenericRequestOptions{}, &secretsList)
+
+			for i := range secretsList.Items {
+				secret := &secretsList.Items[i]
+
+				hasCertificateOwnerRef := false
+				for _, ownerRef := range secret.OwnerReferences {
+					if ownerRef.Kind == "Certificate" {
+						hasCertificateOwnerRef = true
+						break
+					}
+				}
+
+				if hasCertificateOwnerRef {
+					messagesOwnedSecrets = append(messagesOwnedSecrets, fmt.Sprintf("%s/%s has certificate owner ref", secret.Namespace, secret.Name))
+				}
+			}
+
+			// next, check if any certificates are about to be renewed
+			messagesUpcomingRenewals := []string{}
+			upcomingCerts := [][]string{}
+			certificateClient, err := clients.NewCertificateClient(kubeCfg)
+			if err != nil {
+				return fmt.Errorf("error creating certificate client: %s", err)
+			}
+
+			var certificates certmanagerv1.CertificateList
+			err = certificateClient.List(
+				ctx,
+				&clients.GenericRequestOptions{},
+				&certificates,
+			)
+			if err != nil {
+				return fmt.Errorf("error listing certificates: %s", err)
+			}
+			warnBuffer, err := time.ParseDuration("1h")
+			if err != nil {
+				return fmt.Errorf("error parsing duration, this is a bug: %s", err)
+			}
+			for _, c := range certificates.Items {
+				if c.Status.RenewalTime != nil {
+					if time.Now().Add(warnBuffer).After(c.Status.RenewalTime.Time) {
+						diff := c.Status.RenewalTime.Sub(time.Now())
+						messagesUpcomingRenewals = append(
+							messagesUpcomingRenewals,
+							fmt.Sprintf(
+								"%s/%s will be renewed soon (%s)",
+								c.Namespace,
+								c.Name,
+								diff.String(),
+							),
+						)
+						upcomingCerts = append(upcomingCerts, []string{c.Namespace, c.Name})
+					}
+				}
+			}
+
+			// check if any certificates are currently being issued
+			messagesIssuingCerts := []string{}
+			for _, cert := range certificates.Items {
+				issuing := false
+				ready := false
+				for _, cond := range cert.Status.Conditions {
+					if cond.Type == certmanagerv1.CertificateConditionIssuing && cond.Status == "True" {
+						issuing = true
+					}
+					if cond.Type == certmanagerv1.CertificateConditionReady && cond.Status == "True" {
+						ready = true
+					}
+				}
+				if issuing && !ready {
+					messagesIssuingCerts = append(messagesIssuingCerts, fmt.Sprintf("%s/%s", cert.Namespace, cert.Name))
+				}
+			}
+
+			// check for any potentially problematic certificate requests
+			messagesCertificateRequests := []string{}
+			certificateRequestClient, err := clients.NewCertificateRequestClient(kubeCfg)
+			if err != nil {
+				return fmt.Errorf("error creating certificate request client: %s", err)
+			}
+			var certificateRequests certmanagerv1.CertificateRequestList
+			err = certificateRequestClient.List(
+				ctx,
+				&clients.GenericRequestOptions{},
+				&certificateRequests,
+			)
+			if err != nil {
+				return fmt.Errorf("error listing certificate requests: %s", err)
+			}
+			for _, cr := range certificateRequests.Items {
+				ready, denied, approved := false, false, false
+				for _, cond := range cr.Status.Conditions {
+					if cond.Type == certmanagerv1.CertificateRequestConditionReady && cond.Status == "True" {
+						ready = true
+					}
+					if cond.Type == certmanagerv1.CertificateRequestConditionDenied && cond.Status == "True" {
+						denied = true
+					}
+					if cond.Type == certmanagerv1.CertificateRequestConditionApproved && cond.Status == "True" {
+						approved = true
+					}
+				}
+				if !approved && !denied {
+					messagesCertificateRequests = append(messagesCertificateRequests, fmt.Sprintf("%s/%s is pending approval", cr.Namespace, cr.Name))
+				}
+				if approved && !ready {
+					messagesCertificateRequests = append(messagesCertificateRequests, fmt.Sprintf("%s/%s is pending issuance", cr.Namespace, cr.Name))
+				}
+			}
+
+			// display information from the data gathered
+			messagesNextSteps := []string{}
+			if len(messagesOwnedSecrets) > 0 {
+				messagesNextSteps = append(messagesNextSteps, "Run 'jsctl experimental clusters cleanup secrets remove-certificate-owner-refs' to make sure secrets containing certificates are not garbage collected")
+				fmt.Fprintf(os.Stderr, "The following secrets contain certificates and are owned by a Certificate resource:\n")
+				for _, message := range messagesOwnedSecrets {
+					fmt.Fprintf(os.Stderr, " * %s\n", message)
+				}
+			}
+
+			if len(messagesUpcomingRenewals) > 0 {
+				cmctlRenewCmds := []string{}
+				for _, cert := range upcomingCerts {
+					cmctlRenewCmds = append(cmctlRenewCmds, fmt.Sprintf("cmctl renew --namespace=%s %s", cert[0], cert[1]))
+				}
+				messagesNextSteps = append(messagesNextSteps, fmt.Sprintf("Use cmctl to manually renew certificates: %s", strings.Join(cmctlRenewCmds, " && ")))
+
+				fmt.Fprintf(os.Stderr, "The following certificates will be renewed soon:\n")
+				for _, message := range messagesUpcomingRenewals {
+					fmt.Fprintf(os.Stderr, " * %s\n", message)
+				}
+			}
+
+			if len(messagesIssuingCerts) > 0 {
+				messagesNextSteps = append(messagesNextSteps, fmt.Sprintf("Wait for %d certificates to be issued", len(messagesIssuingCerts)))
+				fmt.Fprintf(os.Stderr, "The following certificates are currently being issued:\n")
+				for _, message := range messagesIssuingCerts {
+					fmt.Fprintf(os.Stderr, " * %s\n", message)
+				}
+			}
+
+			if len(messagesCertificateRequests) > 0 {
+				messagesNextSteps = append(messagesNextSteps, fmt.Sprintf("Investigate %d pending certificate requests", len(messagesCertificateRequests)))
+				fmt.Fprintf(os.Stderr, "The following certificate requests are pending approval or issuance:\n")
+				for _, message := range messagesCertificateRequests {
+					fmt.Fprintf(os.Stderr, " * %s\n", message)
+				}
+			}
+
+			// print out any suggested next steps
+			if len(messagesNextSteps) > 0 {
+				fmt.Fprintf(os.Stderr, "\nSuggested next steps:\n")
+				for _, message := range messagesNextSteps {
+					fmt.Fprintf(os.Stderr, " * %s\n", message)
+				}
+			}
+
+			return nil
+		}),
+	}
+
+	return cmd
+}

--- a/internal/command/clusters/uninstall_test.go
+++ b/internal/command/clusters/uninstall_test.go
@@ -1,0 +1,357 @@
+package clusters
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/pointer"
+
+	"github.com/jetstack/jsctl/internal/kubernetes/clients"
+)
+
+func Test_findIssues(t *testing.T) {
+	fakeClock := fakeclock.FakeClock{}
+	fooPod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "foo",
+				},
+			},
+		},
+	}
+	fooSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+	}
+	readyCert := cmapi.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       cmapi.CertificateKind,
+			APIVersion: "v1",
+		},
+		Status: cmapi.CertificateStatus{
+			Conditions: []cmapi.CertificateCondition{
+				{
+					Type:   cmapi.CertificateConditionReady,
+					Status: cmmeta.ConditionTrue,
+				},
+			},
+		},
+	}
+	tests := map[string]struct {
+		want            []notification
+		wantErr         bool
+		podList         *corev1.PodList
+		secretList      *corev1.SecretList
+		certificateList *cmapi.CertificateList
+	}{
+		"cluster that has no cert-manager related resources does not produce any notifications": {
+			podList:         &corev1.PodList{Items: []corev1.Pod{fooPod}},
+			secretList:      &corev1.SecretList{Items: []corev1.Secret{fooSecret}},
+			certificateList: &cmapi.CertificateList{Items: nil},
+			want:            []notification{},
+		},
+		"cluster that has some ready certs should not produce any notifications": {
+			podList:         &corev1.PodList{Items: []corev1.Pod{fooPod}},
+			secretList:      &corev1.SecretList{Items: []corev1.Secret{fooSecret}},
+			certificateList: &cmapi.CertificateList{Items: []cmapi.Certificate{readyCert}},
+			want:            []notification{},
+		},
+		"cluster that has a cert with false ready condition should produce a notification": {
+			podList:    &corev1.PodList{Items: []corev1.Pod{fooPod}},
+			secretList: &corev1.SecretList{Items: []corev1.Secret{fooSecret}},
+			certificateList: &cmapi.CertificateList{Items: []cmapi.Certificate{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "foo",
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       cmapi.CertificateKind,
+					APIVersion: "v1",
+				},
+				Status: cmapi.CertificateStatus{
+					Conditions: []cmapi.CertificateCondition{{
+						Type:   cmapi.CertificateConditionReady,
+						Status: cmmeta.ConditionFalse,
+					},
+					},
+				},
+			}}},
+			want: []notification{{
+				header:        unreadyHeader,
+				resourceInfos: []string{fmt.Sprintf(unreadyInfoTemplate, "foo", "foo")},
+			}},
+		},
+		"cluster that has a cert without a ready condition should produce a notification": {
+			podList:    &corev1.PodList{Items: []corev1.Pod{fooPod}},
+			secretList: &corev1.SecretList{Items: []corev1.Secret{fooSecret}},
+			certificateList: &cmapi.CertificateList{Items: []cmapi.Certificate{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "foo",
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       cmapi.CertificateKind,
+					APIVersion: "v1",
+				},
+				Status: cmapi.CertificateStatus{},
+			}}},
+			want: []notification{{
+				header:        unreadyHeader,
+				resourceInfos: []string{fmt.Sprintf(unreadyInfoTemplate, "foo", "foo")},
+			}},
+		},
+		"cluster that has a cert that is currently being issued should produce a notification": {
+			podList:    &corev1.PodList{Items: []corev1.Pod{fooPod}},
+			secretList: &corev1.SecretList{Items: []corev1.Secret{fooSecret}},
+			certificateList: &cmapi.CertificateList{Items: []cmapi.Certificate{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "foo",
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       cmapi.CertificateKind,
+					APIVersion: "v1",
+				},
+				Status: cmapi.CertificateStatus{
+					Conditions: []cmapi.CertificateCondition{{
+						Type:   cmapi.CertificateConditionIssuing,
+						Status: cmmeta.ConditionTrue,
+					},
+						{
+							Type:   cmapi.CertificateConditionReady,
+							Status: cmmeta.ConditionTrue,
+						},
+					},
+				},
+			}}},
+			want: []notification{{
+				header:        currentIssuancesHeader,
+				resourceInfos: []string{fmt.Sprintf(currentIssuancesInfoTemplate, "foo", "foo")},
+			}},
+		},
+		"cluster that has a cert that failed issuance for latest renewal cycle should produce a notification": {
+			podList:    &corev1.PodList{Items: []corev1.Pod{fooPod}},
+			secretList: &corev1.SecretList{Items: []corev1.Secret{fooSecret}},
+			certificateList: &cmapi.CertificateList{Items: []cmapi.Certificate{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "foo",
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       cmapi.CertificateKind,
+					APIVersion: "v1",
+				},
+				Status: cmapi.CertificateStatus{
+					FailedIssuanceAttempts: pointer.Int(2),
+					Conditions: []cmapi.CertificateCondition{{
+						Type:   cmapi.CertificateConditionIssuing,
+						Status: cmmeta.ConditionFalse,
+					},
+						{
+							Type:   cmapi.CertificateConditionReady,
+							Status: cmmeta.ConditionTrue,
+						},
+					},
+				},
+			}}},
+			want: []notification{{
+				header:        failedInfoHeader,
+				resourceInfos: []string{fmt.Sprintf(failedInfoTemplate, "foo", "foo", 2)},
+			}},
+		},
+		"cluster that has a cert that is about to be renewed should produce a notification": {
+			podList:    &corev1.PodList{Items: []corev1.Pod{fooPod}},
+			secretList: &corev1.SecretList{Items: []corev1.Secret{fooSecret}},
+			certificateList: &cmapi.CertificateList{Items: []cmapi.Certificate{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "foo",
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       cmapi.CertificateKind,
+					APIVersion: "v1",
+				},
+				Status: cmapi.CertificateStatus{
+					RenewalTime: &metav1.Time{Time: fakeClock.Now().Add(time.Minute)},
+					Conditions: []cmapi.CertificateCondition{
+						{
+							Type:   cmapi.CertificateConditionReady,
+							Status: cmmeta.ConditionTrue,
+						},
+					},
+				},
+			}}},
+			want: []notification{{
+				header:        upcomingRenewalInfoHeader,
+				resourceInfos: []string{fmt.Sprintf(upcomingRenewalInfoTemplate, "foo", "foo", fakeClock.Now().Add(time.Minute))},
+			}},
+		},
+		"cluster that has a cert that is about to expire should produce a notification": {
+			podList:    &corev1.PodList{Items: []corev1.Pod{fooPod}},
+			secretList: &corev1.SecretList{Items: []corev1.Secret{fooSecret}},
+			certificateList: &cmapi.CertificateList{Items: []cmapi.Certificate{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "foo",
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       cmapi.CertificateKind,
+					APIVersion: "v1",
+				},
+				Status: cmapi.CertificateStatus{
+					NotAfter: &metav1.Time{Time: fakeClock.Now().Add(time.Minute)},
+					Conditions: []cmapi.CertificateCondition{
+						{
+							Type:   cmapi.CertificateConditionReady,
+							Status: cmmeta.ConditionTrue,
+						},
+					},
+				},
+			}}},
+			want: []notification{{
+				header:        upcomingExpiriesHeader,
+				resourceInfos: []string{fmt.Sprintf(upcomingExpiriesInfoTemplate, "foo", "foo", fakeClock.Now().Add(time.Minute))},
+			}},
+		},
+		"cluster that has an issued cert that would get garbage collected if cert-manager is uninstalled should produce a notification": {
+			podList: &corev1.PodList{Items: []corev1.Pod{fooPod}},
+			secretList: &corev1.SecretList{Items: []corev1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "foo",
+					OwnerReferences: []metav1.OwnerReference{{
+						Kind: "Certificate",
+					}},
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Secret",
+					APIVersion: "v1",
+				},
+			}}},
+			certificateList: &cmapi.CertificateList{Items: nil},
+			want: []notification{{
+				header:        hasOwnerRefHeader,
+				resourceInfos: []string{fmt.Sprintf(hasOwnerRefInfoTemplate, "foo", "foo")},
+			}},
+		},
+		"cluster that appears to have cert-manager-csi-driver installed should produce a warning": {
+			podList: &corev1.PodList{Items: []corev1.Pod{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Pod",
+						APIVersion: "v1",
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Image: "quay.io/cert-manager-csi-driver:v0.0.5",
+						}},
+					},
+				},
+			}},
+			secretList:      &corev1.SecretList{Items: nil},
+			certificateList: &cmapi.CertificateList{Items: nil},
+			want: []notification{{
+				header:        integrationHeader,
+				resourceInfos: []string{fmt.Sprintf(integrationInfoTemplate, "cert-manager-csi-driver")},
+			}},
+		},
+		"cluster that appears to have cert-manager-csi-driver-spiffe installed should produce a warning": {
+			podList: &corev1.PodList{Items: []corev1.Pod{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Pod",
+						APIVersion: "v1",
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Image: "quay.io/cert-manager-csi-driver-spiffe:v0.0.5",
+						}},
+					},
+				},
+			}},
+			secretList:      &corev1.SecretList{Items: nil},
+			certificateList: &cmapi.CertificateList{Items: nil},
+			want: []notification{{
+				header:        integrationHeader,
+				resourceInfos: []string{fmt.Sprintf(integrationInfoTemplate, "cert-manager-csi-driver-spiffe")},
+			}},
+		},
+		"cluster that appears to have cert-manager-istio-csr installed should produce a warning": {
+			podList: &corev1.PodList{Items: []corev1.Pod{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Pod",
+						APIVersion: "v1",
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Image: "quay.io/cert-manager-istio-csr:v0.0.5",
+						}},
+					},
+				},
+			}},
+			secretList:      &corev1.SecretList{Items: nil},
+			certificateList: &cmapi.CertificateList{Items: nil},
+			want: []notification{{
+				header:        integrationHeader,
+				resourceInfos: []string{fmt.Sprintf(integrationInfoTemplate, "cert-manager-istio-csr")},
+			}},
+		},
+	}
+	for name, scenario := range tests {
+		t.Run(name, func(t *testing.T) {
+			clientset := allClients{
+				secrets: &clients.FakeGeneric[*corev1.Secret, *corev1.SecretList]{
+					FakeList: func(_ context.Context, _ *clients.GenericRequestOptions, result *corev1.SecretList) error {
+						result.Items = scenario.secretList.Items
+						return nil
+					},
+				},
+				pods: &clients.FakeGeneric[*corev1.Pod, *corev1.PodList]{
+					FakeList: func(_ context.Context, _ *clients.GenericRequestOptions, result *corev1.PodList) error {
+						result.Items = scenario.podList.Items
+						return nil
+					},
+				},
+				certificates: &clients.FakeGeneric[*cmapi.Certificate, *cmapi.CertificateList]{
+					FakeList: func(_ context.Context, _ *clients.GenericRequestOptions, result *cmapi.CertificateList) error {
+						result.Items = scenario.certificateList.Items
+						return nil
+					},
+				},
+			}
+			got, err := findIssues(context.Background(), clientset, &fakeClock)
+			if (err != nil) != scenario.wantErr {
+				t.Errorf("findIssues() error = %v, wantErr %v", err, scenario.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, scenario.want) {
+				t.Errorf("findIssues() = %v, want %v", got, scenario.want)
+			}
+		})
+	}
+}

--- a/internal/command/experimental.go
+++ b/internal/command/experimental.go
@@ -23,6 +23,7 @@ func Experimental() *cobra.Command {
 	experimentalClustersCommands.AddCommand(
 		clusters.CleanUp(run, &kubeConfig),
 		clusters.Backup(run, &kubeConfig),
+		clusters.Uninstall(run, &kubeConfig),
 	)
 
 	cmd.AddCommand(experimentalClustersCommands)


### PR DESCRIPTION
This PR is part of working on the flow defined in https://docs.google.com/document/d/1AxUss0piE9gb_r31_jBS6mv7zWALDqI0ZIfBUiJj3p0/edit?usp=sharing

Example output in a cluster that has cert-manager-csi-driver, cert-manager-csi-driver-spiffe, cert-manager-istio-csr, a Secret with Certificate owner ref, a Certificate that will be renewed and will expire soon:
```
irbe@jsctl$ go run main.go x clusters uninstall verify
Running checks against cluster Secrets:
        * Checking that issued certificates are safe from garbage collection...
Running checks against cluster Certificates:
        * Checking for upcoming renewals
        * Checking for upcoming expiries
        * Checking for currently failing issuances
        * Checking for unready Certificates
Running checks against cert-manager integrations installed in cluster:
        * Checking for cert-manager-istio-csr
        * Checking for cert-manager-csi-driver
        * Checking for cert-manager-csi-driver-spiffe

Results:
Secrets with Certificate owner refs were found. These Secrets will be garbage collected when Certificate CRD is uninstalled.
You can run 'jsctl experimental clusters cleanup secrets remove-certificate-owner-refs' command to remove the owner references.
        * istio-system/ca-secret secret has certificate owner ref
        * istio-system/istiod-tls secret has certificate owner ref
        * jetstack-secure/foo secret has certificate owner ref
        * jetstack-secure/spiffe-ca secret has certificate owner ref
Some certificates will be renewed soon. You might want to ensure that uninstall is completed before any renewals kick in. Or use 'cmctl renew' command to renew the certificates now.
        * istio-system/istiod certificate will be renewed soon (2023-02-07 08:41:28 +0000 GMT)
        * jetstack-secure/foo certificate will be renewed soon (2023-02-07 08:43:12 +0000 GMT)
Some certificates will expire soon. Ensure that enough time is allocated for re-installation to prevent outages. You can use 'cmctl renew' command to manually renew certs now.
        * istio-system/istiod certificate will expire soon (2023-02-07 09:11:28 +0000 GMT)
        * jetstack-secure/foo certificate will expire soon (2023-02-07 09:33:12 +0000 GMT)
A cert-manager integration that creates certificate requests was found in cluster. You might want to ensure that uninstalling Jetstack Secure software will not cause downtime.
        * cert-manager-csi-driver-spiffe found in cluster
        * cert-manager-csi-driver found in cluster
        * cert-manager-istio-csr found in cluster
```

