### PR TITLE
Add x as alias for experimental

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -162,7 +162,7 @@ func marshalBase64(in interface{}) ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
-// AgentServiceAccount secret takes a service account json and formats it as a
+// AgentServiceAccountSecret takes a service account json and formats it as a
 // k8s secret.
 func AgentServiceAccountSecret(keyData []byte, name, namespace string) *corev1.Secret {
 	secret := &corev1.Secret{

--- a/internal/command/experimental.go
+++ b/internal/command/experimental.go
@@ -10,8 +10,9 @@ import (
 // "jsctl experimental" subcommands.
 func Experimental() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "experimental",
-		Short: "Experimental jsctl commands",
+		Use:     "experimental",
+		Short:   "Experimental jsctl commands",
+		Aliases: []string{"x"},
 	}
 
 	experimentalClustersCommands := &cobra.Command{


### PR DESCRIPTION
I'm trying to reduce the number of unrelated changes in https://github.com/jetstack/jsctl/pull/71 by splitting the PR into multiple smaller PRs.

This PR adds `x` as an alias for `experimental` (source: https://github.com/jetstack/jsctl/pull/71/commits/b413db3ad91015f29d9bcb80251a4e767ccc8cd1)