### PR TITLE
Prevent incorrectly matching images

### DIFF
--- a/internal/kubernetes/status/components/aws_pca_issuer.go
+++ b/internal/kubernetes/status/components/aws_pca_issuer.go
@@ -32,14 +32,10 @@ func (a *AWSPCAIssuerStatus) Match(md *MatchData) (bool, error) {
 
 	for _, pod := range md.Pods {
 		for _, container := range pod.Spec.Containers {
-			if strings.Contains(container.Image, "cert-manager-aws-privateca-issuer") {
+			if strings.Contains(container.Image, "cert-manager-aws-privateca-issuer:") {
 				found = true
 				a.namespace = pod.Namespace
-				if strings.Contains(container.Image, ":") {
-					a.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
-				} else {
-					a.version = "unknown"
-				}
+				a.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
 			}
 		}
 	}

--- a/internal/kubernetes/status/components/cert_discovery_venafi.go
+++ b/internal/kubernetes/status/components/cert_discovery_venafi.go
@@ -32,14 +32,10 @@ func (c *CertDiscoveryVenafiStatus) Match(md *MatchData) (bool, error) {
 
 	for _, pod := range md.Pods {
 		for _, container := range pod.Spec.Containers {
-			if strings.Contains(container.Image, "cert-discovery-venafi") {
+			if strings.Contains(container.Image, "cert-discovery-venafi:") {
 				found = true
 				c.namespace = pod.Namespace
-				if strings.Contains(container.Image, ":") {
-					c.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
-				} else {
-					c.version = "unknown"
-				}
+				c.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
 			}
 		}
 	}

--- a/internal/kubernetes/status/components/cert_manager.go
+++ b/internal/kubernetes/status/components/cert_manager.go
@@ -56,36 +56,24 @@ func (c *CertManagerStatus) Match(md *MatchData) (bool, error) {
 
 	for _, pod := range md.Pods {
 		for _, container := range pod.Spec.Containers {
-			if strings.Contains(container.Image, "cert-manager-controller") {
+			if strings.Contains(container.Image, "cert-manager-controller:") {
 				found = true
 				c.namespace = pod.Namespace
-				if strings.Contains(container.Image, ":") {
-					c.controllerVersion = container.Image[strings.LastIndex(container.Image, ":")+1:]
-				} else {
-					c.controllerVersion = unknownVersionString
-				}
+				c.controllerVersion = container.Image[strings.LastIndex(container.Image, ":")+1:]
 
 				c.controllerArgs = container.Args
 			}
 
-			if strings.Contains(container.Image, "cert-manager-cainjector") {
+			if strings.Contains(container.Image, "cert-manager-cainjector:") {
 				found = true
 				c.namespace = pod.Namespace
-				if strings.Contains(container.Image, ":") {
-					c.cainjectorVersion = container.Image[strings.LastIndex(container.Image, ":")+1:]
-				} else {
-					c.cainjectorVersion = unknownVersionString
-				}
+				c.cainjectorVersion = container.Image[strings.LastIndex(container.Image, ":")+1:]
 			}
 
-			if strings.Contains(container.Image, "cert-manager-webhook") {
+			if strings.Contains(container.Image, "cert-manager-webhook:") {
 				found = true
 				c.namespace = pod.Namespace
-				if strings.Contains(container.Image, ":") {
-					c.webhookVersion = container.Image[strings.LastIndex(container.Image, ":")+1:]
-				} else {
-					c.webhookVersion = unknownVersionString
-				}
+				c.webhookVersion = container.Image[strings.LastIndex(container.Image, ":")+1:]
 			}
 		}
 	}

--- a/internal/kubernetes/status/components/cert_manager_approver_policy.go
+++ b/internal/kubernetes/status/components/cert_manager_approver_policy.go
@@ -32,14 +32,10 @@ func (c *CertManagerApproverPolicyStatus) Match(md *MatchData) (bool, error) {
 
 	for _, pod := range md.Pods {
 		for _, container := range pod.Spec.Containers {
-			if strings.Contains(container.Image, "cert-manager-approver-policy") {
+			if strings.Contains(container.Image, "cert-manager-approver-policy:") {
 				found = true
 				c.namespace = pod.Namespace
-				if strings.Contains(container.Image, ":") {
-					c.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
-				} else {
-					c.version = "unknown"
-				}
+				c.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
 			}
 		}
 	}

--- a/internal/kubernetes/status/components/cert_manager_approver_policy_enterprise.go
+++ b/internal/kubernetes/status/components/cert_manager_approver_policy_enterprise.go
@@ -32,14 +32,10 @@ func (c *CertManagerApproverPolicyEnterpriseStatus) Match(md *MatchData) (bool, 
 
 	for _, pod := range md.Pods {
 		for _, container := range pod.Spec.Containers {
-			if strings.Contains(container.Image, "approver-policy-enterprise") {
+			if strings.Contains(container.Image, "approver-policy-enterprise:") {
 				found = true
 				c.namespace = pod.Namespace
-				if strings.Contains(container.Image, ":") {
-					c.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
-				} else {
-					c.version = "unknown"
-				}
+				c.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
 			}
 		}
 	}

--- a/internal/kubernetes/status/components/cert_manager_csi_driver.go
+++ b/internal/kubernetes/status/components/cert_manager_csi_driver.go
@@ -32,14 +32,10 @@ func (c *CertManagerCSIDriverStatus) Match(md *MatchData) (bool, error) {
 
 	for _, pod := range md.Pods {
 		for _, container := range pod.Spec.Containers {
-			if strings.Contains(container.Image, "cert-manager-csi-driver") {
+			if strings.Contains(container.Image, "cert-manager-csi-driver:") {
 				found = true
 				c.namespace = pod.Namespace
-				if strings.Contains(container.Image, ":") {
-					c.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
-				} else {
-					c.version = "unknown"
-				}
+				c.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
 			}
 		}
 	}

--- a/internal/kubernetes/status/components/cert_manager_csi_driver_spiffe.go
+++ b/internal/kubernetes/status/components/cert_manager_csi_driver_spiffe.go
@@ -39,24 +39,16 @@ func (c *CertManagerCSIDriverSPIFFEStatus) Match(md *MatchData) (bool, error) {
 
 	for _, pod := range md.Pods {
 		for _, container := range pod.Spec.Containers {
-			if strings.Contains(container.Image, "cert-manager-csi-driver-spiffe") {
+			if strings.Contains(container.Image, "cert-manager-csi-driver-spiffe:") {
 				found = true
 				c.namespace = pod.Namespace
-				if strings.Contains(container.Image, ":") {
-					c.csiDriverVersion = container.Image[strings.LastIndex(container.Image, ":")+1:]
-				} else {
-					c.csiDriverVersion = "unknown"
-				}
+				c.csiDriverVersion = container.Image[strings.LastIndex(container.Image, ":")+1:]
 			}
 
-			if strings.Contains(container.Image, "cert-manager-csi-driver-spiffe-approver") {
+			if strings.Contains(container.Image, "cert-manager-csi-driver-spiffe-approver:") {
 				found = true
 				c.namespace = pod.Namespace
-				if strings.Contains(container.Image, ":") {
-					c.approverVersion = container.Image[strings.LastIndex(container.Image, ":")+1:]
-				} else {
-					c.approverVersion = "unknown"
-				}
+				c.approverVersion = container.Image[strings.LastIndex(container.Image, ":")+1:]
 			}
 		}
 	}

--- a/internal/kubernetes/status/components/cert_manager_istio_csr.go
+++ b/internal/kubernetes/status/components/cert_manager_istio_csr.go
@@ -32,14 +32,10 @@ func (c *CertManagerIstioCSRStatus) Match(md *MatchData) (bool, error) {
 
 	for _, pod := range md.Pods {
 		for _, container := range pod.Spec.Containers {
-			if strings.Contains(container.Image, "cert-manager-istio-csr") {
+			if strings.Contains(container.Image, "cert-manager-istio-csr:") {
 				found = true
 				c.namespace = pod.Namespace
-				if strings.Contains(container.Image, ":") {
-					c.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
-				} else {
-					c.version = "unknown"
-				}
+				c.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
 			}
 		}
 	}

--- a/internal/kubernetes/status/components/cert_manager_trust_manager.go
+++ b/internal/kubernetes/status/components/cert_manager_trust_manager.go
@@ -32,14 +32,10 @@ func (c *CertManagerTrustManagerStatus) Match(md *MatchData) (bool, error) {
 
 	for _, pod := range md.Pods {
 		for _, container := range pod.Spec.Containers {
-			if strings.Contains(container.Image, "trust-manager") {
+			if strings.Contains(container.Image, "trust-manager:") {
 				found = true
 				c.namespace = pod.Namespace
-				if strings.Contains(container.Image, ":") {
-					c.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
-				} else {
-					c.version = "unknown"
-				}
+				c.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
 			}
 		}
 	}

--- a/internal/kubernetes/status/components/google_cas_issuer.go
+++ b/internal/kubernetes/status/components/google_cas_issuer.go
@@ -32,14 +32,10 @@ func (g *GoogleCASIssuerStatus) Match(md *MatchData) (bool, error) {
 
 	for _, pod := range md.Pods {
 		for _, container := range pod.Spec.Containers {
-			if strings.Contains(container.Image, "google-cas-issuer") {
+			if strings.Contains(container.Image, "google-cas-issuer:") {
 				found = true
 				g.namespace = pod.Namespace
-				if strings.Contains(container.Image, ":") {
-					g.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
-				} else {
-					g.version = "unknown"
-				}
+				g.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
 			}
 		}
 	}

--- a/internal/kubernetes/status/components/isolated_issuer.go
+++ b/internal/kubernetes/status/components/isolated_issuer.go
@@ -32,14 +32,10 @@ func (i *IsolatedIssuerStatus) Match(md *MatchData) (bool, error) {
 
 	for _, pod := range md.Pods {
 		for _, container := range pod.Spec.Containers {
-			if strings.Contains(container.Image, "isolated-issuer") {
+			if strings.Contains(container.Image, "isolated-issuer:") {
 				found = true
 				i.namespace = pod.Namespace
-				if strings.Contains(container.Image, ":") {
-					i.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
-				} else {
-					i.version = "unknown"
-				}
+				i.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
 			}
 		}
 	}

--- a/internal/kubernetes/status/components/jetstack_secure_agent.go
+++ b/internal/kubernetes/status/components/jetstack_secure_agent.go
@@ -32,14 +32,10 @@ func (j *JetstackSecureAgentStatus) Match(md *MatchData) (bool, error) {
 
 	for _, pod := range md.Pods {
 		for _, container := range pod.Spec.Containers {
-			if strings.Contains(container.Image, "jetstack/preflight") {
+			if strings.Contains(container.Image, "jetstack/preflight:") {
 				found = true
 				j.namespace = pod.Namespace
-				if strings.Contains(container.Image, ":") {
-					j.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
-				} else {
-					j.version = "unknown"
-				}
+				j.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
 			}
 		}
 	}

--- a/internal/kubernetes/status/components/jetstack_secure_operator.go
+++ b/internal/kubernetes/status/components/jetstack_secure_operator.go
@@ -32,14 +32,10 @@ func (j *JetstackSecureOperatorStatus) Match(md *MatchData) (bool, error) {
 
 	for _, pod := range md.Pods {
 		for _, container := range pod.Spec.Containers {
-			if strings.Contains(container.Image, "js-operator") {
+			if strings.Contains(container.Image, "js-operator:") {
 				found = true
 				j.namespace = pod.Namespace
-				if strings.Contains(container.Image, ":") {
-					j.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
-				} else {
-					j.version = "unknown"
-				}
+				j.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
 			}
 		}
 	}

--- a/internal/kubernetes/status/components/kms_issuer.go
+++ b/internal/kubernetes/status/components/kms_issuer.go
@@ -32,14 +32,10 @@ func (k *KMSIssuerStatus) Match(md *MatchData) (bool, error) {
 
 	for _, pod := range md.Pods {
 		for _, container := range pod.Spec.Containers {
-			if strings.Contains(container.Image, "kms-issuer") {
+			if strings.Contains(container.Image, "kms-issuer:") {
 				found = true
 				k.namespace = pod.Namespace
-				if strings.Contains(container.Image, ":") {
-					k.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
-				} else {
-					k.version = "unknown"
-				}
+				k.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
 			}
 		}
 	}

--- a/internal/kubernetes/status/components/origin_ca_issuer.go
+++ b/internal/kubernetes/status/components/origin_ca_issuer.go
@@ -32,14 +32,10 @@ func (o *OriginCAIssuerStatus) Match(md *MatchData) (bool, error) {
 
 	for _, pod := range md.Pods {
 		for _, container := range pod.Spec.Containers {
-			if strings.Contains(container.Image, "origin-ca-issuer") {
+			if strings.Contains(container.Image, "origin-ca-issuer:") {
 				found = true
 				o.namespace = pod.Namespace
-				if strings.Contains(container.Image, ":") {
-					o.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
-				} else {
-					o.version = "unknown"
-				}
+				o.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
 			}
 		}
 	}

--- a/internal/kubernetes/status/components/small_step_issuer.go
+++ b/internal/kubernetes/status/components/small_step_issuer.go
@@ -32,14 +32,10 @@ func (s *SmallStepIssuerStatus) Match(md *MatchData) (bool, error) {
 
 	for _, pod := range md.Pods {
 		for _, container := range pod.Spec.Containers {
-			if strings.Contains(container.Image, "step-issuer") {
+			if strings.Contains(container.Image, "step-issuer:") {
 				found = true
 				s.namespace = pod.Namespace
-				if strings.Contains(container.Image, ":") {
-					s.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
-				} else {
-					s.version = "unknown"
-				}
+				s.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
 			}
 		}
 	}

--- a/internal/kubernetes/status/components/venafi_enhanced_issuer.go
+++ b/internal/kubernetes/status/components/venafi_enhanced_issuer.go
@@ -32,14 +32,10 @@ func (v *VenafiEnhancedIssuerStatus) Match(md *MatchData) (bool, error) {
 
 	for _, pod := range md.Pods {
 		for _, container := range pod.Spec.Containers {
-			if strings.Contains(container.Image, "venafi-enhanced-issuer") {
+			if strings.Contains(container.Image, "venafi-enhanced-issuer:") {
 				found = true
 				v.namespace = pod.Namespace
-				if strings.Contains(container.Image, ":") {
-					v.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
-				} else {
-					v.version = "unknown"
-				}
+				v.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
 			}
 		}
 	}

--- a/internal/kubernetes/status/components/venafi_oauth_helper.go
+++ b/internal/kubernetes/status/components/venafi_oauth_helper.go
@@ -32,14 +32,10 @@ func (v *VenafiOAuthHelperStatus) Match(md *MatchData) (bool, error) {
 
 	for _, pod := range md.Pods {
 		for _, container := range pod.Spec.Containers {
-			if strings.Contains(container.Image, "venafi-oauth-helper") {
+			if strings.Contains(container.Image, "venafi-oauth-helper:") {
 				found = true
 				v.namespace = pod.Namespace
-				if strings.Contains(container.Image, ":") {
-					v.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
-				} else {
-					v.version = "unknown"
-				}
+				v.version = container.Image[strings.LastIndex(container.Image, ":")+1:]
 			}
 		}
 	}


### PR DESCRIPTION
We want to prevent matching images that have common prefixes:
- "cert-manager-csi-driver"
- "cert-manager-csi-driver-spiffe"
- "cert-manager-csi-driver-spiffe-approver"

This PR solves this issue by matching the `:` in the image too, so we can be sure no unwanted suffix exists.