### PR TITLE
Ensures that namespace is hardcoded to jetstack-secure

### DIFF
--- a/internal/operator/installers/v0.0.1-alpha.24.yaml
+++ b/internal/operator/installers/v0.0.1-alpha.24.yaml
@@ -10,6 +10,7 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   name: js-operator-cainjector
+  namespace: jetstack-secure
   labels:
     helm.sh/chart: js-operator-v0.0.1-alpha.24
     app.kubernetes.io/name: js-operator
@@ -22,6 +23,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: js-operator-operator
+  namespace: jetstack-secure
   labels:
     helm.sh/chart: js-operator-v0.0.1-alpha.24
     app.kubernetes.io/name: js-operator
@@ -34,6 +36,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: js-operator-webhook-tls
+  namespace: jetstack-secure
   annotations:
     cert-manager.io/allow-direct-injection: "true"
   labels:
@@ -6462,6 +6465,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: js-operator-webhook
+  namespace: jetstack-secure
   labels:
     helm.sh/chart: js-operator-v0.0.1-alpha.24
     app.kubernetes.io/name: js-operator
@@ -6482,6 +6486,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: js-operator-cainjector
+  namespace: jetstack-secure
   labels:
     helm.sh/chart: js-operator-v0.0.1-alpha.24
     app.kubernetes.io/name: js-operator
@@ -6530,6 +6535,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: js-operator-operator
+  namespace: jetstack-secure
   labels:
     helm.sh/chart: js-operator-v0.0.1-alpha.24
     app.kubernetes.io/name: js-operator


### PR DESCRIPTION
See https://github.com/helm/helm/issues/3553 - helm template command does not properly interpolate namespace for namespaced resources

In general, I think we already had a discussion that we want to remove the install commands from this tool and keep it just for helper commands like retrieving creds, verifying cluster status etc

To verify that this works:
- `kind create cluster`
- `kubectl create namespace jetstack-secure`
- Run `go run main.go operator deploy --auto-registry-credentials` from this branch
- Verify that v0.0.1-alpha.24 of the operator got installed in `jetstack-secure`
- Apply an example `Installation` manifest like https://github.com/jetstack/js-operator/blob/main/examples/installation.yaml with lines 18, 19 uncommented, verify that operator installed cert-manager as expected