### PR TITLE
Add Fake client for generic Kubernetes client

### DIFF
--- a/internal/kubernetes/clients/clients.go
+++ b/internal/kubernetes/clients/clients.go
@@ -10,7 +10,7 @@ import (
 )
 
 // NewCRDClient returns an instance of a generic client for querying CRDs
-func NewCRDClient(config *rest.Config) (*Generic[*v1extensions.CustomResourceDefinition, *v1extensions.CustomResourceDefinitionList], error) {
+func NewCRDClient(config *rest.Config) (Generic[*v1extensions.CustomResourceDefinition, *v1extensions.CustomResourceDefinitionList], error) {
 	genericClient, err := NewGenericClient[*v1extensions.CustomResourceDefinition, *v1extensions.CustomResourceDefinitionList](
 		&GenericClientOptions{
 			RestConfig: config,
@@ -28,7 +28,7 @@ func NewCRDClient(config *rest.Config) (*Generic[*v1extensions.CustomResourceDef
 }
 
 // NewCertificateClient returns an instance of a generic client for querying cert-manager Certificates
-func NewCertificateClient(config *rest.Config) (*Generic[*cmapi.Certificate, *cmapi.CertificateList], error) {
+func NewCertificateClient(config *rest.Config) (Generic[*cmapi.Certificate, *cmapi.CertificateList], error) {
 	genericClient, err := NewGenericClient[*cmapi.Certificate, *cmapi.CertificateList](
 		&GenericClientOptions{
 			RestConfig: config,
@@ -45,9 +45,27 @@ func NewCertificateClient(config *rest.Config) (*Generic[*cmapi.Certificate, *cm
 	return genericClient, nil
 }
 
+// NewCertificateRequestClient returns an instance of a generic client for querying cert-manager CertificateRequests
+func NewCertificateRequestClient(config *rest.Config) (Generic[*cmapi.CertificateRequest, *cmapi.CertificateRequestList], error) {
+	genericClient, err := NewGenericClient[*cmapi.CertificateRequest, *cmapi.CertificateRequestList](
+		&GenericClientOptions{
+			RestConfig: config,
+			APIPath:    "/apis",
+			Group:      cmapi.SchemeGroupVersion.Group,
+			Version:    cmapi.SchemeGroupVersion.Version,
+			Kind:       "certificaterequests",
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error creating generic client: %w", err)
+	}
+
+	return genericClient, nil
+}
+
 // NewCertificateRequestPolicyClient returns an instance of a generic client for
 // querying approver policy CertificateRequestPolicies
-func NewCertificateRequestPolicyClient(config *rest.Config) (*Generic[*v1alpha1approverpolicy.CertificateRequestPolicy, *v1alpha1approverpolicy.CertificateRequestPolicyList], error) {
+func NewCertificateRequestPolicyClient(config *rest.Config) (Generic[*v1alpha1approverpolicy.CertificateRequestPolicy, *v1alpha1approverpolicy.CertificateRequestPolicyList], error) {
 	genericClient, err := NewGenericClient[*v1alpha1approverpolicy.CertificateRequestPolicy, *v1alpha1approverpolicy.CertificateRequestPolicyList](
 		&GenericClientOptions{
 			RestConfig: config,

--- a/internal/kubernetes/clients/fake.go
+++ b/internal/kubernetes/clients/fake.go
@@ -1,0 +1,31 @@
+package clients
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type FakeGeneric[T, ListT runtime.Object] struct {
+	FakeGet     func(context.Context, *GenericRequestOptions, T) error
+	FakeList    func(context.Context, *GenericRequestOptions, ListT) error
+	FakePresent func(context.Context, *GenericRequestOptions) (bool, error)
+	FakePatch   func(context.Context, *GenericRequestOptions, []byte) error
+}
+
+var _ Generic[*runtime.Unknown, *runtime.Unknown] = &FakeGeneric[*runtime.Unknown, *runtime.Unknown]{}
+
+func (f *FakeGeneric[T, ListT]) Get(ctx context.Context, options *GenericRequestOptions, result T) error {
+	return f.FakeGet(ctx, options, result)
+}
+
+func (f *FakeGeneric[T, ListT]) List(ctx context.Context, options *GenericRequestOptions, result ListT) error {
+	return f.FakeList(ctx, options, result)
+}
+
+func (f *FakeGeneric[T, ListT]) Present(ctx context.Context, options *GenericRequestOptions) (bool, error) {
+	return f.FakePresent(ctx, options)
+}
+func (f *FakeGeneric[T, ListT]) Patch(ctx context.Context, options *GenericRequestOptions, patch []byte) error {
+	return f.FakePatch(ctx, options, patch)
+}

--- a/internal/kubernetes/clients/installation.go
+++ b/internal/kubernetes/clients/installation.go
@@ -14,7 +14,7 @@ import (
 type (
 	// The InstallationClient is used to query information on an Installation resource within a Kubernetes cluster.
 	InstallationClient struct {
-		client *Generic[*v1alpha1.Installation, *v1alpha1.InstallationList]
+		client Generic[*v1alpha1.Installation, *v1alpha1.InstallationList]
 	}
 
 	// ComponentStatus describes the status of an individual operator component.

--- a/internal/kubernetes/clients/issuers.go
+++ b/internal/kubernetes/clients/issuers.go
@@ -136,7 +136,7 @@ func ListSupportedIssuers() (SupportedIssuerList, error) {
 // AllIssuers is a special client to wrap logic for determining the kinds of
 // issuers present in a cluster
 type AllIssuers struct {
-	crdClient *Generic[*apiextensionsv1.CustomResourceDefinition, *apiextensionsv1.CustomResourceDefinitionList]
+	crdClient Generic[*apiextensionsv1.CustomResourceDefinition, *apiextensionsv1.CustomResourceDefinitionList]
 }
 
 func (a *AllIssuers) ListKinds(ctx context.Context) ([]AnyIssuer, error) {
@@ -178,7 +178,7 @@ func NewAllIssuers(config *rest.Config) (*AllIssuers, error) {
 
 // NewCertManagerIssuerClient returns an instance of a generic client for querying
 // cert-manager Issuers
-func NewCertManagerIssuerClient(config *rest.Config) (*Generic[*cmapi.Issuer, *cmapi.IssuerList], error) {
+func NewCertManagerIssuerClient(config *rest.Config) (Generic[*cmapi.Issuer, *cmapi.IssuerList], error) {
 	genericClient, err := NewGenericClient[*cmapi.Issuer, *cmapi.IssuerList](
 		&GenericClientOptions{
 			RestConfig: config,
@@ -197,7 +197,7 @@ func NewCertManagerIssuerClient(config *rest.Config) (*Generic[*cmapi.Issuer, *c
 
 // NewCertManagerClusterIssuerClient returns an instance of a generic client
 // for querying cert-manager ClusterIssuers
-func NewCertManagerClusterIssuerClient(config *rest.Config) (*Generic[*cmapi.ClusterIssuer, *cmapi.ClusterIssuerList], error) {
+func NewCertManagerClusterIssuerClient(config *rest.Config) (Generic[*cmapi.ClusterIssuer, *cmapi.ClusterIssuerList], error) {
 	genericClient, err := NewGenericClient[*cmapi.ClusterIssuer, *cmapi.ClusterIssuerList](
 		&GenericClientOptions{
 			RestConfig: config,
@@ -216,7 +216,7 @@ func NewCertManagerClusterIssuerClient(config *rest.Config) (*Generic[*cmapi.Clu
 
 // NewGoogleCASIssuerClient returns an instance of a generic client for querying
 // google CAS Issuers
-func NewGoogleCASIssuerClient(config *rest.Config) (*Generic[*googlecasissuerv1beta1.GoogleCASIssuer, *googlecasissuerv1beta1.GoogleCASIssuerList], error) {
+func NewGoogleCASIssuerClient(config *rest.Config) (Generic[*googlecasissuerv1beta1.GoogleCASIssuer, *googlecasissuerv1beta1.GoogleCASIssuerList], error) {
 	genericClient, err := NewGenericClient[*googlecasissuerv1beta1.GoogleCASIssuer, *googlecasissuerv1beta1.GoogleCASIssuerList](
 		&GenericClientOptions{
 			RestConfig: config,
@@ -235,7 +235,7 @@ func NewGoogleCASIssuerClient(config *rest.Config) (*Generic[*googlecasissuerv1b
 
 // NewGoogleCASClusterIssuerClient returns an instance of a generic client for querying
 // google CAS cluster Issuers
-func NewGoogleCASClusterIssuerClient(config *rest.Config) (*Generic[*googlecasissuerv1beta1.GoogleCASClusterIssuer, *googlecasissuerv1beta1.GoogleCASClusterIssuerList], error) {
+func NewGoogleCASClusterIssuerClient(config *rest.Config) (Generic[*googlecasissuerv1beta1.GoogleCASClusterIssuer, *googlecasissuerv1beta1.GoogleCASClusterIssuerList], error) {
 	genericClient, err := NewGenericClient[*googlecasissuerv1beta1.GoogleCASClusterIssuer, *googlecasissuerv1beta1.GoogleCASClusterIssuerList](
 		&GenericClientOptions{
 			RestConfig: config,
@@ -254,7 +254,7 @@ func NewGoogleCASClusterIssuerClient(config *rest.Config) (*Generic[*googlecasis
 
 // NewAWSPCAIssuerClient returns an instance of a generic client for querying
 // AWS PCA Issuers
-func NewAWSPCAIssuerClient(config *rest.Config) (*Generic[*awspcaissuerv1beta1.AWSPCAIssuer, *awspcaissuerv1beta1.AWSPCAIssuerList], error) {
+func NewAWSPCAIssuerClient(config *rest.Config) (Generic[*awspcaissuerv1beta1.AWSPCAIssuer, *awspcaissuerv1beta1.AWSPCAIssuerList], error) {
 	genericClient, err := NewGenericClient[*awspcaissuerv1beta1.AWSPCAIssuer, *awspcaissuerv1beta1.AWSPCAIssuerList](
 		&GenericClientOptions{
 			RestConfig: config,
@@ -273,7 +273,7 @@ func NewAWSPCAIssuerClient(config *rest.Config) (*Generic[*awspcaissuerv1beta1.A
 
 // NewAWSPCAClusterIssuerClient returns an instance of a generic client for querying
 // AWS PCA cluster Issuers
-func NewAWSPCAClusterIssuerClient(config *rest.Config) (*Generic[*awspcaissuerv1beta1.AWSPCAClusterIssuer, *awspcaissuerv1beta1.AWSPCAClusterIssuerList], error) {
+func NewAWSPCAClusterIssuerClient(config *rest.Config) (Generic[*awspcaissuerv1beta1.AWSPCAClusterIssuer, *awspcaissuerv1beta1.AWSPCAClusterIssuerList], error) {
 	genericClient, err := NewGenericClient[*awspcaissuerv1beta1.AWSPCAClusterIssuer, *awspcaissuerv1beta1.AWSPCAClusterIssuerList](
 		&GenericClientOptions{
 			RestConfig: config,
@@ -292,7 +292,7 @@ func NewAWSPCAClusterIssuerClient(config *rest.Config) (*Generic[*awspcaissuerv1
 
 // NewKMSIssuerClient returns an instance of a generic client for querying
 // KMS Issuers
-func NewKMSIssuerClient(config *rest.Config) (*Generic[*kmsissuerv1alpha1.KMSIssuer, *kmsissuerv1alpha1.KMSIssuerList], error) {
+func NewKMSIssuerClient(config *rest.Config) (Generic[*kmsissuerv1alpha1.KMSIssuer, *kmsissuerv1alpha1.KMSIssuerList], error) {
 	genericClient, err := NewGenericClient[*kmsissuerv1alpha1.KMSIssuer, *kmsissuerv1alpha1.KMSIssuerList](
 		&GenericClientOptions{
 			RestConfig: config,
@@ -311,7 +311,7 @@ func NewKMSIssuerClient(config *rest.Config) (*Generic[*kmsissuerv1alpha1.KMSIss
 
 // NewVenafiEnhancedIssuerClient returns an instance of a generic client for querying
 // Venafi enhanced issuers
-func NewVenafiEnhancedIssuerClient(config *rest.Config) (*Generic[*veiv1alpha1.VenafiIssuer, *veiv1alpha1.VenafiIssuerList], error) {
+func NewVenafiEnhancedIssuerClient(config *rest.Config) (Generic[*veiv1alpha1.VenafiIssuer, *veiv1alpha1.VenafiIssuerList], error) {
 	genericClient, err := NewGenericClient[*veiv1alpha1.VenafiIssuer, *veiv1alpha1.VenafiIssuerList](
 		&GenericClientOptions{
 			RestConfig: config,
@@ -330,7 +330,7 @@ func NewVenafiEnhancedIssuerClient(config *rest.Config) (*Generic[*veiv1alpha1.V
 
 // NewVenafiEnhancedClusterIssuerClient returns an instance of a generic client for querying
 // Venafi enhanced cluster issuers
-func NewVenafiEnhancedClusterIssuerClient(config *rest.Config) (*Generic[*veiv1alpha1.VenafiClusterIssuer, *veiv1alpha1.VenafiClusterIssuerList], error) {
+func NewVenafiEnhancedClusterIssuerClient(config *rest.Config) (Generic[*veiv1alpha1.VenafiClusterIssuer, *veiv1alpha1.VenafiClusterIssuerList], error) {
 	genericClient, err := NewGenericClient[*veiv1alpha1.VenafiClusterIssuer, *veiv1alpha1.VenafiClusterIssuerList](
 		&GenericClientOptions{
 			RestConfig: config,
@@ -349,7 +349,7 @@ func NewVenafiEnhancedClusterIssuerClient(config *rest.Config) (*Generic[*veiv1a
 
 // NewOriginCAIssuerClient returns an instance of a generic client for querying
 // Origin CA Issuers
-func NewOriginCAIssuerClient(config *rest.Config) (*Generic[*origincaissuerv1.OriginIssuer, *origincaissuerv1.OriginIssuerList], error) {
+func NewOriginCAIssuerClient(config *rest.Config) (Generic[*origincaissuerv1.OriginIssuer, *origincaissuerv1.OriginIssuerList], error) {
 	genericClient, err := NewGenericClient[*origincaissuerv1.OriginIssuer, *origincaissuerv1.OriginIssuerList](
 		&GenericClientOptions{
 			RestConfig: config,
@@ -368,7 +368,7 @@ func NewOriginCAIssuerClient(config *rest.Config) (*Generic[*origincaissuerv1.Or
 
 // NewSmallStepIssuerClient returns an instance of a generic client for querying
 // Step Issuers
-func NewSmallStepIssuerClient(config *rest.Config) (*Generic[*stepissuerv1beta1.StepIssuer, *stepissuerv1beta1.StepIssuerList], error) {
+func NewSmallStepIssuerClient(config *rest.Config) (Generic[*stepissuerv1beta1.StepIssuer, *stepissuerv1beta1.StepIssuerList], error) {
 	genericClient, err := NewGenericClient[*stepissuerv1beta1.StepIssuer, *stepissuerv1beta1.StepIssuerList](
 		&GenericClientOptions{
 			RestConfig: config,
@@ -387,7 +387,7 @@ func NewSmallStepIssuerClient(config *rest.Config) (*Generic[*stepissuerv1beta1.
 
 // NewSmallStepClusterIssuerClient returns an instance of a generic client for querying
 // Step Cluster Issuers
-func NewSmallStepClusterIssuerClient(config *rest.Config) (*Generic[*stepissuerv1beta1.StepClusterIssuer, *stepissuerv1beta1.StepClusterIssuerList], error) {
+func NewSmallStepClusterIssuerClient(config *rest.Config) (Generic[*stepissuerv1beta1.StepClusterIssuer, *stepissuerv1beta1.StepClusterIssuerList], error) {
 	genericClient, err := NewGenericClient[*stepissuerv1beta1.StepClusterIssuer, *stepissuerv1beta1.StepClusterIssuerList](
 		&GenericClientOptions{
 			RestConfig: config,


### PR DESCRIPTION
I'm trying to reduce the number of unrelated changes in https://github.com/jetstack/jsctl/pull/71 by splitting the PR into multiple smaller PRs.

This PR adds a fake client for to the generic Kubernetes client.