### PR TITLE
Fix group for VEI issuers

### DIFF
--- a/internal/kubernetes/backup/backup.go
+++ b/internal/kubernetes/backup/backup.go
@@ -96,7 +96,11 @@ func FetchClusterBackup(ctx context.Context, opts ClusterBackupOptions) (*Cluste
 	if err != nil {
 		return nil, fmt.Errorf("failed to list CRDs to determine the cert-manager API version in use: %s", err)
 	}
+	policyCRDsFound := false
 	for _, crd := range crds.Items {
+		if crd.Spec.Group == v1alpha1approverpolicy.SchemeGroupVersion.Group {
+			policyCRDsFound = true
+		}
 		if crd.Spec.Group != "cert-manager.io" {
 			continue
 		}
@@ -161,7 +165,7 @@ func FetchClusterBackup(ctx context.Context, opts ClusterBackupOptions) (*Cluste
 	// fetch certificate request policies
 	// Note: this back up data is not used in the migration to an operator managed installation.
 	// These resourcse are only included for disaster recovery purposes.
-	if opts.IncludeCertificateRequestPolicies {
+	if policyCRDsFound && opts.IncludeCertificateRequestPolicies {
 		certificateRequestPolicyClient, err := clients.NewCertificateRequestPolicyClient(opts.RestConfig)
 		if err != nil {
 			return &ClusterBackup{}, fmt.Errorf("failed to create client for certificate request policies: %w", err)

--- a/internal/kubernetes/status/status.go
+++ b/internal/kubernetes/status/status.go
@@ -376,7 +376,7 @@ func findIssuers(ctx context.Context, cfg *rest.Config) ([]summaryIssuer, error)
 			}
 			for _, issuer := range issuers.Items {
 				summaryIssuers = append(summaryIssuers, summaryIssuer{
-					APIVersion: veiv1alpha1.SchemeGroupVersion.Group,
+					APIVersion: veiv1alpha1.SchemeGroupVersion.String(),
 					Name:       issuer.Name,
 					Namespace:  issuer.Namespace,
 					Kind:       issuer.Kind,
@@ -394,7 +394,7 @@ func findIssuers(ctx context.Context, cfg *rest.Config) ([]summaryIssuer, error)
 			}
 			for _, issuer := range issuers.Items {
 				summaryIssuers = append(summaryIssuers, summaryIssuer{
-					APIVersion: veiv1alpha1.SchemeGroupVersion.Group,
+					APIVersion: veiv1alpha1.SchemeGroupVersion.String(),
 					Name:       issuer.Name,
 					Kind:       issuer.Kind,
 				})

--- a/internal/kubernetes/status/status.go
+++ b/internal/kubernetes/status/status.go
@@ -376,7 +376,7 @@ func findIssuers(ctx context.Context, cfg *rest.Config) ([]summaryIssuer, error)
 			}
 			for _, issuer := range issuers.Items {
 				summaryIssuers = append(summaryIssuers, summaryIssuer{
-					APIVersion: kmsissuerv1alpha1.GroupVersion.String(),
+					APIVersion: veiv1alpha1.SchemeGroupVersion.Group,
 					Name:       issuer.Name,
 					Namespace:  issuer.Namespace,
 					Kind:       issuer.Kind,
@@ -394,7 +394,7 @@ func findIssuers(ctx context.Context, cfg *rest.Config) ([]summaryIssuer, error)
 			}
 			for _, issuer := range issuers.Items {
 				summaryIssuers = append(summaryIssuers, summaryIssuer{
-					APIVersion: kmsissuerv1alpha1.GroupVersion.String(),
+					APIVersion: veiv1alpha1.SchemeGroupVersion.Group,
 					Name:       issuer.Name,
 					Kind:       issuer.Kind,
 				})


### PR DESCRIPTION
This fixes a typo where the wrong API group was being used in a command that lists Venafi Enhanced issuers in cluster.


Signed-off-by: irbekrm <irbekrm@gmail.com>