### PR TITLE
venafiissuer and venaficlusterissuer were missing an "s"

### DIFF
--- a/internal/cluster/templates/agent.yaml
+++ b/internal/cluster/templates/agent.yaml
@@ -449,19 +449,19 @@ data:
           version: v1alpha3
           resource: virtualservices
     - kind: "k8s-dynamic"
-      name: "k8s/venaficlusterissuer"
+      name: "k8s/venaficlusterissuers"
       config:
         resource-type:
           group: jetstack.io
           version: v1alpha1
-          resource: venaficlusterissuer
+          resource: venaficlusterissuers
     - kind: "k8s-dynamic"
-      name: "k8s/venafiissuer"
+      name: "k8s/venafiissuers"
       config:
         resource-type:
           group: jetstack.io
           version: v1alpha1
-          resource: venafiissuer
+          resource: venafiissuers
 kind: ConfigMap
 metadata:
   name: agent-config


### PR DESCRIPTION
In https://github.com/jetstack/jsctl/pull/79, the `agent.yaml` configuration for reporting the VenafiIssuer and VenafiClusterIssuer types was added, but an `s` was missing. Because of that, the agent would fail with the following messages:

```
2023/02/06 14:50:45 server missing resource for datagatherer of "jetstack.io/v1alpha1, Resource=venaficlusterissuer"
W0206 14:50:46.292946  530468 reflector.go:424] pkg/mod/k8s.io/client-go@v0.25.0/tools/cache/reflector.go:169: failed to list *unstructured.Unstructured: the server could not find the requested resource
2023/02/06 14:50:46 server missing resource for datagatherer of "jetstack.io/v1alpha1, Resource=venafiissuer"
W0206 14:51:06.172629  530468 reflector.go:424] pkg/mod/k8s.io/client-go@v0.25.0/tools/cache/reflector.go:169: failed to list *unstructured.Unstructured: the server could not find the requested resource
```

I also noticed that the agent doesn't watch for changes to the `agent.yaml` file.