### PR TITLE
[VC-24828] Fixed initialization of the config object

### DIFF
--- a/internal/command/auth/login.go
+++ b/internal/command/auth/login.go
@@ -48,12 +48,16 @@ func Login(run types.RunFunc) *cobra.Command {
 
 			fmt.Println("Login succeeded")
 
-			cnf := &config.Config{}
+			var cnf *config.Config
 
 			// if the user already has an organization selected, we don't need to do anything
 			cnf, ok := config.FromContext(ctx)
 			if ok && cnf.Organization != "" {
 				return nil
+			}
+			// initiate empty config
+			if !ok {
+				cnf = &config.Config{}
 			}
 
 			http := client.New(ctx, apiURL)


### PR DESCRIPTION
Fixed initialization of the config object, it was causing nil pointer dereference on the first run:

```
Opening browser to: https://auth.jetstack.io/authorize?access_type=offline&audience=https%3A%2F%2Fpreflight.jetstack.io%2Fapi%2Fv1&client_id=jmQwDGl86WAevq6K6zZo6hJ4WUvp14yD&redirect_uri=http%3A%2F%2Flocalhost%3A9999%2Foauth%2Fcallback&response_type=code&scope=openid+profile+offline_access&state=2402307c-15ab-425b-a2fb-712b5037edf9
You will be taken to your browser for authentication
Login succeeded

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x8 pc=0x100981ac0]

goroutine 1 [running]:
github.com/jetstack/jsctl/internal/command/auth.Login.func1({0x1017b7ca0, 0x14000189980}, {0x1017a0160?, 0x14000184f40?, 0x101654ba0?})
	github.com/jetstack/jsctl/internal/command/auth/login.go:68 +0x430
github.com/jetstack/jsctl/internal/command.run.func1(0x1400003cf00?, {0x102296278, 0x0, 0x0})
	github.com/jetstack/jsctl/internal/command/run.go:69 +0x358
github.com/spf13/cobra.(*Command).execute(0x1400003cf00, {0x102296278, 0x0, 0x0})
	github.com/spf13/cobra@v1.6.1/command.go:920 +0x5b0
github.com/spf13/cobra.(*Command).ExecuteC(0x1400003c900)
	github.com/spf13/cobra@v1.6.1/command.go:1044 +0x35c
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.6.1/command.go:968
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	github.com/spf13/cobra@v1.6.1/command.go:961
main.main()
	github.com/jetstack/jsctl/main.go:26 +0x1dc
```

The situation only occurred if the user is part of only one organization and run jsctl for the first time.

Testing procedure (tested manually only):
- ensure my user is part of single org
- delete ~/.jsctl/config.json
- launch ```jsctl auth```
- observe the crash described above
- apply workaround (create config.json with following content: ```{"organization":""}```)
- observe correct behavior
- delete ~/.jsctl/config.json
- apply the path
- launch ```jsctl auth```
- observe correct behavior