### PR TITLE
Rename 'v1certmanager' import to 'cmapi'

### DIFF
--- a/internal/kubernetes/clients/clients.go
+++ b/internal/kubernetes/clients/clients.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	v1alpha1approverpolicy "github.com/cert-manager/approver-policy/pkg/apis/policy/v1alpha1"
-	v1certmanager "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	v1extensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/client-go/rest"
 )
@@ -28,13 +28,13 @@ func NewCRDClient(config *rest.Config) (*Generic[*v1extensions.CustomResourceDef
 }
 
 // NewCertificateClient returns an instance of a generic client for querying cert-manager Certificates
-func NewCertificateClient(config *rest.Config) (*Generic[*v1certmanager.Certificate, *v1certmanager.CertificateList], error) {
-	genericClient, err := NewGenericClient[*v1certmanager.Certificate, *v1certmanager.CertificateList](
+func NewCertificateClient(config *rest.Config) (*Generic[*cmapi.Certificate, *cmapi.CertificateList], error) {
+	genericClient, err := NewGenericClient[*cmapi.Certificate, *cmapi.CertificateList](
 		&GenericClientOptions{
 			RestConfig: config,
 			APIPath:    "/apis",
-			Group:      v1certmanager.SchemeGroupVersion.Group,
-			Version:    v1certmanager.SchemeGroupVersion.Version,
+			Group:      cmapi.SchemeGroupVersion.Group,
+			Version:    cmapi.SchemeGroupVersion.Version,
 			Kind:       "certificates",
 		},
 	)

--- a/internal/kubernetes/clients/issuers.go
+++ b/internal/kubernetes/clients/issuers.go
@@ -7,7 +7,7 @@ import (
 
 	kmsissuerv1alpha1 "github.com/Skyscanner/kms-issuer/apis/certmanager/v1alpha1"
 	awspcaissuerv1beta1 "github.com/cert-manager/aws-privateca-issuer/pkg/api/v1beta1"
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	origincaissuerv1 "github.com/cloudflare/origin-ca-issuer/pkgs/apis/v1"
 	googlecasissuerv1beta1 "github.com/jetstack/google-cas-issuer/api/v1beta1"
 	veiv1alpha1 "github.com/jetstack/venafi-enhanced-issuer/api/v1alpha1"
@@ -178,13 +178,13 @@ func NewAllIssuers(config *rest.Config) (*AllIssuers, error) {
 
 // NewCertManagerIssuerClient returns an instance of a generic client for querying
 // cert-manager Issuers
-func NewCertManagerIssuerClient(config *rest.Config) (*Generic[*certmanagerv1.Issuer, *certmanagerv1.IssuerList], error) {
-	genericClient, err := NewGenericClient[*certmanagerv1.Issuer, *certmanagerv1.IssuerList](
+func NewCertManagerIssuerClient(config *rest.Config) (*Generic[*cmapi.Issuer, *cmapi.IssuerList], error) {
+	genericClient, err := NewGenericClient[*cmapi.Issuer, *cmapi.IssuerList](
 		&GenericClientOptions{
 			RestConfig: config,
 			APIPath:    "/apis",
-			Group:      certmanagerv1.SchemeGroupVersion.Group,
-			Version:    certmanagerv1.SchemeGroupVersion.Version,
+			Group:      cmapi.SchemeGroupVersion.Group,
+			Version:    cmapi.SchemeGroupVersion.Version,
 			Kind:       "issuers",
 		},
 	)
@@ -197,13 +197,13 @@ func NewCertManagerIssuerClient(config *rest.Config) (*Generic[*certmanagerv1.Is
 
 // NewCertManagerClusterIssuerClient returns an instance of a generic client
 // for querying cert-manager ClusterIssuers
-func NewCertManagerClusterIssuerClient(config *rest.Config) (*Generic[*certmanagerv1.ClusterIssuer, *certmanagerv1.ClusterIssuerList], error) {
-	genericClient, err := NewGenericClient[*certmanagerv1.ClusterIssuer, *certmanagerv1.ClusterIssuerList](
+func NewCertManagerClusterIssuerClient(config *rest.Config) (*Generic[*cmapi.ClusterIssuer, *cmapi.ClusterIssuerList], error) {
+	genericClient, err := NewGenericClient[*cmapi.ClusterIssuer, *cmapi.ClusterIssuerList](
 		&GenericClientOptions{
 			RestConfig: config,
 			APIPath:    "/apis",
-			Group:      certmanagerv1.SchemeGroupVersion.Group,
-			Version:    certmanagerv1.SchemeGroupVersion.Version,
+			Group:      cmapi.SchemeGroupVersion.Group,
+			Version:    cmapi.SchemeGroupVersion.Version,
 			Kind:       "clusterissuers",
 		},
 	)

--- a/internal/kubernetes/restore/restore.go
+++ b/internal/kubernetes/restore/restore.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	veiv1alpha1 "github.com/jetstack/venafi-enhanced-issuer/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -20,8 +20,8 @@ import (
 // RestoredIssuers contains the issuers and cluster issuers that were extracted
 // from a backup file. Issuers which were unsupported are listed in Missed.
 type RestoredIssuers struct {
-	CertManagerIssuers        []*certmanagerv1.Issuer
-	CertManagerClusterIssuers []*certmanagerv1.ClusterIssuer
+	CertManagerIssuers        []*cmapi.Issuer
+	CertManagerClusterIssuers []*cmapi.ClusterIssuer
 	VenafiIssuers             []*veiv1alpha1.VenafiIssuer
 	VenafiClusterIssuers      []*veiv1alpha1.VenafiClusterIssuer
 
@@ -88,7 +88,7 @@ func ExtractOperatorManageableIssuersFromBackupFile(backupFilePath string) (*Res
 			}
 			switch resource.GroupVersionKind().Kind {
 			case "Issuer":
-				var issuer *certmanagerv1.Issuer
+				var issuer *cmapi.Issuer
 
 				err = runtime.DefaultUnstructuredConverter.FromUnstructured(resource.Object, &issuer)
 				if err != nil {
@@ -97,7 +97,7 @@ func ExtractOperatorManageableIssuersFromBackupFile(backupFilePath string) (*Res
 
 				restoredIssuers.CertManagerIssuers = append(restoredIssuers.CertManagerIssuers, issuer)
 			case "ClusterIssuer":
-				var issuer *certmanagerv1.ClusterIssuer
+				var issuer *cmapi.ClusterIssuer
 
 				err = runtime.DefaultUnstructuredConverter.FromUnstructured(resource.Object, &issuer)
 				if err != nil {

--- a/internal/kubernetes/restore/restore_test.go
+++ b/internal/kubernetes/restore/restore_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	certmanageracmev1 "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	veiv1alpha1 "github.com/jetstack/venafi-enhanced-issuer/api/v1alpha1"
 	"github.com/stretchr/testify/require"
@@ -31,7 +31,7 @@ func TestExtractOperatorManageableIssuersFromBackupFile(t *testing.T) {
 		NeedsConversion: []string{
 			"ClusterIssuer/outdated-cm-issuer",
 		},
-		CertManagerIssuers: []*certmanagerv1.Issuer{
+		CertManagerIssuers: []*cmapi.Issuer{
 			{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Issuer",
@@ -41,16 +41,16 @@ func TestExtractOperatorManageableIssuersFromBackupFile(t *testing.T) {
 					Name:      "cm-issuer-sample",
 					Namespace: "jetstack-secure",
 				},
-				Spec: certmanagerv1.IssuerSpec{
-					IssuerConfig: certmanagerv1.IssuerConfig{
-						CA: &certmanagerv1.CAIssuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
+						CA: &cmapi.CAIssuer{
 							SecretName: "ca-key-pair",
 						},
 					},
 				},
 			},
 		},
-		CertManagerClusterIssuers: []*certmanagerv1.ClusterIssuer{
+		CertManagerClusterIssuers: []*cmapi.ClusterIssuer{
 			{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "ClusterIssuer",
@@ -59,8 +59,8 @@ func TestExtractOperatorManageableIssuersFromBackupFile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cm-cluster-issuer-sample",
 				},
-				Spec: certmanagerv1.IssuerSpec{
-					IssuerConfig: certmanagerv1.IssuerConfig{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &certmanageracmev1.ACMEIssuer{
 							Email:  "dummy-email@example.com",
 							Server: "https://",

--- a/internal/kubernetes/status/status.go
+++ b/internal/kubernetes/status/status.go
@@ -7,7 +7,7 @@ import (
 
 	kmsissuerv1alpha1 "github.com/Skyscanner/kms-issuer/apis/certmanager/v1alpha1"
 	awspcaissuerv1beta1 "github.com/cert-manager/aws-privateca-issuer/pkg/api/v1beta1"
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	origincaissuerv1 "github.com/cloudflare/origin-ca-issuer/pkgs/apis/v1"
 	googlecasissuerv1beta1 "github.com/jetstack/google-cas-issuer/api/v1beta1"
 	veiv1alpha1 "github.com/jetstack/venafi-enhanced-issuer/api/v1alpha1"
@@ -246,14 +246,14 @@ func findIssuers(ctx context.Context, cfg *rest.Config) ([]summaryIssuer, error)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create clusterissuer client: %s", err)
 			}
-			var issuers certmanagerv1.IssuerList
+			var issuers cmapi.IssuerList
 			err = client.List(ctx, &clients.GenericRequestOptions{}, &issuers)
 			if err != nil {
 				return nil, fmt.Errorf("failed to list clusterissuers: %s", err)
 			}
 			for _, issuer := range issuers.Items {
 				summaryIssuers = append(summaryIssuers, summaryIssuer{
-					APIVersion: certmanagerv1.SchemeGroupVersion.String(),
+					APIVersion: cmapi.SchemeGroupVersion.String(),
 					Name:       issuer.Name,
 					Namespace:  issuer.Namespace,
 					Kind:       issuer.Kind,
@@ -264,14 +264,14 @@ func findIssuers(ctx context.Context, cfg *rest.Config) ([]summaryIssuer, error)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create clusterissuer client: %s", err)
 			}
-			var clusterIssuers certmanagerv1.ClusterIssuerList
+			var clusterIssuers cmapi.ClusterIssuerList
 			err = client.List(ctx, &clients.GenericRequestOptions{}, &clusterIssuers)
 			if err != nil {
 				return nil, fmt.Errorf("failed to list clusterissuers: %s", err)
 			}
 			for _, issuer := range clusterIssuers.Items {
 				summaryIssuers = append(summaryIssuers, summaryIssuer{
-					APIVersion: certmanagerv1.SchemeGroupVersion.String(),
+					APIVersion: cmapi.SchemeGroupVersion.String(),
 					Name:       issuer.Name,
 					Kind:       issuer.Kind,
 				})

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	certmanageracmev1 "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	operatorv1alpha1 "github.com/jetstack/js-operator/pkg/apis/operator/v1alpha1"
 	veiv1alpha1 "github.com/jetstack/venafi-enhanced-issuer/api/v1alpha1"
@@ -207,10 +207,10 @@ type (
 
 		// ImportedCertManagerIssuers is a list of cert-manager issuers to include in
 		// the generated installation file
-		ImportedCertManagerIssuers []*certmanagerv1.Issuer
+		ImportedCertManagerIssuers []*cmapi.Issuer
 		// ImportedCertManagerClusterIssuers is a list of cert-manager cluster issuers
 		// to include in the generated installation file
-		ImportedCertManagerClusterIssuers []*certmanagerv1.ClusterIssuer
+		ImportedCertManagerClusterIssuers []*cmapi.ClusterIssuer
 
 		// ImportedVenafiIssuers is a list of Venafi issuers to include in the generated
 		// installation file
@@ -308,8 +308,8 @@ func ApplyInstallationYAML(ctx context.Context, applier Applier, options ApplyIn
 
 func addIssuersToInstallation(
 	mf *manifests,
-	certManagerIssuers []*certmanagerv1.Issuer,
-	certManagerClusterIssuers []*certmanagerv1.ClusterIssuer,
+	certManagerIssuers []*cmapi.Issuer,
+	certManagerClusterIssuers []*cmapi.ClusterIssuer,
 	venafiIssuers []*veiv1alpha1.VenafiIssuer,
 	venafiClusterIssuers []*veiv1alpha1.VenafiClusterIssuer,
 ) error {
@@ -339,19 +339,19 @@ func addIssuersToInstallation(
 				return nil
 			}(),
 
-			Vault: func() *certmanagerv1.VaultIssuer {
+			Vault: func() *cmapi.VaultIssuer {
 				if issuer.Spec.Vault != nil {
 					return issuer.Spec.Vault
 				}
 				return nil
 			}(),
-			SelfSigned: func() *certmanagerv1.SelfSignedIssuer {
+			SelfSigned: func() *cmapi.SelfSignedIssuer {
 				if issuer.Spec.SelfSigned != nil {
 					return issuer.Spec.SelfSigned
 				}
 				return nil
 			}(),
-			Venafi: func() *certmanagerv1.VenafiIssuer {
+			Venafi: func() *cmapi.VenafiIssuer {
 				if issuer.Spec.Venafi != nil {
 					return issuer.Spec.Venafi
 				}
@@ -386,19 +386,19 @@ func addIssuersToInstallation(
 				return nil
 			}(),
 
-			Vault: func() *certmanagerv1.VaultIssuer {
+			Vault: func() *cmapi.VaultIssuer {
 				if issuer.Spec.Vault != nil {
 					return issuer.Spec.Vault
 				}
 				return nil
 			}(),
-			SelfSigned: func() *certmanagerv1.SelfSignedIssuer {
+			SelfSigned: func() *cmapi.SelfSignedIssuer {
 				if issuer.Spec.SelfSigned != nil {
 					return issuer.Spec.SelfSigned
 				}
 				return nil
 			}(),
-			Venafi: func() *certmanagerv1.VenafiIssuer {
+			Venafi: func() *cmapi.VenafiIssuer {
 				if issuer.Spec.Venafi != nil {
 					return issuer.Spec.Venafi
 				}
@@ -558,8 +558,8 @@ func applyIstioCSRToInstallation(manifests *manifests, options ApplyInstallation
 
 	manifests.installation.Spec.IstioCSR.IssuerRef = &certmanagermetav1.ObjectReference{
 		Name:  options.IstioCSRIssuer,
-		Kind:  certmanagerv1.IssuerKind,
-		Group: certmanagerv1.SchemeGroupVersion.Group,
+		Kind:  cmapi.IssuerKind,
+		Group: cmapi.SchemeGroupVersion.Group,
 	}
 
 	return nil

--- a/internal/operator/operator_test.go
+++ b/internal/operator/operator_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	certmanageracmev1 "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	operatorv1alpha1 "github.com/jetstack/js-operator/pkg/apis/operator/v1alpha1"
 	veiv1alpha1 "github.com/jetstack/venafi-enhanced-issuer/api/v1alpha1"
@@ -267,8 +267,8 @@ func TestApplyInstallationYAML(t *testing.T) {
 		if assert.NotNil(t, actual.Spec.IstioCSR) && assert.NotNil(t, actual.Spec.IstioCSR.IssuerRef) {
 			issuer := actual.Spec.IstioCSR.IssuerRef
 
-			assert.EqualValues(t, certmanagerv1.SchemeGroupVersion.Group, issuer.Group)
-			assert.EqualValues(t, certmanagerv1.IssuerKind, issuer.Kind)
+			assert.EqualValues(t, cmapi.SchemeGroupVersion.Group, issuer.Group)
+			assert.EqualValues(t, cmapi.IssuerKind, issuer.Kind)
 			assert.EqualValues(t, options.IstioCSRIssuer, issuer.Name)
 		}
 	})
@@ -377,13 +377,13 @@ func TestApplyInstallationYAML(t *testing.T) {
 	})
 
 	t.Run("It should generate a manifest with issuers", func(t *testing.T) {
-		certManagerIssuer := certmanagerv1.Issuer{
+		certManagerIssuer := cmapi.Issuer{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "cm-issuer-example",
 				Namespace: "test-namespace",
 			},
-			Spec: certmanagerv1.IssuerSpec{
-				IssuerConfig: certmanagerv1.IssuerConfig{
+			Spec: cmapi.IssuerSpec{
+				IssuerConfig: cmapi.IssuerConfig{
 					ACME: &certmanageracmev1.ACMEIssuer{
 						Email:  "dummy-email@example.com",
 						Server: "https://",
@@ -397,13 +397,13 @@ func TestApplyInstallationYAML(t *testing.T) {
 			},
 		}
 
-		certManagerClusterIssuer := certmanagerv1.ClusterIssuer{
+		certManagerClusterIssuer := cmapi.ClusterIssuer{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "cm-cluster-issuer-example",
 			},
-			Spec: certmanagerv1.IssuerSpec{
-				IssuerConfig: certmanagerv1.IssuerConfig{
-					CA: &certmanagerv1.CAIssuer{
+			Spec: cmapi.IssuerSpec{
+				IssuerConfig: cmapi.IssuerConfig{
+					CA: &cmapi.CAIssuer{
 						SecretName: "ca-key-pair",
 					},
 				},
@@ -451,8 +451,8 @@ func TestApplyInstallationYAML(t *testing.T) {
 		}
 
 		options := operator.ApplyInstallationYAMLOptions{
-			ImportedCertManagerIssuers:        []*certmanagerv1.Issuer{&certManagerIssuer},
-			ImportedCertManagerClusterIssuers: []*certmanagerv1.ClusterIssuer{&certManagerClusterIssuer},
+			ImportedCertManagerIssuers:        []*cmapi.Issuer{&certManagerIssuer},
+			ImportedCertManagerClusterIssuers: []*cmapi.ClusterIssuer{&certManagerClusterIssuer},
 			ImportedVenafiIssuers:             []*veiv1alpha1.VenafiIssuer{&venafiIssuer},
 			ImportedVenafiClusterIssuers:      []*veiv1alpha1.VenafiClusterIssuer{&venafiClusterIssuer},
 		}

--- a/internal/venafi/venafi.go
+++ b/internal/venafi/venafi.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	alpha1operatorv1 "github.com/jetstack/js-operator/pkg/apis/operator/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -120,9 +120,9 @@ func GenerateOperatorManifestsForIssuer(issuer *VenafiIssuer) (*alpha1operatorv1
 	}
 	vc := issuer.Conn.VC
 	iss := &alpha1operatorv1.Issuer{
-		Venafi: &certmanagerv1.VenafiIssuer{
+		Venafi: &cmapi.VenafiIssuer{
 			Zone: vc.Zone,
-			TPP: &certmanagerv1.VenafiTPP{
+			TPP: &cmapi.VenafiTPP{
 				URL: vc.URL,
 			},
 		},

--- a/internal/venafi/venafi_test.go
+++ b/internal/venafi/venafi_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	operatorv1alpha1 "github.com/jetstack/js-operator/pkg/apis/operator/v1alpha1"
 	"github.com/stretchr/testify/assert"
@@ -176,9 +176,9 @@ func TestGenerateOperatorManifestsForIssuer(t *testing.T) {
 			expectedIssuer: &operatorv1alpha1.Issuer{
 				Name:      "foo",
 				Namespace: "foo",
-				Venafi: &certmanagerv1.VenafiIssuer{
+				Venafi: &cmapi.VenafiIssuer{
 					Zone: "foo",
-					TPP: &certmanagerv1.VenafiTPP{
+					TPP: &cmapi.VenafiTPP{
 						URL: "foo",
 						CredentialsRef: certmanagermetav1.LocalObjectReference{
 							Name: "foo-jsctl",
@@ -210,9 +210,9 @@ func TestGenerateOperatorManifestsForIssuer(t *testing.T) {
 				Name:         "foo",
 				Namespace:    "foo",
 				ClusterScope: true,
-				Venafi: &certmanagerv1.VenafiIssuer{
+				Venafi: &cmapi.VenafiIssuer{
 					Zone: "foo",
-					TPP: &certmanagerv1.VenafiTPP{
+					TPP: &cmapi.VenafiTPP{
 						URL: "foo",
 						CredentialsRef: certmanagermetav1.LocalObjectReference{
 							Name: "foo-jsctl",
@@ -245,9 +245,9 @@ func TestGenerateOperatorManifestsForIssuer(t *testing.T) {
 			expectedIssuer: &operatorv1alpha1.Issuer{
 				Name:      "foo",
 				Namespace: "foo",
-				Venafi: &certmanagerv1.VenafiIssuer{
+				Venafi: &cmapi.VenafiIssuer{
 					Zone: "foo",
-					TPP: &certmanagerv1.VenafiTPP{
+					TPP: &cmapi.VenafiTPP{
 						URL: "foo",
 						CredentialsRef: certmanagermetav1.LocalObjectReference{
 							Name: "foo-jsctl",
@@ -298,9 +298,9 @@ func TestGenerateOperatorManifestsForIssuer(t *testing.T) {
 			expectedIssuer: &operatorv1alpha1.Issuer{
 				Name:      "foo",
 				Namespace: "foo",
-				Venafi: &certmanagerv1.VenafiIssuer{
+				Venafi: &cmapi.VenafiIssuer{
 					Zone: "foo",
-					TPP: &certmanagerv1.VenafiTPP{
+					TPP: &cmapi.VenafiTPP{
 						URL: "foo",
 						CredentialsRef: certmanagermetav1.LocalObjectReference{
 							Name: "foo-jsctl",


### PR DESCRIPTION
I'm trying to reduce the number of unrelated changes in https://github.com/jetstack/jsctl/pull/71 by splitting the PR into multiple smaller PRs.
This PR just "renames the 'v1certmanager' import to 'cmapi'"
