### PR TITLE
Add script to install the latest version of jsctl

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,6 @@ builds:
     - linux
     goarch:
     - amd64
-    - arm
     - arm64
   - id: "darwin"
     env:
@@ -45,41 +44,29 @@ builds:
     - windows
     goarch:
     - amd64
-    - "386"
     - arm64
 archives:
   - id: linux
     format: tar.gz
-    name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
     wrap_in_directory: true
     builds:
     - "linux"
-    replacements:
-      arm: armv7l
-      arm64: aarch64
-      amd64: x86_64
   - id: darwin
     format: tar.gz
-    name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
     wrap_in_directory: true
     builds:
     - "darwin"
-    replacements:
-      arm: armv7l
-      amd64: x86_64
   - id: windows
     format: tar.gz
-    name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
     wrap_in_directory: true
     builds:
     - "windows"
-    replacements:
-      arm64: Arm64
-      amd64: 64bit
-      386: 32bit
 
 checksum:
-  name_template: "{{ .ProjectName }}-{{ .Version }}-SHA256SUMS"
+  name_template: "{{ .ProjectName }}-SHA256SUMS"
   algorithm: sha256
 release:
   draft: true

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,55 @@
+#!/usr/bin/env pwsh
+
+$ErrorActionPreference = 'Stop'
+
+$JsctlInstall = $env:JSCTL_INSTALL
+$BinDir = if ($JsctlInstall) {
+  "${JsctlInstall}\bin"
+} else {
+  "${Home}\.jsctl\bin"
+}
+
+$JsctlTar = "$BinDir\jsctl.tar.gz"
+$JsctlExe = "$BinDir\jsctl.exe"
+
+$Target = if ($ENV:OS -eq "Windows_NT") {
+    $arch = if ($ENV:PROCESSOR_ARCHITEW6432) {
+        $ENV:PROCESSOR_ARCHITEW6432
+    } else {
+        $ENV:PROCESSOR_ARCHITECTURE
+    }
+
+    switch ($arch) {
+        "AMD64" { "jsctl-amd64-windows" }
+        "ARM64" { "jsctl-arm64-windows" }
+        default { throw "Error: Unsupported windows achitecture: ${arch}" }
+    }
+} else {
+    throw "Error: Unsupported operating system, use the install.sh script instead."
+}
+
+$DownloadUrl = "https://github.com/jetstack/jsctl/releases/latest/download/${Target}.tar.gz"
+
+if (!(Test-Path $BinDir)) {
+  New-Item $BinDir -ItemType Directory | Out-Null
+}
+
+curl.exe --fail --location --progress-bar --output $JsctlTar $DownloadUrl
+
+tar.exe -x -C $BinDir -f $JsctlTar "$Target/jsctl.exe"
+
+Move-Item -Path "$BinDir\$Target\jsctl.exe" -Destination $JsctlExe -Force
+
+Remove-Item "$BinDir\$Target\"
+Remove-Item $JsctlTar
+
+$User = [System.EnvironmentVariableTarget]::User
+$Path = [System.Environment]::GetEnvironmentVariable('Path', $User)
+if (!(";${Path};".ToLower() -like "*;${BinDir};*".ToLower())) {
+    [System.Environment]::SetEnvironmentVariable('Path', "${Path};${BinDir}", $User)
+    $Env:Path += ";${BinDir}"
+}
+
+Write-Output "jsctl was installed successfully to ${JsctlExe}"
+Write-Output "Run 'jsctl --help' to get started"
+Write-Output "Checkout https://platform.jetstack.io/documentation for more information"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+
+set -e
+
+if ! command -v tar >/dev/null; then
+	echo "Error: tar is required to install jsctl" 1>&2
+	exit 1
+fi
+
+if ! command -v curl >/dev/null; then
+    echo "Error: curl is required to install jsctl" 1>&2
+    exit 1
+fi
+
+if [ "$OS" = "Windows_NT" ]; then
+    if [ -z "$PROCESSOR_ARCHITEW6432" ]; then
+        arch="$PROCESSOR_ARCHITECTURE"
+    else
+        arch="$PROCESSOR_ARCHITEW6432"
+    fi
+
+    case $arch in
+    "AMD64") target="jsctl-amd64-windows" ;;
+    "ARM64") target="jsctl-arm64-windows" ;;
+    *)
+        echo "Error: Unsupported windows achitecture: ${arch}" 1>&2
+        exit 1 ;;
+    esac
+    target_file="jsctl.exe"
+else
+	case $(uname -sm) in
+	"Darwin x86_64") target="jsctl-amd64-darwin" ;;
+	"Darwin arm64")  target="jsctl-arm64-darwin" ;;
+    "Linux x86_64")  target="jsctl-amd64-linux" ;;
+	"Linux aarch64") target="jsctl-arm64-linux" ;;
+    *)
+        echo "Error: Unsupported operating system or architecture: $(uname -sm)" 1>&2
+        exit 1 ;;
+	esac
+    target_file="jsctl"
+fi
+
+jsctl_uri="https://github.com/jetstack/jsctl/releases/latest/download/${target}.tar.gz"
+
+jsctl_install="${JSCTL_INSTALL:-$HOME/.jsctl}"
+bin_dir="$jsctl_install/bin"
+bin="$bin_dir/$target_file"
+
+if [ ! -d "$bin_dir" ]; then
+	mkdir -p "$bin_dir"
+fi
+
+curl --fail --location --progress-bar --output "$bin.tar.gz" "$jsctl_uri"
+tar xfO "$bin.tar.gz" "$target/$target_file" > "$bin"
+chmod +x "$bin"
+rm "$bin.tar.gz"
+
+echo "jsctl was installed successfully to $bin"
+if command -v jsctl >/dev/null; then
+	echo "Run 'jsctl --help' to get started"
+else
+	case $SHELL in
+	/bin/zsh) shell_profile=".zshrc" ;;
+	*) shell_profile=".bashrc" ;;
+	esac
+    echo
+	echo "Manually add the directory to your \$HOME/$shell_profile (or similar)"
+	echo "  export JSCTL_INSTALL=\"$jsctl_install\""
+	echo "  export PATH=\"\$JSCTL_INSTALL/bin:\$PATH\""
+    echo
+	echo "And run \"source $HOME/.bashrc\" to update your current shell"
+    echo
+	echo "Run '$bin --help' to get started"
+fi
+echo
+echo "Checkout https://platform.jetstack.io/documentation for more information"


### PR DESCRIPTION
This is how we recommend the user installs jsctl currently:
```
$ VERSION="0.1.15"
$ ASSET_REF="jsctl-$VERSION-$(uname -s)-$(uname -m)"
$ ARCHIVE="$ASSET_REF.tar.gz"
$ curl -LO https://github.com/jetstack/jsctl/releases/download/v$VERSION/$ARCHIVE
$ tar -zxvf $ARCHIVE
$ sudo mv ./$ASSET_REF/jsctl /usr/local/bin/jsctl
```
This does not work for me since `uname -s` returns `Linux` instead of `linux` and that causes the sudo mv command to fail.

In https://github.com/jetstack/jsctl/issues/51 we were saying not to create a one-line install script, however I'm convinced that the advantages (simple & easy-to-use) outweigh the disadvantages (potentially insecure -> which is a moot point since the script is used to download and run our binary on the machine).

I renamed the release artefacts such that they don't contain the version anymore, this makes it easier to download the latest version directly. I also removed the architecture renaming from `.goreleaser.yml`, that is now done in the script instead. I also removed some target architectures that I think are not used (anymore) like windows 32 bit etc.

After creating a new release, the one liners should be:
```
curl -fsSL https://raw.githubusercontent.com/jetstack/jsctl/main/install.sh | sh
```
and
```
irm https://raw.githubusercontent.com/jetstack/jsctl/main/install.ps1 | iex
```