### PR TITLE
Ensures that manifest generation still works if issuers backup file not provided

### DIFF
--- a/internal/command/operator/apply.go
+++ b/internal/command/operator/apply.go
@@ -104,9 +104,12 @@ Note: If --auto-registry-credentials and --registry-credentials-path are unset, 
 				return fmt.Errorf("error validating provided flags: %w", err)
 			}
 
-			issuers, err := restore.ExtractOperatorManageableIssuersFromBackupFile(backupFilePath)
-			if err != nil {
-				return fmt.Errorf("error extracting issuers from backup file: %w", err)
+			issuers := &restore.RestoredIssuers{}
+			if backupFilePath != "" {
+				issuers, err = restore.ExtractOperatorManageableIssuersFromBackupFile(backupFilePath)
+				if err != nil {
+					return fmt.Errorf("error extracting issuers from backup file: %w", err)
+				}
 			}
 			if len(issuers.Missed) != 0 {
 				fmt.Fprintf(os.Stderr, "The following issuers cannot be managed by the operator and must be restored manually: %s\n", strings.Join(issuers.Missed, ", "))


### PR DESCRIPTION
In #70 we added functionality to restore issuers from a backup file.
This broke the jsctl command that can be used to generate operator manifests for cases where issuers backup file is not provided.

To verify the bug run `go run main.go operator installations apply --stdout` from latest master and observe failure:
```
irbe@jsctl$ go run main.go operator installations apply --stdout
error extracting issuers from backup file: failed to open backup file: open : no such file or directory
exit status 1
```
This PR fixes that.

Signed-off-by: irbekrm <irbekrm@gmail.com>