### PR TITLE
Update agent version to v0.1.39

### DIFF
--- a/internal/cluster/templates/agent.yaml
+++ b/internal/cluster/templates/agent.yaml
@@ -33,7 +33,7 @@ spec:
             secretName: agent-credentials
       containers:
         - name: agent
-          image: quay.io/jetstack/preflight:v0.1.38
+          image: quay.io/jetstack/preflight:v0.1.39
           args:
             - "agent"
             - "-c"


### PR DESCRIPTION
Updates agent installation to version v0.1.39: https://github.com/jetstack/jetstack-secure/releases/tag/v0.1.39