### PR TITLE
Add APIPath where missing/ wrong and fix issues in tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.25.3
 	k8s.io/apimachinery v0.25.4
 	k8s.io/client-go v0.25.3
+	k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2
 	sigs.k8s.io/yaml v1.3.0
 )
 
@@ -78,7 +79,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221106113015-f73e7dbcfe29 // indirect
-	k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2 // indirect
 	sigs.k8s.io/controller-runtime v0.13.1 // indirect
 	sigs.k8s.io/gateway-api v0.5.1 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect

--- a/internal/kubernetes/clients/generic_test.go
+++ b/internal/kubernetes/clients/generic_test.go
@@ -3,7 +3,6 @@ package clients
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -155,7 +154,7 @@ func TestGeneric_List_WithDropFields(t *testing.T) {
 
 	assert.True(t, called)
 	assert.Equal(t, "/api/v1/namespaces/test-namespace/pods", requestedPath)
-	assert.Equal(t, "", fmt.Sprintf("%s", result.Items[0].Status.Phase))
+	assert.Equal(t, "", string(result.Items[0].Status.Phase))
 }
 
 func TestGeneric_Get_ClusterScope(t *testing.T) {
@@ -175,11 +174,13 @@ func TestGeneric_Get_ClusterScope(t *testing.T) {
 	client, err := NewGenericClient[*apiextensionsv1.CustomResourceDefinition, *apiextensionsv1.CustomResourceDefinitionList](
 		&GenericClientOptions{
 			RestConfig: cfg,
+			APIPath:    "/apis/",
 			Group:      apiextensionsv1.GroupName,
 			Version:    apiextensionsv1.SchemeGroupVersion.Version,
 			Kind:       "customresourcedefinitions",
 		},
 	)
+	require.NoError(t, err)
 
 	var result apiextensionsv1.CustomResourceDefinition
 	err = client.Get(ctx, &GenericRequestOptions{Name: "crd-name"}, &result)
@@ -249,11 +250,13 @@ func TestGeneric_List_ClusterScope(t *testing.T) {
 	client, err := NewGenericClient[*apiextensionsv1.CustomResourceDefinition, *apiextensionsv1.CustomResourceDefinitionList](
 		&GenericClientOptions{
 			RestConfig: cfg,
+			APIPath:    "/apis/",
 			Group:      apiextensionsv1.GroupName,
 			Version:    apiextensionsv1.SchemeGroupVersion.Version,
 			Kind:       "customresourcedefinitions",
 		},
 	)
+	require.NoError(t, err)
 
 	var result apiextensionsv1.CustomResourceDefinitionList
 	err = client.List(ctx, &GenericRequestOptions{}, &result)
@@ -285,6 +288,7 @@ func TestGeneric_Present(t *testing.T) {
 	client, err := NewGenericClient[*corev1.Pod, *corev1.PodList](
 		&GenericClientOptions{
 			RestConfig: cfg,
+			APIPath:    "/api/",
 			Group:      corev1.GroupName,
 			Version:    corev1.SchemeGroupVersion.Version,
 			Kind:       "pods",
@@ -309,7 +313,7 @@ func TestGeneric_Update(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
 		require.Equal(t, "PATCH", r.Method)
-		require.Equal(t, "/apis/v1/namespaces/jetstack-secure/secrets/test", r.URL.Path)
+		require.Equal(t, "/api/v1/namespaces/jetstack-secure/secrets/test", r.URL.Path)
 		bodyBytes, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		require.Equal(t, `{"stringData":{"foo":"bar"}}`, string(bodyBytes))
@@ -336,6 +340,7 @@ func TestGeneric_Update(t *testing.T) {
 	client, err := NewGenericClient[*corev1.Secret, *corev1.Secret](
 		&GenericClientOptions{
 			RestConfig: cfg,
+			APIPath:    "/api/",
 			Group:      corev1.GroupName,
 			Version:    corev1.SchemeGroupVersion.Version,
 			Kind:       "secrets",

--- a/internal/kubernetes/status/status.go
+++ b/internal/kubernetes/status/status.go
@@ -150,6 +150,7 @@ func GatherClusterStatus(ctx context.Context, cfg *rest.Config) (*ClusterStatus,
 	ingressClient, err := clients.NewGenericClient[*networkingv1.Ingress, *networkingv1.IngressList](
 		&clients.GenericClientOptions{
 			RestConfig: cfg,
+			APIPath:    "/apis/",
 			Group:      networkingv1.GroupName,
 			Version:    networkingv1.SchemeGroupVersion.Version,
 			Kind:       "ingresses",


### PR DESCRIPTION
- added missing `require.NoError(t, err)`
- explicitly specify `APIPath: "/apis/"` where missing
- specify `APIPath: "/api/"` for some clients that incorrectly did not have this specified