### PR TITLE
Throw error if jsctl was already installed at another location

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -30,6 +30,11 @@ $Target = if ($ENV:OS -eq "Windows_NT") {
 
 $DownloadUrl = "https://github.com/jetstack/jsctl/releases/latest/download/${Target}.tar.gz"
 
+$CurrentInstall = (Get-Command jsctl).Definition
+if (!(Test-Path $JsctlExe) -and ($CurrentInstall -ne $JsctlExe)) {
+    throw "Error: tried to install jsctl to "$JsctlExe", but is already installed at "$CurrentInstall"."
+}
+
 if (!(Test-Path $BinDir)) {
   New-Item $BinDir -ItemType Directory | Out-Null
 }

--- a/install.sh
+++ b/install.sh
@@ -46,6 +46,12 @@ jsctl_install="${JSCTL_INSTALL:-$HOME/.jsctl}"
 bin_dir="$jsctl_install/bin"
 bin="$bin_dir/$target_file"
 
+if current_install=$( command -v jsctl ) && [ ! -x "$bin" ] && [ "$current_install" != "$bin" ]; then
+    echo "failed to install jsctl to \"$bin\"" >&2
+    echo "jsctl is already installed in another location: \"$current_install\"" >&2
+    exit 1
+fi
+
 if [ ! -d "$bin_dir" ]; then
 	mkdir -p "$bin_dir"
 fi


### PR DESCRIPTION
If `jsctl` is found in a location that differs from the location that we want to install to, stop and explain in an error message.
NOTE: If a binary is found at the install location, we just continue and overwrite the binary.
